### PR TITLE
fix/claude cli subscription env

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2513,6 +2513,22 @@ def api_claude_login_cancel(
     return {"ok": True}
 
 
+@app.get("/claude/models", response_class=JSONResponse)
+def api_claude_models(
+    cli_path: Optional[str] = None,
+    current_user: dict = Depends(get_current_user),
+):
+    """List the Claude subscription models selectable for a claude-cli model
+    (the /models form dropdown). Merges a curated base set with the account-
+    specific options the CLI caches in ~/.claude.json. Each entry flags
+    ``requires_credits`` for the 1M-context ``[1m]`` variants."""
+    try:
+        from chatbot.claude_cli_provider import list_available_models
+    except Exception as e:
+        return {"models": [], "error": f"claude provider unavailable: {e}"}
+    return list_available_models((cli_path or "claude").strip() or "claude")
+
+
 @app.post("/claude/logout", response_class=JSONResponse)
 async def api_claude_logout(current_user: dict = Depends(get_current_user)):
     """Run ``claude auth logout`` to drop the deployment's Claude

--- a/backend/chatbot/claude_cli_provider.py
+++ b/backend/chatbot/claude_cli_provider.py
@@ -353,6 +353,31 @@ _SAFETY_FLAGS = [
 ]
 
 
+# Env vars that make ``claude`` authenticate as something OTHER than the
+# operator's Claude subscription (OAuth). Claude Code's auth precedence is
+# ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` BEFORE the subscription
+# OAuth, so a deployment that sets either (e.g. for a different provider)
+# silently hijacks every claude-cli call: the request goes out with the
+# API key and the server returns ``401 Invalid authentication credentials``
+# even though ``claude auth status`` reports the subscription as logged in.
+# We run claude-cli strictly in subscription mode, so we scrub these from
+# every spawned child env. (We inherit the parent env with ``os.environ
+# .copy()`` to keep PATH / HOME / locale, then strip just the auth keys.)
+_SUBSCRIPTION_CONFLICTING_ENV = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+)
+
+
+def _strip_api_key_env(env: Dict[str, str]) -> Dict[str, str]:
+    """Remove API-key/token env vars so ``claude`` uses the subscription
+    OAuth, not an inherited key. Mutates and returns *env* for chaining:
+    ``child_env = _strip_api_key_env(os.environ.copy())``."""
+    for key in _SUBSCRIPTION_CONFLICTING_ENV:
+        env.pop(key, None)
+    return env
+
+
 # Argv that opens up the IntelliStock MCP server (and ONLY the
 # IntelliStock MCP server — CC's built-in Bash / Read / Edit / etc. stay
 # disabled). The session populates ``--mcp-config`` with the per-session
@@ -1520,7 +1545,7 @@ class ClaudeCliSessionManager:
         # Build the env for the child. We override HOME so CC reads the
         # chowned copy of ~/.claude that the runtime user can access, and
         # we keep PATH so claude / node / python still resolve.
-        child_env = os.environ.copy()
+        child_env = _strip_api_key_env(os.environ.copy())
         if sess.runtime_home:
             child_env["HOME"] = sess.runtime_home
         # Diagnostic: log the actual argv head + runtime config so it's
@@ -2266,7 +2291,7 @@ def call_claude_cli_structured(
     _init_claude_state_once()
     runtime_home = _get_structured_runtime_home()
     argv = _wrap_argv_for_runtime_user(argv)
-    child_env = os.environ.copy()
+    child_env = _strip_api_key_env(os.environ.copy())
     if runtime_home and runtime_home != (os.environ.get("HOME") or "/root"):
         child_env["HOME"] = runtime_home
 
@@ -2824,7 +2849,7 @@ def test_claude_cli(
         *_SAFETY_FLAGS,
     ]
     argv = _wrap_argv_for_runtime_user(argv)
-    child_env = os.environ.copy()
+    child_env = _strip_api_key_env(os.environ.copy())
     if runtime_home and runtime_home != (os.environ.get("HOME") or "/root"):
         child_env["HOME"] = runtime_home
     try:
@@ -2872,12 +2897,30 @@ def test_claude_cli(
 
     if envelope.get("is_error"):
         result_text = str(envelope.get("result") or "")
+        api_status = envelope.get("api_error_status")
+        low = result_text.lower()
         if any(n in result_text for n in _NOT_LOGGED_IN_NEEDLES):
             return {
                 "ok": False, "version": version, "logged_in": False, "model_response": None,
                 "error": (
-                    "Claude Code is not logged in on this server. SSH in and "
-                    "run `claude` to log in."
+                    "Claude Code is not logged in on this server. Use the "
+                    "“Re-authenticate Claude” button to sign in."
+                ),
+                "elapsed_ms": int((time.monotonic() - started) * 1000),
+            }
+        # 401 + an "invalid API key" message means a stale ANTHROPIC_API_KEY
+        # (or ANTHROPIC_AUTH_TOKEN) is overriding the subscription OAuth.
+        # We scrub those from the spawn env (_strip_api_key_env), so if this
+        # still fires the key is being injected some other way — surface an
+        # actionable hint rather than a bare "Invalid API key".
+        if api_status == 401 or "invalid api key" in low or "invalid authentication" in low:
+            return {
+                "ok": False, "version": version, "logged_in": False, "model_response": None,
+                "error": (
+                    "Claude returned 401. An ANTHROPIC_API_KEY / "
+                    "ANTHROPIC_AUTH_TOKEN in the server environment is "
+                    "overriding the Claude subscription. Unset it so claude-cli "
+                    "uses the subscription OAuth."
                 ),
                 "elapsed_ms": int((time.monotonic() - started) * 1000),
             }
@@ -2967,7 +3010,7 @@ def claude_auth_status(cli_path: str = "claude") -> Dict[str, Any]:
     except (subprocess.TimeoutExpired, OSError):
         pass
 
-    env = os.environ.copy()
+    env = _strip_api_key_env(os.environ.copy())
     env["HOME"] = _operator_home()
     try:
         res = subprocess.run(
@@ -3006,7 +3049,7 @@ def claude_logout(cli_path: str = "claude") -> tuple[bool, str]:
         resolved = _resolve_cli_path(cli_path or "claude")
     except ClaudeCliError as e:
         return False, str(e)
-    env = os.environ.copy()
+    env = _strip_api_key_env(os.environ.copy())
     env["HOME"] = _operator_home()
     try:
         res = subprocess.run(
@@ -3108,7 +3151,7 @@ class ClaudeCliLogin:
                 fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 1000, 0, 0))
             except Exception:
                 pass
-            env = os.environ.copy()
+            env = _strip_api_key_env(os.environ.copy())
             env["HOME"] = _operator_home()
             env["TERM"] = "xterm-256color"
             # Discourage the CLI from trying to auto-launch a browser the

--- a/backend/chatbot/claude_cli_provider.py
+++ b/backend/chatbot/claude_cli_provider.py
@@ -378,6 +378,30 @@ def _strip_api_key_env(env: Dict[str, str]) -> Dict[str, str]:
     return env
 
 
+# Stripping the *process* env (above) is not enough on its own: Claude Code
+# also loads an ``env`` block out of ``settings.json`` (user/project/managed)
+# and injects it into the session. A deployment with
+# ``{"env": {"ANTHROPIC_API_KEY": "…"}}`` in its claude settings therefore
+# still hijacks every call — the request goes out with that key and the
+# server returns 401, even though ``claude auth status`` reports the
+# subscription as logged in and even right after a fresh re-auth.
+#
+# A ``--settings`` CLI flag deep-merges with the HIGHEST precedence over
+# user/project settings, so blanking the keys here makes claude ignore the
+# settings-file values and fall back to the subscription OAuth. This works
+# regardless of where the key is configured or whether we run in a copied
+# runtime HOME. Verified empirically: the healthy subscription path is
+# unaffected (still succeeds), while a stale settings ``env`` key that
+# otherwise 401s is neutralized. We inject this on every *model* invocation
+# (chat / structured / test-cli); the ``claude auth …`` management commands
+# don't need it. ``--settings`` is in ``_HARD_REJECTED_FLAGS`` so a user's
+# extra_args can never add a second, conflicting one.
+_FORCE_SUBSCRIPTION_SETTINGS = json.dumps(
+    {"env": {"ANTHROPIC_API_KEY": "", "ANTHROPIC_AUTH_TOKEN": ""}}
+)
+_FORCE_SUBSCRIPTION_ARGS = ["--settings", _FORCE_SUBSCRIPTION_SETTINGS]
+
+
 # Argv that opens up the IntelliStock MCP server (and ONLY the
 # IntelliStock MCP server — CC's built-in Bash / Read / Edit / etc. stay
 # disabled). The session populates ``--mcp-config`` with the per-session
@@ -989,6 +1013,7 @@ def _build_chat_argv(
         "--output-format", "stream-json",
         "--model", model,
         "--system-prompt", system_prompt,
+        *_FORCE_SUBSCRIPTION_ARGS,
         *safety,
         *effective_extra,
     ]
@@ -1030,6 +1055,7 @@ def _build_structured_argv(
         "--model", model,
         "--system-prompt", augmented_system_prompt,
         "--json-schema", json_schema,
+        *_FORCE_SUBSCRIPTION_ARGS,
         *_SAFETY_FLAGS,
         *effective_extra,
     ]
@@ -2846,6 +2872,7 @@ def test_claude_cli(
         resolved_cli, "-p",
         "--output-format", "json",
         "--model", model,
+        *_FORCE_SUBSCRIPTION_ARGS,
         *_SAFETY_FLAGS,
     ]
     argv = _wrap_argv_for_runtime_user(argv)
@@ -2908,19 +2935,21 @@ def test_claude_cli(
                 ),
                 "elapsed_ms": int((time.monotonic() - started) * 1000),
             }
-        # 401 + an "invalid API key" message means a stale ANTHROPIC_API_KEY
-        # (or ANTHROPIC_AUTH_TOKEN) is overriding the subscription OAuth.
-        # We scrub those from the spawn env (_strip_api_key_env), so if this
-        # still fires the key is being injected some other way — surface an
-        # actionable hint rather than a bare "Invalid API key".
+        # 401 + an "invalid API key" message means a stale API key is
+        # overriding the subscription OAuth. We neutralize the known sources
+        # (process env via _strip_api_key_env, settings ``env`` block via
+        # _FORCE_SUBSCRIPTION_ARGS); if this still fires the key is coming
+        # from some other source (e.g. ``apiKeyHelper`` or a stored
+        # ``primaryApiKey`` in ``.claude.json``) — surface an actionable hint.
         if api_status == 401 or "invalid api key" in low or "invalid authentication" in low:
             return {
                 "ok": False, "version": version, "logged_in": False, "model_response": None,
                 "error": (
-                    "Claude returned 401. An ANTHROPIC_API_KEY / "
-                    "ANTHROPIC_AUTH_TOKEN in the server environment is "
-                    "overriding the Claude subscription. Unset it so claude-cli "
-                    "uses the subscription OAuth."
+                    "Claude returned 401: an API key is overriding the "
+                    "subscription. Check for an apiKeyHelper or a stored "
+                    "primaryApiKey in the server's ~/.claude config (an "
+                    "ANTHROPIC_API_KEY env var and a settings.json env block "
+                    "are already neutralized)."
                 ),
                 "elapsed_ms": int((time.monotonic() - started) * 1000),
             }

--- a/backend/chatbot/claude_cli_provider.py
+++ b/backend/chatbot/claude_cli_provider.py
@@ -683,6 +683,70 @@ def _init_claude_state_once() -> None:
             _log(f"failed to restore .claude.json from backup: {e}", "yellow")
 
 
+def _scrub_json_file(path: str, mutate) -> bool:
+    """Load the JSON object at *path*, apply ``mutate(dict)`` in place, and
+    rewrite the file only if it actually changed. Returns True on a write.
+    Silent no-op for missing / unreadable / non-object files."""
+    if not os.path.isfile(path):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    before = json.dumps(data, sort_keys=True)
+    try:
+        mutate(data)
+    except Exception:
+        return False
+    if json.dumps(data, sort_keys=True) == before:
+        return False
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return True
+    except Exception:
+        return False
+
+
+def _scrub_settings_dict(d: Dict[str, Any]) -> None:
+    # apiKeyHelper runs a command whose stdout becomes the API key; an env
+    # block can pin ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN. Both override the
+    # subscription OAuth and 401 if stale.
+    d.pop("apiKeyHelper", None)
+    env = d.get("env")
+    if isinstance(env, dict):
+        for k in _SUBSCRIPTION_CONFLICTING_ENV:
+            env.pop(k, None)
+        if not env:
+            d.pop("env", None)
+
+
+def _neutralize_api_key_config(runtime_home: str) -> None:
+    """Strip every non-subscription auth source from a COPIED runtime HOME so
+    claude-cli authenticates with the operator's subscription OAuth, never a
+    stale API key. Claude Code's auth precedence puts an API key (env var,
+    settings ``env`` block, ``apiKeyHelper``, or a stored ``primaryApiKey``
+    in ``.claude.json``) BEFORE the subscription, so any one of these — left
+    over from an earlier API-key setup — silently 401s every claude-cli call
+    even though ``claude auth status`` reports the subscription as logged in.
+
+    We scrub the per-call COPY only; the operator's real ``~/.claude`` files
+    are never touched. Combined with ``_strip_api_key_env`` (process env) and
+    ``_FORCE_SUBSCRIPTION_ARGS`` (the ``--settings`` env override), this
+    covers all four sources.
+    """
+    _scrub_json_file(
+        os.path.join(runtime_home, ".claude.json"),
+        lambda d: d.pop("primaryApiKey", None),
+    )
+    sdir = os.path.join(runtime_home, ".claude")
+    for name in ("settings.json", "settings.local.json"):
+        _scrub_json_file(os.path.join(sdir, name), _scrub_settings_dict)
+
+
 def _get_structured_runtime_home() -> str:
     """Process-wide shared runtime HOME for the spawn-per-call structured
     path. Created once on first use, reused by every subsequent call.
@@ -772,6 +836,11 @@ def _prepare_runtime_home(sess: "_Session") -> str:
         # naturally rather than restoring a stale backup per call.
         if _CLAUDE_JSON_SOURCE:
             shutil.copy2(_CLAUDE_JSON_SOURCE, os.path.join(runtime_dir, ".claude.json"))
+        # Scrub any non-subscription auth source from the COPY (a stored
+        # primaryApiKey / apiKeyHelper / env API key would otherwise override
+        # the subscription OAuth and 401 every call). Done before the chown
+        # walk so the rewritten files get the runtime-user ownership too.
+        _neutralize_api_key_config(runtime_dir)
         # Recursively chown to the runtime user so the dropped
         # subprocess can read everything. mode is left as-is from the
         # source.

--- a/backend/chatbot/claude_cli_provider.py
+++ b/backend/chatbot/claude_cli_provider.py
@@ -353,19 +353,26 @@ _SAFETY_FLAGS = [
 ]
 
 
-# Env vars that make ``claude`` authenticate as something OTHER than the
-# operator's Claude subscription (OAuth). Claude Code's auth precedence is
-# ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` BEFORE the subscription
-# OAuth, so a deployment that sets either (e.g. for a different provider)
-# silently hijacks every claude-cli call: the request goes out with the
-# API key and the server returns ``401 Invalid authentication credentials``
-# even though ``claude auth status`` reports the subscription as logged in.
-# We run claude-cli strictly in subscription mode, so we scrub these from
-# every spawned child env. (We inherit the parent env with ``os.environ
-# .copy()`` to keep PATH / HOME / locale, then strip just the auth keys.)
+# Env vars that derail claude-cli's subscription (OAuth) mode. We run claude
+# strictly on the operator's Claude subscription, so we scrub these from every
+# spawned child env (and from copied settings ``env`` blocks). We inherit the
+# parent env with ``os.environ.copy()`` to keep PATH / HOME / locale, then
+# strip just these:
+#
+#   * ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN — Claude Code's auth precedence
+#     puts these BEFORE the subscription OAuth, so a leftover key hijacks every
+#     call and 401s ("Invalid authentication credentials") even though
+#     ``claude auth status`` reports the subscription as logged in.
+#   * ANTHROPIC_BETAS — a leftover ``context-1m-2025-08-07`` here forces the 1M
+#     context window on EVERY call, which fails with HTTP 429 "Usage credits
+#     required for 1M context" regardless of the model alias the user picks
+#     (reproduced: this env var alone turns a plain ``claude-sonnet-4-6`` call
+#     into the 1M error). 1M is opt-in via the ``...[1m]`` model variant, never
+#     a global env var, so subscription mode always clears it.
 _SUBSCRIPTION_CONFLICTING_ENV = (
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BETAS",
 )
 
 
@@ -397,7 +404,7 @@ def _strip_api_key_env(env: Dict[str, str]) -> Dict[str, str]:
 # don't need it. ``--settings`` is in ``_HARD_REJECTED_FLAGS`` so a user's
 # extra_args can never add a second, conflicting one.
 _FORCE_SUBSCRIPTION_SETTINGS = json.dumps(
-    {"env": {"ANTHROPIC_API_KEY": "", "ANTHROPIC_AUTH_TOKEN": ""}}
+    {"env": {k: "" for k in _SUBSCRIPTION_CONFLICTING_ENV}}
 )
 _FORCE_SUBSCRIPTION_ARGS = ["--settings", _FORCE_SUBSCRIPTION_SETTINGS]
 

--- a/backend/chatbot/claude_cli_provider.py
+++ b/backend/chatbot/claude_cli_provider.py
@@ -3163,6 +3163,57 @@ def claude_logout(cli_path: str = "claude") -> tuple[bool, str]:
     return False, ((res.stderr or res.stdout or "").strip() or f"claude auth logout exit {res.returncode}")
 
 
+# Curated base set of Claude Code subscription model aliases. The CLI has no
+# "list models" command, so we ship a sensible base and merge the account-
+# specific extras the CLI caches in ~/.claude.json (additionalModelOptionsCache)
+# — that part IS dynamic per subscription. ``[1m]`` variants use the 1M context
+# window, which requires turning on usage credits at claude.ai/settings/usage
+# ON TOP of the subscription; the plain aliases use the standard 200K context.
+_BASE_CLAUDE_MODELS = [
+    {"value": "claude-haiku-4-5", "label": "Haiku 4.5",
+     "description": "Fastest, cheapest · standard 200K context"},
+    {"value": "claude-sonnet-4-6", "label": "Sonnet 4.6",
+     "description": "Balanced · standard 200K context"},
+    {"value": "claude-sonnet-4-6[1m]", "label": "Sonnet 4.6 (1M context)",
+     "description": "1M context · requires usage credits"},
+    {"value": "claude-opus-4-8", "label": "Opus 4.8",
+     "description": "Most capable · standard 200K context"},
+    {"value": "claude-opus-4-8[1m]", "label": "Opus 4.8 (1M context)",
+     "description": "1M context · requires usage credits"},
+]
+
+
+def list_available_models(cli_path: str = "claude") -> Dict[str, Any]:
+    """Return the Claude subscription models selectable for a claude-cli
+    model, for the /models UI dropdown. Merges the curated base set with the
+    account-specific options the CLI caches in ``~/.claude.json``. Each entry
+    carries ``requires_credits`` (true for ``[1m]`` 1M-context variants, which
+    need usage credits enabled and otherwise fail with a 1M-context error)."""
+    models = [dict(m) for m in _BASE_CLAUDE_MODELS]
+    seen = {m["value"] for m in models}
+    try:
+        cj = os.path.join(_operator_home(), ".claude.json")
+        if os.path.isfile(cj):
+            with open(cj, "r", encoding="utf-8") as f:
+                doc = json.load(f)
+            for opt in (doc.get("additionalModelOptionsCache") or []):
+                if not isinstance(opt, dict):
+                    continue
+                val = str(opt.get("value") or "").strip()
+                if val and val not in seen:
+                    seen.add(val)
+                    models.append({
+                        "value": val,
+                        "label": str(opt.get("label") or val),
+                        "description": str(opt.get("description") or ""),
+                    })
+    except Exception:
+        pass
+    for m in models:
+        m["requires_credits"] = "[1m]" in m["value"]
+    return {"models": models}
+
+
 # ANSI/VT100 escape stripper for PTY output (URL/prompt parsing).
 _ANSI_ESCAPE_RE_CC = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[=>]")
 # Anthropic OAuth URL — captured from the login flow's stdout. The host
@@ -3479,4 +3530,5 @@ __all__ = [
     "claude_auth_status",
     "claude_logout",
     "invalidate_runtime_home_cache",
+    "list_available_models",
 ]

--- a/backend/tests/test_claude_cli_login.py
+++ b/backend/tests/test_claude_cli_login.py
@@ -246,6 +246,58 @@ def test_strip_api_key_env_noop_when_absent():
     assert provider._strip_api_key_env(env) == {"PATH": "/usr/bin"}
 
 
+def test_neutralize_api_key_config_removes_all_sources(tmp_path):
+    import json as _json
+    home = tmp_path
+    (home / ".claude").mkdir()
+    (home / ".claude.json").write_text(
+        _json.dumps({"primaryApiKey": "sk-bogus", "oauthAccount": {"email": "x@y.z"}})
+    )
+    (home / ".claude" / "settings.json").write_text(
+        _json.dumps({
+            "apiKeyHelper": "/path/helper.sh",
+            "env": {"ANTHROPIC_API_KEY": "sk", "ANTHROPIC_AUTH_TOKEN": "t", "FOO": "bar"},
+            "theme": "dark",
+        })
+    )
+    provider._neutralize_api_key_config(str(home))
+
+    cj = _json.loads((home / ".claude.json").read_text())
+    assert "primaryApiKey" not in cj
+    assert cj["oauthAccount"] == {"email": "x@y.z"}  # subscription state preserved
+
+    s = _json.loads((home / ".claude" / "settings.json").read_text())
+    assert "apiKeyHelper" not in s
+    assert "ANTHROPIC_API_KEY" not in s.get("env", {})
+    assert "ANTHROPIC_AUTH_TOKEN" not in s.get("env", {})
+    assert s["env"]["FOO"] == "bar"   # unrelated env vars preserved
+    assert s["theme"] == "dark"       # unrelated settings preserved
+
+
+def test_neutralize_api_key_config_drops_empty_env_block(tmp_path):
+    import json as _json
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(
+        _json.dumps({"env": {"ANTHROPIC_API_KEY": "sk"}})
+    )
+    provider._neutralize_api_key_config(str(tmp_path))
+    s = _json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert "env" not in s  # emptied env block removed entirely
+
+
+def test_neutralize_api_key_config_noop_when_files_absent(tmp_path):
+    # Must not raise when .claude.json / settings.json don't exist.
+    provider._neutralize_api_key_config(str(tmp_path))
+
+
+def test_scrub_json_file_leaves_clean_file_untouched(tmp_path):
+    import json as _json
+    p = tmp_path / "x.json"
+    p.write_text(_json.dumps({"a": 1}))
+    changed = provider._scrub_json_file(str(p), lambda d: d.pop("nope", None))
+    assert changed is False
+
+
 def test_force_subscription_settings_blanks_anthropic_keys():
     import json as _json
     d = _json.loads(provider._FORCE_SUBSCRIPTION_SETTINGS)

--- a/backend/tests/test_claude_cli_login.py
+++ b/backend/tests/test_claude_cli_login.py
@@ -246,6 +246,38 @@ def test_strip_api_key_env_noop_when_absent():
     assert provider._strip_api_key_env(env) == {"PATH": "/usr/bin"}
 
 
+def test_force_subscription_settings_blanks_anthropic_keys():
+    import json as _json
+    d = _json.loads(provider._FORCE_SUBSCRIPTION_SETTINGS)
+    assert d["env"]["ANTHROPIC_API_KEY"] == ""
+    assert d["env"]["ANTHROPIC_AUTH_TOKEN"] == ""
+
+
+def test_structured_argv_injects_settings_override():
+    argv = provider._build_structured_argv(
+        cli_path="claude",
+        model="claude-sonnet-4-6",
+        system_prompt="hi",
+        json_schema="{}",
+        extra_args=[],
+    )
+    assert "--settings" in argv
+    i = argv.index("--settings")
+    assert argv[i + 1] == provider._FORCE_SUBSCRIPTION_SETTINGS
+
+
+def test_chat_argv_injects_settings_override():
+    argv = provider._build_chat_argv(
+        cli_path="claude",
+        model="claude-sonnet-4-6",
+        system_prompt="hi",
+        extra_args=[],
+    )
+    assert "--settings" in argv
+    i = argv.index("--settings")
+    assert argv[i + 1] == provider._FORCE_SUBSCRIPTION_SETTINGS
+
+
 def test_test_cli_maps_invalid_api_key_401_to_actionable_hint(monkeypatch):
     monkeypatch.setattr(provider, "_resolve_cli_path", lambda p: "/usr/bin/claude")
     monkeypatch.setattr(provider, "_init_claude_state_once", lambda: None)

--- a/backend/tests/test_claude_cli_login.py
+++ b/backend/tests/test_claude_cli_login.py
@@ -256,7 +256,10 @@ def test_neutralize_api_key_config_removes_all_sources(tmp_path):
     (home / ".claude" / "settings.json").write_text(
         _json.dumps({
             "apiKeyHelper": "/path/helper.sh",
-            "env": {"ANTHROPIC_API_KEY": "sk", "ANTHROPIC_AUTH_TOKEN": "t", "FOO": "bar"},
+            "env": {
+                "ANTHROPIC_API_KEY": "sk", "ANTHROPIC_AUTH_TOKEN": "t",
+                "ANTHROPIC_BETAS": "context-1m-2025-08-07", "FOO": "bar",
+            },
             "theme": "dark",
         })
     )
@@ -270,6 +273,7 @@ def test_neutralize_api_key_config_removes_all_sources(tmp_path):
     assert "apiKeyHelper" not in s
     assert "ANTHROPIC_API_KEY" not in s.get("env", {})
     assert "ANTHROPIC_AUTH_TOKEN" not in s.get("env", {})
+    assert "ANTHROPIC_BETAS" not in s.get("env", {})  # 1M-context beta removed
     assert s["env"]["FOO"] == "bar"   # unrelated env vars preserved
     assert s["theme"] == "dark"       # unrelated settings preserved
 
@@ -303,6 +307,9 @@ def test_force_subscription_settings_blanks_anthropic_keys():
     d = _json.loads(provider._FORCE_SUBSCRIPTION_SETTINGS)
     assert d["env"]["ANTHROPIC_API_KEY"] == ""
     assert d["env"]["ANTHROPIC_AUTH_TOKEN"] == ""
+    # ANTHROPIC_BETAS blanked too — a leftover context-1m beta otherwise
+    # forces the 1M context window and 429s every call.
+    assert d["env"]["ANTHROPIC_BETAS"] == ""
 
 
 def test_structured_argv_injects_settings_override():

--- a/backend/tests/test_claude_cli_login.py
+++ b/backend/tests/test_claude_cli_login.py
@@ -219,6 +219,56 @@ def test_submit_code_dead_proc_fails_cleanly():
             ClaudeCliLogin._jobs.pop("j2", None)
 
 
+# ── API-key env scrub (the subscription-vs-API-key 401 root cause) ──────────
+
+
+def test_strip_api_key_env_removes_conflicting_vars():
+    env = {
+        "PATH": "/usr/bin",
+        "HOME": "/root",
+        "ANTHROPIC_API_KEY": "sk-ant-stale",
+        "ANTHROPIC_AUTH_TOKEN": "tok-stale",
+        "LANG": "C.UTF-8",
+    }
+    out = provider._strip_api_key_env(env)
+    assert "ANTHROPIC_API_KEY" not in out
+    assert "ANTHROPIC_AUTH_TOKEN" not in out
+    # Everything else is preserved so PATH/HOME/locale still reach claude.
+    assert out["PATH"] == "/usr/bin"
+    assert out["HOME"] == "/root"
+    assert out["LANG"] == "C.UTF-8"
+    # Mutates-and-returns the same dict (used as copy().pipe pattern).
+    assert out is env
+
+
+def test_strip_api_key_env_noop_when_absent():
+    env = {"PATH": "/usr/bin"}
+    assert provider._strip_api_key_env(env) == {"PATH": "/usr/bin"}
+
+
+def test_test_cli_maps_invalid_api_key_401_to_actionable_hint(monkeypatch):
+    monkeypatch.setattr(provider, "_resolve_cli_path", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr(provider, "_init_claude_state_once", lambda: None)
+    monkeypatch.setattr(provider, "_prepare_runtime_home_for_id", lambda h: "/root")
+    monkeypatch.setattr(provider, "_cleanup_runtime_home", lambda p: None)
+    monkeypatch.setattr(provider, "_wrap_argv_for_runtime_user", lambda argv: argv)
+
+    def _runner(argv, **kw):
+        if "--version" in argv:
+            return SimpleNamespace(stdout="2.1.170 (Claude Code)\n", stderr="", returncode=0)
+        envelope = (
+            '{"type":"result","is_error":true,"api_error_status":401,'
+            '"result":"Invalid API key · Fix external API key"}'
+        )
+        return SimpleNamespace(stdout=envelope, stderr="", returncode=0)
+
+    monkeypatch.setattr(provider.subprocess, "run", _runner)
+    out = provider.test_claude_cli(cli_path="claude", model="claude-sonnet-4-6")
+    assert out["ok"] is False
+    assert "ANTHROPIC_API_KEY" in out["error"]
+    assert "subscription" in out["error"].lower()
+
+
 def test_reader_parses_url_from_pty_output(monkeypatch):
     # Drive _reader with a fake fd that yields colorized output then EOF.
     chunks = [

--- a/backend/tests/test_claude_cli_login.py
+++ b/backend/tests/test_claude_cli_login.py
@@ -353,6 +353,37 @@ def test_test_cli_maps_invalid_api_key_401_to_actionable_hint(monkeypatch):
     assert "subscription" in out["error"].lower()
 
 
+def test_list_available_models_merges_cache_and_flags_1m(tmp_path, monkeypatch):
+    import json as _json
+    (tmp_path / ".claude.json").write_text(_json.dumps({
+        "additionalModelOptionsCache": [
+            {"value": "claude-custom-x", "label": "Custom X", "description": "d"},
+            {"value": "claude-sonnet-4-6", "label": "dup"},  # collides with base
+        ]
+    }))
+    monkeypatch.setattr(provider, "_operator_home", lambda: str(tmp_path))
+    out = provider.list_available_models("claude")
+    by = {m["value"]: m for m in out["models"]}
+    vals = [m["value"] for m in out["models"]]
+    # Base set present
+    assert "claude-sonnet-4-6" in by and "claude-haiku-4-5" in by
+    # Account-specific extra merged in
+    assert "claude-custom-x" in by
+    # Collision with base is deduped (base entry wins, appears once)
+    assert vals.count("claude-sonnet-4-6") == 1
+    assert by["claude-sonnet-4-6"]["label"] == "Sonnet 4.6"  # not "dup"
+    # 1M variants flagged; standard ones not
+    assert by["claude-sonnet-4-6[1m]"]["requires_credits"] is True
+    assert by["claude-sonnet-4-6"]["requires_credits"] is False
+    assert by["claude-custom-x"]["requires_credits"] is False
+
+
+def test_list_available_models_tolerates_missing_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider, "_operator_home", lambda: str(tmp_path))
+    out = provider.list_available_models("claude")
+    assert len(out["models"]) >= 5  # base set always present
+
+
 def test_reader_parses_url_from_pty_output(monkeypatch):
     # Drive _reader with a fake fd that yields colorized output then EOF.
     chunks = [

--- a/frontend/src/components/LlmConfigForm.vue
+++ b/frontend/src/components/LlmConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onUnmounted } from 'vue'
 import {
   LLM_PROVIDER_OPTIONS,
   LLM_REASONING_EFFORT_OPTIONS,
@@ -11,8 +11,20 @@ import {
 } from '../utils/strategyConfig.js'
 import { loadOllamaModels } from '../composables/useOllamaModels.js'
 import { loadBedrockModels } from '../composables/useBedrockModels.js'
+import { getToken } from '../utils/auth.js'
 import CodexCliSetupPanel from './CodexCliSetupPanel.vue'
 import ClaudeCliSetupPanel from './ClaudeCliSetupPanel.vue'
+
+const API_BASE = import.meta.env.DEV
+  ? '/api'
+  : (import.meta.env.VITE_API_URL || '/api')
+
+function authHeaders() {
+  const token = getToken()
+  return token
+    ? { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    : { 'Content-Type': 'application/json' }
+}
 
 const props = defineProps({
   draft: { type: Object, required: true },
@@ -195,6 +207,121 @@ function onProviderChange(value) {
   }
   emit('update:draft', next)
 }
+
+// ── Claude Code CLI model dropdown ───────────────────────────────────────────
+// For provider 'claude-cli' the model field becomes a <select> populated from
+// GET /api/claude/models (the list is dynamic — it merges the account's cached
+// options — so we always fetch, never hardcode). A "Custom…" sentinel reveals
+// the original free-text input so power users can type any alias, and an
+// existing draft.model that isn't in the fetched list keeps the dropdown on
+// "Custom…" with the value preserved. If the fetch fails or returns an error,
+// claudeModelsError is set and the template falls back to the free-text input
+// so the form always works.
+//
+// Per-instance lifecycle guards (closures in <script setup>, NOT module-level)
+// mirror ClaudeCliSetupPanel / CodexCliSetupPanel: _claudeAbort cancels the
+// in-flight fetch on unmount, _mounted blocks ref mutation after teardown.
+const CUSTOM_MODEL_SENTINEL = '__custom__'
+
+const claudeModels = ref([])           // [{ value, label, description, requires_credits }]
+const claudeModelsLoading = ref(false)
+const claudeModelsError = ref('')
+const claudeModelsLoaded = ref(false)  // a fetch has completed (success or error)
+const claudeCustomSelected = ref(false)  // user explicitly chose "Custom…"
+
+let _claudeAbort = new AbortController()
+let _mounted = true
+
+// The dropdown's bound value: the matching option's value, or the sentinel
+// when the current draft.model isn't in the list (or "Custom…" was chosen).
+const claudeModelSelectValue = computed(() => {
+  if (claudeCustomSelected.value) return CUSTOM_MODEL_SENTINEL
+  const current = props.draft.model || ''
+  const match = claudeModels.value.find((m) => m.value === current)
+  return match ? match.value : CUSTOM_MODEL_SENTINEL
+})
+
+// Show the free-text input when the user picked "Custom…", when the current
+// value isn't a known option, or when the list isn't usable (loading / error /
+// empty) so the operator is never blocked from entering a value.
+const claudeShowCustomInput = computed(() => {
+  if (claudeModelsError.value) return true
+  if (!claudeModels.value.length) return true
+  return claudeModelSelectValue.value === CUSTOM_MODEL_SENTINEL
+})
+
+function claudeModelOptionLabel(m) {
+  return m.requires_credits ? `${m.label} — needs usage credits` : m.label
+}
+
+async function fetchClaudeModels() {
+  if (props.draft.provider !== 'claude-cli') return
+  claudeModelsLoading.value = true
+  claudeModelsError.value = ''
+  try {
+    const cliPath = props.draft.cliPath || 'claude'
+    const url = `${API_BASE}/claude/models?cli_path=${encodeURIComponent(cliPath)}`
+    const res = await fetch(url, {
+      headers: authHeaders(),
+      signal: _claudeAbort.signal,
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(data.detail || data.error || `HTTP ${res.status}`)
+    if (!_mounted) return
+    if (data.error) {
+      claudeModels.value = Array.isArray(data.models) ? data.models : []
+      claudeModelsError.value = data.error
+    } else {
+      claudeModels.value = Array.isArray(data.models) ? data.models : []
+      claudeModelsError.value = ''
+    }
+  } catch (e) {
+    if (e.name === 'AbortError' || !_mounted) return
+    claudeModels.value = []
+    claudeModelsError.value = e.message || 'Failed to load Claude models'
+  } finally {
+    if (_mounted) {
+      claudeModelsLoading.value = false
+      claudeModelsLoaded.value = true
+    }
+  }
+}
+
+function onClaudeModelSelect(value) {
+  if (value === CUSTOM_MODEL_SENTINEL) {
+    // Reveal the free-text input but keep whatever's already in draft.model
+    // (e.g. an existing alias) so the operator's value is never lost.
+    claudeCustomSelected.value = true
+    return
+  }
+  claudeCustomSelected.value = false
+  update('model', value)
+}
+
+// Fetch when the form mounts already on claude-cli, and whenever the provider
+// switches to claude-cli. cliPath is also watched so changing the binary path
+// re-fetches the account's merged option list.
+watch(
+  () => [props.draft?.provider, props.draft?.cliPath],
+  ([provider], oldVal) => {
+    if (provider !== 'claude-cli') {
+      claudeModels.value = []
+      claudeModelsError.value = ''
+      claudeModelsLoaded.value = false
+      claudeCustomSelected.value = false
+      return
+    }
+    // Re-arming a fresh controller so a fetch after a previous abort works.
+    if (oldVal && oldVal[0] !== 'claude-cli') claudeCustomSelected.value = false
+    fetchClaudeModels()
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  _mounted = false
+  try { _claudeAbort.abort() } catch (e) { /* ignore */ }
+})
 </script>
 
 <template>
@@ -215,12 +342,55 @@ function onProviderChange(value) {
       <label class="block text-xs font-medium text-slate-400 mb-1.5">
         {{ draft.provider === 'azure' ? 'Deployment / Model Name' : 'Model' }}
       </label>
+
+      <!-- claude-cli: dropdown of available Claude models with a "Custom…"
+           escape hatch. Falls back to the plain free-text input below when the
+           list fails to load or is empty so the form always works. -->
+      <template v-if="draft.provider === 'claude-cli'">
+        <select
+          v-if="claudeModels.length && !claudeModelsError"
+          :value="claudeModelSelectValue"
+          @change="onClaudeModelSelect($event.target.value)"
+          :disabled="disabled || readOnly"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary transition-colors disabled:opacity-50"
+        >
+          <option v-for="m in claudeModels" :key="m.value" :value="m.value">{{ claudeModelOptionLabel(m) }}</option>
+          <option :value="CUSTOM_MODEL_SENTINEL">Custom…</option>
+        </select>
+        <p v-if="claudeModelsLoading" class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          Loading available Claude models…
+        </p>
+        <div v-else-if="claudeModelsError" class="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-300 mb-2 space-y-1">
+          <div>Couldn't load the Claude model list — enter the model name manually below.</div>
+          <div class="text-amber-200/70 font-mono whitespace-pre-wrap break-words">{{ claudeModelsError }}</div>
+        </div>
+
+        <!-- Free-text input: shown for "Custom…", unknown current values, or
+             when the list is unusable (loading/error/empty). Pre-filled with
+             draft.model so an existing value is never lost. -->
+        <input
+          v-if="claudeShowCustomInput"
+          :value="draft.model"
+          @input="update('model', $event.target.value)"
+          type="text"
+          :disabled="disabled || readOnly"
+          placeholder="claude-sonnet-4-6"
+          :class="claudeModels.length && !claudeModelsError ? 'mt-2' : ''"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-primary transition-colors font-mono disabled:opacity-50"
+        />
+        <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          1M-context models need usage credits enabled at <span class="font-mono">claude.ai/settings/usage</span>; standard models don't. Pick <span class="text-slate-400">Custom…</span> to type any model alias.
+        </p>
+      </template>
+
+      <!-- All other providers: free text exactly as before. -->
       <input
+        v-else
         :value="draft.model"
         @input="update('model', $event.target.value)"
         type="text"
         :disabled="disabled || readOnly"
-        :placeholder="draft.provider === 'azure' ? 'e.g. gpt-5.2 deployment name' : (draft.provider === 'claude-cli' ? 'claude-sonnet-4-6' : (draft.provider === 'codex-cli' ? 'gpt-5-codex' : 'e.g. gemini-3-flash-preview'))"
+        :placeholder="draft.provider === 'azure' ? 'e.g. gpt-5.2 deployment name' : (draft.provider === 'codex-cli' ? 'gpt-5-codex' : 'e.g. gemini-3-flash-preview')"
         class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-primary transition-colors font-mono disabled:opacity-50"
       />
     </div>

--- a/mobile/lib/features/models/data/model_repository.dart
+++ b/mobile/lib/features/models/data/model_repository.dart
@@ -94,6 +94,34 @@ class LlmModel {
   }
 }
 
+/// One entry from `GET /claude/models`. The `requires_credits` flag marks
+/// variants (e.g. the `[1m]` context models) that fail unless the Claude
+/// subscription has usage credits enabled.
+class ClaudeModelOption {
+  const ClaudeModelOption({
+    required this.value,
+    required this.label,
+    this.description,
+    this.requiresCredits = false,
+  });
+
+  final String value;
+  final String label;
+  final String? description;
+  final bool requiresCredits;
+
+  factory ClaudeModelOption.fromJson(Map<String, dynamic> j) {
+    final value = _asStr(j['value']) ?? '';
+    final label = _asStr(j['label']);
+    return ClaudeModelOption(
+      value: value,
+      label: (label != null && label.isNotEmpty) ? label : value,
+      description: _asStr(j['description']),
+      requiresCredits: (j['requires_credits'] as bool?) ?? false,
+    );
+  }
+}
+
 class LlmTestResult {
   const LlmTestResult({
     this.provider,
@@ -292,6 +320,17 @@ class ModelRepository {
       _client.post<dynamic>('/codex/logout');
 
   // ── Claude ───────────────────────────────────────────────────────────────────
+
+  /// GET /claude/models — returns `{models: [...], error?: String}`.
+  ///
+  /// The model list is dynamic (depends on the server's claude binary), so the
+  /// form always fetches it rather than hardcoding. Pass [cliPath] to probe a
+  /// specific binary.
+  Future<Map<String, dynamic>> claudeModels({String? cliPath}) =>
+      _client.get<Map<String, dynamic>>(
+        '/claude/models',
+        query: (cliPath != null && cliPath.isNotEmpty) ? {'cli_path': cliPath} : null,
+      );
 
   /// GET /claude/auth/status
   Future<Map<String, dynamic>> claudeAuthStatus() =>

--- a/mobile/lib/features/models/presentation/llm_config_form.dart
+++ b/mobile/lib/features/models/presentation/llm_config_form.dart
@@ -218,6 +218,17 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
   bool _bedrockLoading = false;
   String _bedrockError = '';
 
+  // Claude CLI model picker
+  List<ClaudeModelOption> _claudeModels = [];
+  bool _claudeLoading = false;
+  String _claudeError = '';
+  // True once the user explicitly picks "Custom…" (or the saved model isn't in
+  // the fetched list), so the free-text field stays revealed.
+  bool _claudeCustom = false;
+
+  // Sentinel value for the "Custom…" dropdown entry.
+  static const _kClaudeCustom = '__custom__';
+
   ModelRepository get _repo =>
       widget.repo ?? ref.read(modelRepositoryProvider);
 
@@ -226,6 +237,7 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
     super.initState();
     if (widget.draft.provider == 'ollama') _fetchOllama();
     if (widget.draft.provider == 'bedrock') _fetchBedrock();
+    if (widget.draft.provider == 'claude-cli') _fetchClaudeModels();
   }
 
   @override
@@ -241,6 +253,10 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
         widget.draft.bedrockRegion != old.draft.bedrockRegion ||
         widget.draft.apiKey != old.draft.apiKey)) {
       _fetchBedrock();
+    }
+    if (p == 'claude-cli' && (op != 'claude-cli' ||
+        widget.draft.cliPath != old.draft.cliPath)) {
+      _fetchClaudeModels();
     }
   }
 
@@ -274,6 +290,42 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
       if (mounted) setState(() { _bedrockModels = models; _bedrockLoading = false; });
     } catch (e) {
       if (mounted) setState(() { _bedrockError = e.toString(); _bedrockLoading = false; });
+    }
+  }
+
+  Future<void> _fetchClaudeModels({bool force = false}) async {
+    setState(() { _claudeLoading = true; _claudeError = ''; });
+    try {
+      final data = await _repo.claudeModels(cliPath: widget.draft.cliPath);
+      final err = data['error'];
+      final rawList = data['models'];
+      final models = rawList is List
+          ? rawList
+              .whereType<Map<String, dynamic>>()
+              .map(ClaudeModelOption.fromJson)
+              .where((m) => m.value.isNotEmpty)
+              .toList()
+          : <ClaudeModelOption>[];
+      if (!mounted) return;
+      setState(() {
+        _claudeModels = models;
+        _claudeError = (err is String && err.isNotEmpty)
+            ? err
+            : (models.isEmpty ? 'No models returned' : '');
+        // Reveal the free-text field when the saved model isn't a known option,
+        // so an existing alias is never lost.
+        final current = widget.draft.model;
+        _claudeCustom = current.isNotEmpty &&
+            !models.any((m) => m.value == current);
+        _claudeLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _claudeError = e.toString();
+        _claudeModels = [];
+        _claudeLoading = false;
+      });
     }
   }
 
@@ -326,13 +378,16 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
 
         // Model
         _label(d.provider == 'azure' ? 'Deployment / Model Name' : 'Model'),
-        _textField(
-          value: d.model,
-          placeholder: _modelPlaceholder(d.provider),
-          mono: true,
-          disabled: disabled,
-          onChanged: (v) => _update(d.copyWith(model: v)),
-        ),
+        if (d.provider == 'claude-cli')
+          ..._claudeModelField(d, disabled)
+        else
+          _textField(
+            value: d.model,
+            placeholder: _modelPlaceholder(d.provider),
+            mono: true,
+            disabled: disabled,
+            onChanged: (v) => _update(d.copyWith(model: v)),
+          ),
         const SizedBox(height: 16),
 
         // Cache Family
@@ -586,6 +641,74 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
       default: return 'e.g. gemini-3-flash-preview';
     }
   }
+
+  /// Model selector for the `claude-cli` provider: a dropdown of the dynamic
+  /// model list (with a "Custom…" escape hatch) plus the usage-credits hint.
+  /// Falls back to the plain free-text field while loading or on error so the
+  /// form always works.
+  List<Widget> _claudeModelField(LlmConfigDraft d, bool disabled) {
+    final freeText = _textField(
+      value: d.model,
+      placeholder: _modelPlaceholder('claude-cli'),
+      mono: true,
+      disabled: disabled,
+      onChanged: (v) => _update(d.copyWith(model: v)),
+    );
+
+    // No usable list (loading / fetch failed / empty / error field) → free text.
+    if (_claudeModels.isEmpty) {
+      return [
+        _pickerLabel('Available models',
+            onRefresh: () => _fetchClaudeModels(force: true), loading: _claudeLoading),
+        if (_claudeError.isNotEmpty)
+          _infoBox("Couldn't list Claude models: $_claudeError\n"
+              'Enter the model name manually above (e.g. claude-sonnet-4-6).',
+              AppColors.warning),
+        freeText,
+        _claudeCreditsHint(),
+      ];
+    }
+
+    final known = _claudeModels.any((m) => m.value == d.model);
+    final useCustom = _claudeCustom || (d.model.isNotEmpty && !known);
+    final dropdownValue = useCustom ? _kClaudeCustom : (known ? d.model : null);
+
+    return [
+      _pickerLabel('Available models',
+          onRefresh: () => _fetchClaudeModels(force: true), loading: _claudeLoading),
+      _dropdown(
+        value: dropdownValue,
+        hint: 'Select a model',
+        items: [
+          ..._claudeModels.map((m) {
+            final label = m.requiresCredits ? '${m.label} — needs credits' : m.label;
+            return DropdownMenuItem(value: m.value, child: Text(label));
+          }),
+          const DropdownMenuItem(value: _kClaudeCustom, child: Text('Custom…')),
+        ],
+        onChanged: disabled
+            ? null
+            : (v) {
+                if (v == _kClaudeCustom) {
+                  setState(() => _claudeCustom = true);
+                } else if (v != null) {
+                  setState(() => _claudeCustom = false);
+                  _update(d.copyWith(model: v));
+                }
+              },
+      ),
+      if (useCustom) ...[
+        const SizedBox(height: 8),
+        freeText,
+      ],
+      _claudeCreditsHint(),
+    ];
+  }
+
+  Widget _claudeCreditsHint() => _hint(
+        '1M-context models need usage credits (claude.ai/settings/usage); '
+        'standard models don\'t.',
+      );
 
   Widget _label(String text) {
     return Padding(


### PR DESCRIPTION
- **fix(claude-cli): scrub ANTHROPIC_API_KEY from spawn env so subscription is used**
- **fix(claude-cli): force subscription via --settings override (settings.json env block)**
- **fix(claude-cli): scrub primaryApiKey/apiKeyHelper from copied runtime config**
- **feat(claude-cli): model picker dropdown (avoid 1M-context credit errors)**
- **fix(claude-cli): scrub ANTHROPIC_BETAS so the subscription uses standard context**
