### PR TITLE
feat/mobile chart scrubbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,7 +223,8 @@ __marimo__/
 # Backtest logs
 backtest_logs/
 # Logs pulled locally via scripts/pull_backtest_logs.py
-backtests/
+# Anchored to repo root so it does NOT swallow mobile/lib/features/backtests/
+/backtests/
 
 # Local dev tooling state — Claude Code, MCP, Codex, hive-mind, RuFlo
 .gitnexus

--- a/docs/superpowers/specs/2026-06-10-mobile-chart-scrubbing-design.md
+++ b/docs/superpowers/specs/2026-06-10-mobile-chart-scrubbing-design.md
@@ -1,0 +1,119 @@
+# Mobile Chart Scrubbing & Cleanup — Design
+
+**Date:** 2026-06-10
+**Branch:** `feat/mobile-chart-scrubbing`
+**Status:** Approved (design decisions confirmed with user)
+
+## Problem
+
+On the mobile app's equity/value charts (dashboard, live-trading terminal, backtests):
+
+1. The vertical (Y) axis price labels are unwanted — should be removed for a clean
+   Robinhood-style look.
+2. The scrub line does **not** align with the value it reports, and the reported value
+   is shifted right of where the line visually sits.
+3. Scrubbing glitches/janks while dragging.
+4. Lines should be smoother, and scrubbing should feel smooth, responsive, and give a
+   soft haptic tick like the Robinhood app.
+
+## Root cause of the misalignment
+
+The custom-scrubber charts (`portfolio_chart.dart`, `equity_chart.dart`) overlay a
+hairline using full-widget-width pixel math:
+
+- `fraction = localDx / widgetWidth`, then `nearestIndex(fraction)` → value.
+- Hairline drawn at `fraction * widgetWidth`.
+
+But Syncfusion insets its **plot area** by the Y-axis label gutter on the left (plus
+default `rangePadding` and `plotOffset`). The curve therefore lives in
+`[gutter → rightEdge]`, while the finger→value mapping assumes `[0 → rightEdge]`. Net:
+the reported value is shifted **right** of the curve. The dashboard hairline is worse —
+it is positioned against `MediaQuery.size.width` (the whole screen), not the card.
+
+The jank is separate: every drag frame calls `setState`, rebuilding the **entire**
+Syncfusion chart (and, on dashboard, the whole card).
+
+## Decisions (confirmed with user)
+
+- **Axis labels:** hide Y (price) labels on all equity/value charts; **keep** clean X
+  date/time labels (and fix the dashboard's raw-epoch `1781108200000` label bug).
+- **Smoothing:** subtle spline, using `SplineType.monotonic` — smooth but **zero
+  overshoot**, so it never invents false highs/lows on a money chart and the curve still
+  passes exactly through each data point (keeps scrub accurate).
+
+## Solution
+
+### 1. Plot-area geometry (the alignment fix)
+For each scrubbable equity chart:
+- `primaryYAxis.isVisible = false` → removes the left gutter entirely (also satisfies the
+  "no Y labels" request).
+- Explicit Y `minimum`/`maximum` derived from the data with a small symmetric pad, and
+  `rangePadding: ChartRangePadding.none` → deterministic vertical mapping (lets us place a
+  dot precisely and keeps the curve from being clipped).
+- X axis: `plotOffset: 0`, `rangePadding: ChartRangePadding.none`,
+  `edgeLabelPlacement: EdgeLabelPlacement.hide`.
+
+Result: **plot area == widget rect**, so `fraction = dx / width` maps exactly onto the
+curve, and a hairline at `fraction * width` sits on it.
+
+### 2. X labels
+- `portfolio_chart.dart`: switch X from raw-epoch `NumericAxis` to `DateTimeAxis` with a
+  per-range date formatter (`HH:mm` for 1D, `EEE`/`MMM d`/`MMM ''yy` for longer ranges).
+- `equity_chart.dart` and the backtest charts already format X correctly — kept.
+
+### 3. Smooth, responsive scrubbing (kills the glitch)
+- **Cache the `SfCartesianChart`** so it is built only when data/range/style change, never
+  on a scrub frame.
+- Drive the scrubber via a `ValueNotifier<ScrubSample?>`; a thin `CustomPaint` overlay
+  (hairline + dot) and the header value text rebuild via `ValueListenableBuilder` only.
+- The `SfCartesianChart` lives under a `RepaintBoundary` so the overlay never repaints it.
+
+### 4. Haptics
+- `HapticFeedback.selectionClick()` fired **once per data point crossed** (on index
+  change), matching Robinhood's tick-per-point feel.
+
+### 5. Line smoothing
+- `AreaSeries → SplineAreaSeries`, `LineSeries → SplineSeries`, `splineType:
+  SplineType.monotonic`. Candlesticks unchanged.
+
+### 6. Shared, tested helper (`mobile/lib/core/charts/`)
+Extract the fragile bits into one tested module so both scrubbers share one correct
+implementation:
+- `chart_geometry.dart` — pure functions: `fractionToIndex`, `indexToFraction`,
+  `valueToY`, `dataBounds` (min/max with pad). Unit-tested.
+- `borderless_axes.dart` — factory helpers returning the hidden-Y / borderless-X
+  `NumericAxis`/`DateTimeAxis` configs.
+- `scrub_controller.dart` — `ScrubController` (a `ValueNotifier`) that holds the current
+  sample and fires `HapticFeedback.selectionClick()` only when the index changes. Haptic
+  call is injected so it can be unit-tested with a fake.
+
+## Scope
+
+**Full treatment (Y off / keep X / monotonic spline):**
+- `dashboard/.../portfolio_chart.dart` — + scrub-alignment fix, repaint isolation, haptics.
+- `live_trading/.../equity_chart.dart` — + scrub-alignment fix, repaint isolation, haptics.
+- `live_trading/.../position_card.dart` — sparklines: spline only (axes already hidden, no
+  scrubber).
+- `backtests/.../backtest_playback_screen.dart` — Y off, keep X, spline.
+- `backtests/.../backtest_detail_screen.dart` (×2 charts) — Y off, keep X, spline.
+  Syncfusion-native trackball already aligns correctly.
+
+**Deliberately left as-is** (analytical charts where the Y magnitude *is* the information):
+- `token_usage/.../token_usage_screen.dart` — "Cost (USD)" stacked chart (axis title +
+  legend).
+- `chatbot/.../chat_rich_block.dart` — LLM-generated arbitrary charts.
+
+## Testing
+
+- Unit tests for `chart_geometry` pure functions and the `ScrubController` haptic-on-change
+  logic (fake haptic sink).
+- Existing `nearestIndex` / `computeChange` tests kept green.
+- Widget test: scrubbing an equity chart reports the index whose value matches the curve at
+  that fraction (alignment regression guard), and no `$`-prefixed Y label text is rendered.
+- `flutter analyze` + `flutter test` green; manual run on simulator to confirm feel.
+
+## Risk
+
+LOW — changes are confined to the presentation layer. The two scrubbable widgets are leaf
+widgets (`EquityChart` used only by the live-trading screen; `PortfolioChart` only by the
+dashboard). GitNexus's index does not cover the Dart layer, so impact was assessed by hand.

--- a/mobile/lib/core/charts/chart_decorations.dart
+++ b/mobile/lib/core/charts/chart_decorations.dart
@@ -119,6 +119,19 @@ String formatChartDate(DateTime ts, String range) {
   }
 }
 
+/// Formats an x-axis label by the total visible [span] — for charts whose
+/// range isn't a named preset (e.g. backtests over arbitrary windows).
+String formatChartDateBySpan(DateTime ts, Duration span) {
+  String two(int n) => n.toString().padLeft(2, '0');
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  if (span.inDays <= 2) return '${two(ts.hour)}:${two(ts.minute)}';
+  if (span.inDays <= 120) return '${months[ts.month - 1]} ${ts.day}';
+  return "${months[ts.month - 1]} '${ts.year.toString().substring(2)}";
+}
+
 /// Picks up to [slots] evenly-spaced data indices for labelling (always
 /// includes first and last). Returns fewer when there are fewer points.
 List<int> evenlySpacedLabelIndices(int count, int slots) {

--- a/mobile/lib/core/charts/chart_decorations.dart
+++ b/mobile/lib/core/charts/chart_decorations.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_text_styles.dart';
+
+/// Paints the scrubber hairline plus a dot sitting exactly on the line.
+///
+/// Both are drawn at the SAME [fraction] (the snapped data point's fraction),
+/// so the hairline always passes through the dot and the dot sits on the curve.
+class ScrubPainter extends CustomPainter {
+  ScrubPainter({
+    required this.fraction,
+    required this.dotY,
+    required this.color,
+  });
+
+  /// Horizontal position 0..1 of the hairline + dot.
+  final double fraction;
+
+  /// Pixel y of the data point on the line, or null to draw only the hairline
+  /// (e.g. candlestick mode where there is no single line value).
+  final double? dotY;
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final x = (size.width * fraction).clamp(0.0, size.width);
+
+    canvas.drawLine(
+      Offset(x, 0),
+      Offset(x, size.height),
+      Paint()
+        ..color = color.withValues(alpha: 0.55)
+        ..strokeWidth = 1.2,
+    );
+
+    if (dotY != null) {
+      final y = dotY!.clamp(0.0, size.height);
+      // soft glow
+      canvas.drawCircle(
+        Offset(x, y),
+        7,
+        Paint()..color = color.withValues(alpha: 0.18),
+      );
+      // solid core
+      canvas.drawCircle(Offset(x, y), 4, Paint()..color = color);
+      // white ring for contrast on the dark theme
+      canvas.drawCircle(
+        Offset(x, y),
+        4,
+        Paint()
+          ..color = Colors.white.withValues(alpha: 0.9)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.5,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(ScrubPainter old) =>
+      old.fraction != fraction || old.dotY != dotY || old.color != color;
+}
+
+/// A thin row of evenly-spaced x-axis date/time labels rendered *below* the
+/// plot. The custom-scrubber charts hide Syncfusion's own axes so the plot area
+/// fills the widget exactly (the alignment fix); these labels replace the
+/// hidden x-axis without affecting plot geometry.
+class ChartDateLabels extends StatelessWidget {
+  const ChartDateLabels({super.key, required this.labels});
+
+  final List<String> labels;
+
+  @override
+  Widget build(BuildContext context) {
+    if (labels.isEmpty) return const SizedBox.shrink();
+    final style = AppTextStyles.nano.copyWith(color: AppColors.chartAxis);
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          for (var i = 0; i < labels.length; i++)
+            Text(
+              labels[i],
+              style: style,
+              textAlign: i == 0
+                  ? TextAlign.start
+                  : (i == labels.length - 1 ? TextAlign.end : TextAlign.center),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Formats a timestamp for an x-axis label, scaled to the selected [range]
+/// (e.g. `09:31` for 1D, `Mon` for 1W, `Jun 10` for 1M/3M/YTD, `Jun '26`
+/// otherwise). Shared by the dashboard and live-trading charts.
+String formatChartDate(DateTime ts, String range) {
+  String two(int n) => n.toString().padLeft(2, '0');
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  switch (range) {
+    case '1D':
+      return '${two(ts.hour)}:${two(ts.minute)}';
+    case '1W':
+      const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+      return days[(ts.weekday - 1).clamp(0, 6)];
+    case '1M':
+    case '3M':
+    case 'YTD':
+      return '${months[ts.month - 1]} ${ts.day}';
+    default:
+      return "${months[ts.month - 1]} '${ts.year.toString().substring(2)}";
+  }
+}
+
+/// Picks up to [slots] evenly-spaced data indices for labelling (always
+/// includes first and last). Returns fewer when there are fewer points.
+List<int> evenlySpacedLabelIndices(int count, int slots) {
+  if (count <= 0) return const [];
+  if (count == 1) return const [0];
+  final n = slots.clamp(2, count);
+  return [
+    for (var s = 0; s < n; s++) ((s / (n - 1)) * (count - 1)).round(),
+  ];
+}
+
+/// A Y value-axis configured to be invisible and inset-free, with explicit
+/// [minimum]/[maximum] so the vertical mapping is deterministic (lets the dot
+/// land exactly on the line). Used by every equity/value chart.
+NumericAxis hiddenValueAxis({double? minimum, double? maximum}) {
+  return NumericAxis(
+    isVisible: false,
+    minimum: minimum,
+    maximum: maximum,
+    rangePadding: ChartRangePadding.none,
+    majorGridLines: const MajorGridLines(width: 0),
+    minorGridLines: const MinorGridLines(width: 0),
+    axisLine: const AxisLine(width: 0),
+    majorTickLines: const MajorTickLines(size: 0),
+  );
+}
+
+/// An index-based X axis that maps data edge-to-edge (no plot offset, no range
+/// padding) and draws no labels/lines — used by the custom-scrubber charts that
+/// render their own [ChartDateLabels] below the plot.
+NumericAxis edgeToEdgeIndexAxis(int count) {
+  return NumericAxis(
+    isVisible: false,
+    minimum: 0,
+    maximum: (count <= 1 ? 1 : count - 1).toDouble(),
+    plotOffset: 0,
+    rangePadding: ChartRangePadding.none,
+    majorGridLines: const MajorGridLines(width: 0),
+    minorGridLines: const MinorGridLines(width: 0),
+    axisLine: const AxisLine(width: 0),
+    majorTickLines: const MajorTickLines(size: 0),
+  );
+}

--- a/mobile/lib/core/charts/chart_geometry.dart
+++ b/mobile/lib/core/charts/chart_geometry.dart
@@ -1,0 +1,52 @@
+/// Pure pixel/value geometry helpers shared by the app's scrubbable charts.
+///
+/// These exist so the scrubber hairline, the dot on the line, and the value the
+/// header reports all use ONE consistent mapping. Getting these wrong is what
+/// made the old scrubber report a value shifted right of the curve.
+library;
+
+/// Maps a horizontal fraction in `[0, 1]` to the nearest data index for an
+/// evenly-spaced series of [count] points. Clamped and rounded.
+int fractionToIndex(double fraction, int count) {
+  if (count <= 1) return 0;
+  final f = fraction.clamp(0.0, 1.0);
+  return (f * (count - 1)).round().clamp(0, count - 1);
+}
+
+/// The x-fraction in `[0, 1]` of data point [index] in an evenly-spaced series
+/// of [count] points. Inverse of [fractionToIndex] at the data points.
+double indexToFraction(int index, int count) {
+  if (count <= 1) return 0.0;
+  final i = index.clamp(0, count - 1);
+  return i / (count - 1);
+}
+
+/// Min/max of [values] expanded by [padFraction] of the span on each side so
+/// the line never touches the top/bottom edge. Degenerate inputs still return a
+/// range with positive height so downstream divisions stay finite.
+({double min, double max}) paddedBounds(
+  Iterable<double> values, {
+  double padFraction = 0.06,
+}) {
+  var lo = double.infinity;
+  var hi = double.negativeInfinity;
+  for (final v in values) {
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
+  if (lo == double.infinity) return (min: 0.0, max: 1.0); // empty
+  if (lo == hi) {
+    final pad = lo.abs() < 1 ? 1.0 : lo.abs() * 0.01;
+    return (min: lo - pad, max: hi + pad);
+  }
+  final pad = (hi - lo) * padFraction;
+  return (min: lo - pad, max: hi + pad);
+}
+
+/// Pixel y (0 = top, [height] = bottom) for [value] within `[min, max]` over a
+/// plot of [height] logical pixels. Clamps values outside the range.
+double valueToY(double value, double min, double max, double height) {
+  if (max <= min) return height / 2;
+  final t = ((value - min) / (max - min)).clamp(0.0, 1.0);
+  return height * (1 - t);
+}

--- a/mobile/lib/core/charts/chart_geometry.dart
+++ b/mobile/lib/core/charts/chart_geometry.dart
@@ -50,3 +50,49 @@ double valueToY(double value, double min, double max, double height) {
   final t = ((value - min) / (max - min)).clamp(0.0, 1.0);
   return height * (1 - t);
 }
+
+// ── Time-based mapping ────────────────────────────────────────────────────────
+//
+// For charts plotted against real time (a DateTime axis spanning
+// first..last), the horizontal position of a point is proportional to its
+// timestamp, not its index — so unevenly-spaced samples and trade markers stay
+// aligned. These mirror [fractionToIndex] / [indexToFraction] for that case.
+
+/// Nearest data index to a horizontal [fraction] (0..1) on a time-based plot
+/// spanning `timestamps.first..timestamps.last`.
+int nearestIndexByTime(List<DateTime> timestamps, double fraction) {
+  if (timestamps.length <= 1) return 0;
+  final first = timestamps.first.millisecondsSinceEpoch;
+  final last = timestamps.last.millisecondsSinceEpoch;
+  if (last <= first) return 0;
+  final f = fraction.clamp(0.0, 1.0);
+  final target = first + f * (last - first);
+  var lo = 0;
+  var hi = timestamps.length - 1;
+  while (lo < hi) {
+    final mid = (lo + hi) ~/ 2;
+    if (timestamps[mid].millisecondsSinceEpoch < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  if (lo <= 0) return 0;
+  final prev = lo - 1;
+  return (timestamps[lo].millisecondsSinceEpoch - target).abs() <
+          (timestamps[prev].millisecondsSinceEpoch - target).abs()
+      ? lo
+      : prev;
+}
+
+/// The horizontal fraction (0..1) of data point [index] on a time-based plot.
+/// Inverse of [nearestIndexByTime] at the data points.
+double timeFractionOf(List<DateTime> timestamps, int index) {
+  if (timestamps.length <= 1) return 0.0;
+  final i = index.clamp(0, timestamps.length - 1);
+  final first = timestamps.first.millisecondsSinceEpoch;
+  final last = timestamps.last.millisecondsSinceEpoch;
+  if (last <= first) return 0.0;
+  return ((timestamps[i].millisecondsSinceEpoch - first) / (last - first))
+      .clamp(0.0, 1.0);
+}

--- a/mobile/lib/core/charts/scrub_controller.dart
+++ b/mobile/lib/core/charts/scrub_controller.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// A single scrub reading: which data point is snapped to, and the horizontal
+/// fraction `[0, 1]` at which the hairline + dot should be drawn (the data
+/// point's own fraction, so the hairline passes exactly through the point).
+@immutable
+class ScrubSample {
+  const ScrubSample({required this.index, required this.fraction});
+
+  final int index;
+  final double fraction;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ScrubSample && other.index == index && other.fraction == fraction;
+
+  @override
+  int get hashCode => Object.hash(index, fraction);
+}
+
+/// Default haptic: the soft iOS "selection" tick, matching Robinhood's
+/// per-data-point feel while scrubbing. Wrapped in a block body so the returned
+/// Future is intentionally discarded.
+void defaultScrubTick() {
+  HapticFeedback.selectionClick();
+}
+
+/// Holds the active scrub sample and emits a soft haptic tick each time the
+/// snapped data index changes (not on every pixel of movement).
+///
+/// Driving the scrubber through a [ValueNotifier] lets the chart cache its
+/// expensive Syncfusion widget and rebuild only a thin overlay + the header
+/// value while the finger moves — which is what removes the scrubbing jank.
+class ScrubController extends ValueNotifier<ScrubSample?> {
+  ScrubController({VoidCallback? onTick})
+      : _onTick = onTick ?? defaultScrubTick,
+        super(null);
+
+  final VoidCallback _onTick;
+
+  /// Update to a new sample. Fires a haptic tick only when [index] differs from
+  /// the current sample's index. Always notifies listeners so the hairline can
+  /// follow the finger smoothly.
+  void update(int index, double fraction) {
+    final prev = value;
+    if (prev == null || prev.index != index) {
+      _onTick();
+    }
+    value = ScrubSample(index: index, fraction: fraction);
+  }
+
+  /// Clear the scrub state. Only notifies if there was an active sample.
+  void clear() {
+    if (value != null) value = null;
+  }
+}

--- a/mobile/lib/core/charts/scrubbable_area_chart.dart
+++ b/mobile/lib/core/charts/scrubbable_area_chart.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+
+import '../theme/app_colors.dart';
+import 'chart_decorations.dart';
+import 'chart_geometry.dart';
+import 'scrub_controller.dart';
+
+/// A reusable equity/value chart with the app's "dashboard" look & feel:
+/// hidden axes, a monotonic spline area fill, clean date labels rendered below
+/// the plot, and a scrub interaction (hairline + dot on the line + a soft
+/// haptic tick) that reports the touched data index.
+///
+/// Plotted against real time (a DateTime axis spanning first..last) so
+/// unevenly-spaced samples and any [markerSeries] (e.g. buy/sell dots) stay
+/// aligned with the curve.
+class ScrubbableAreaChart extends StatefulWidget {
+  const ScrubbableAreaChart({
+    super.key,
+    required this.timestamps,
+    required this.values,
+    required this.lineColor,
+    this.height = 200,
+    this.baseline,
+    this.markerSeries,
+    this.onScrub,
+    this.animate = true,
+  });
+
+  final List<DateTime> timestamps;
+  final List<double> values;
+  final Color lineColor;
+  final double height;
+
+  /// Optional horizontal reference line (e.g. starting equity).
+  final double? baseline;
+
+  /// Optional extra series painted over the area (e.g. trade markers). Built
+  /// lazily so they're only created when the cached chart (re)builds.
+  final List<CartesianSeries> Function()? markerSeries;
+
+  /// Reports the scrubbed data index, or null when the finger lifts. Wire this
+  /// to a ValueNotifier-backed header so scrubbing doesn't rebuild the chart.
+  final ValueChanged<int?>? onScrub;
+
+  final bool animate;
+
+  @override
+  State<ScrubbableAreaChart> createState() => _ScrubbableAreaChartState();
+}
+
+class _ScrubbableAreaChartState extends State<ScrubbableAreaChart> {
+  final ScrubController _scrub = ScrubController();
+
+  // Cache the Syncfusion chart so an incidental rebuild never re-runs it.
+  Widget? _cachedChart;
+  List<DateTime>? _cacheTs;
+  List<double>? _cacheVals;
+  double? _cacheHeight;
+
+  static const double _labelRowHeight = 20;
+
+  @override
+  void dispose() {
+    _scrub.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final n = widget.values.length;
+    if (n == 0 || widget.timestamps.length != n) {
+      return SizedBox(height: widget.height);
+    }
+
+    final plotHeight =
+        (widget.height - _labelRowHeight).clamp(40.0, widget.height);
+    final boundsValues = widget.baseline != null
+        ? <double>[...widget.values, widget.baseline!]
+        : widget.values;
+    final bounds = paddedBounds(boundsValues);
+
+    final chart = _chartFor(bounds);
+
+    final span = widget.timestamps.last.difference(widget.timestamps.first);
+    final labels = [
+      for (final i in evenlySpacedLabelIndices(n, 4))
+        formatChartDateBySpan(widget.timestamps[i], span),
+    ];
+
+    return SizedBox(
+      height: widget.height,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            height: plotHeight,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final width = constraints.maxWidth;
+                return GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onHorizontalDragStart: (d) =>
+                      _onDrag(d.localPosition.dx, width, n),
+                  onHorizontalDragUpdate: (d) =>
+                      _onDrag(d.localPosition.dx, width, n),
+                  onHorizontalDragEnd: (_) => _end(),
+                  onHorizontalDragCancel: _end,
+                  child: Stack(
+                    children: [
+                      Positioned.fill(child: RepaintBoundary(child: chart)),
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: ValueListenableBuilder<ScrubSample?>(
+                            valueListenable: _scrub,
+                            builder: (_, sample, _) {
+                              if (sample == null ||
+                                  sample.index < 0 ||
+                                  sample.index >= n) {
+                                return const SizedBox.shrink();
+                              }
+                              final dotY = valueToY(
+                                widget.values[sample.index],
+                                bounds.min,
+                                bounds.max,
+                                plotHeight,
+                              );
+                              return CustomPaint(
+                                painter: ScrubPainter(
+                                  fraction: sample.fraction,
+                                  dotY: dotY,
+                                  color: widget.lineColor,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          ChartDateLabels(labels: labels),
+        ],
+      ),
+    );
+  }
+
+  Widget _chartFor(({double min, double max}) bounds) {
+    if (_cachedChart != null &&
+        identical(_cacheTs, widget.timestamps) &&
+        identical(_cacheVals, widget.values) &&
+        _cacheHeight == widget.height) {
+      return _cachedChart!;
+    }
+    _cacheTs = widget.timestamps;
+    _cacheVals = widget.values;
+    _cacheHeight = widget.height;
+
+    final pts = [
+      for (var i = 0; i < widget.values.length; i++)
+        _TVPoint(widget.timestamps[i], widget.values[i]),
+    ];
+    final c = widget.lineColor;
+
+    return _cachedChart = SfCartesianChart(
+      backgroundColor: Colors.transparent,
+      plotAreaBorderWidth: 0,
+      margin: EdgeInsets.zero,
+      primaryXAxis: DateTimeAxis(
+        isVisible: false,
+        plotOffset: 0,
+        rangePadding: ChartRangePadding.none,
+        majorGridLines: const MajorGridLines(width: 0),
+        axisLine: const AxisLine(width: 0),
+        majorTickLines: const MajorTickLines(size: 0),
+      ),
+      primaryYAxis: hiddenValueAxis(minimum: bounds.min, maximum: bounds.max),
+      annotations: widget.baseline != null
+          ? <CartesianChartAnnotation>[
+              CartesianChartAnnotation(
+                widget: Container(
+                  width: double.infinity,
+                  height: 1,
+                  color: AppColors.textFaint.withValues(alpha: 0.4),
+                ),
+                coordinateUnit: CoordinateUnit.point,
+                x: widget.timestamps.first,
+                y: widget.baseline,
+              ),
+            ]
+          : null,
+      series: <CartesianSeries>[
+        SplineAreaSeries<_TVPoint, DateTime>(
+          dataSource: pts,
+          splineType: SplineType.monotonic,
+          animationDuration: widget.animate ? 700 : 0,
+          xValueMapper: (p, _) => p.t,
+          yValueMapper: (p, _) => p.v,
+          color: c.withValues(alpha: 0.18),
+          borderColor: c,
+          borderWidth: 2,
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              c.withValues(alpha: 0.34),
+              c.withValues(alpha: 0.0),
+            ],
+          ),
+        ),
+        if (widget.markerSeries != null) ...widget.markerSeries!(),
+      ],
+    );
+  }
+
+  void _onDrag(double dx, double width, int n) {
+    if (width <= 0) return;
+    final frac = (dx / width).clamp(0.0, 1.0);
+    final idx = nearestIndexByTime(widget.timestamps, frac);
+    final prev = _scrub.value?.index;
+    // Draw the hairline + dot at the data point's own time-fraction so they sit
+    // on the curve and match the value reported to the header.
+    _scrub.update(idx, timeFractionOf(widget.timestamps, idx));
+    if (idx != prev) widget.onScrub?.call(idx);
+  }
+
+  void _end() {
+    if (_scrub.value == null) return;
+    _scrub.clear();
+    widget.onScrub?.call(null);
+  }
+}
+
+class _TVPoint {
+  const _TVPoint(this.t, this.v);
+  final DateTime t;
+  final double v;
+}

--- a/mobile/lib/features/backtests/application/backtest_detail_controller.dart
+++ b/mobile/lib/features/backtests/application/backtest_detail_controller.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../data/backtest_repository.dart';
+import '../data/models/backtest.dart';
+
+/// Holds all data for the detail screen.
+class BacktestDetailState {
+  const BacktestDetailState({
+    this.summary,
+    this.graphData,
+    this.llmCost,
+    this.statusData,
+    this.loading = true,
+    this.error,
+    this.llmCostLoading = false,
+    this.llmCostError,
+    this.logsLoading = false,
+    this.logsError,
+    this.logLines = const [],
+    this.logSource = '',
+  });
+
+  final BacktestSummary? summary;
+  final BacktestGraphData? graphData;
+  final LlmCost? llmCost;
+  final BacktestStatus? statusData;
+  final bool loading;
+  final String? error;
+  final bool llmCostLoading;
+  final String? llmCostError;
+  final bool logsLoading;
+  final String? logsError;
+  final List<String> logLines;
+  final String logSource;
+
+  String get currentStatus =>
+      statusData?.status ?? summary?.status ?? 'unknown';
+
+  num? get progress => statusData?.progress;
+  num? get elapsedSeconds =>
+      statusData?.timeElapsedSeconds ?? summary?.timeElapsedSeconds;
+  NexusLookback? get nexusLookback => statusData?.nexusLookback;
+
+  bool get isActive {
+    final s = currentStatus.toLowerCase();
+    return s == 'running' || s == 'queued' || s == 'pending' ||
+        s == 'paused' || s == 'paused_llm_critical';
+  }
+
+  bool get isTerminal {
+    final s = currentStatus.toLowerCase();
+    return s == 'completed' || s == 'finished' || s == 'stopped' ||
+        s == 'failed' || s == 'error' || s == 'cancelled';
+  }
+
+  BacktestDetailState copyWith({
+    BacktestSummary? summary,
+    BacktestGraphData? graphData,
+    LlmCost? llmCost,
+    BacktestStatus? statusData,
+    bool? loading,
+    String? error,
+    bool clearError = false,
+    bool? llmCostLoading,
+    String? llmCostError,
+    bool clearLlmCostError = false,
+    bool? logsLoading,
+    String? logsError,
+    bool clearLogsError = false,
+    List<String>? logLines,
+    String? logSource,
+  }) =>
+      BacktestDetailState(
+        summary: summary ?? this.summary,
+        graphData: graphData ?? this.graphData,
+        llmCost: llmCost ?? this.llmCost,
+        statusData: statusData ?? this.statusData,
+        loading: loading ?? this.loading,
+        error: clearError ? null : (error ?? this.error),
+        llmCostLoading: llmCostLoading ?? this.llmCostLoading,
+        llmCostError: clearLlmCostError
+            ? null
+            : (llmCostError ?? this.llmCostError),
+        logsLoading: logsLoading ?? this.logsLoading,
+        logsError:
+            clearLogsError ? null : (logsError ?? this.logsError),
+        logLines: logLines ?? this.logLines,
+        logSource: logSource ?? this.logSource,
+      );
+}
+
+class BacktestDetailController
+    extends AutoDisposeFamilyNotifier<BacktestDetailState, String> {
+  Timer? _pollTimer;
+  int _llmCostTick = 0;
+  late final String _id;
+
+  @override
+  BacktestDetailState build(String id) {
+    _id = id;
+    ref.onDispose(_stopPoll);
+    Future.microtask(() => _init(id));
+    return const BacktestDetailState(loading: true);
+  }
+
+  BacktestRepository get _repo => ref.read(backtestRepositoryProvider);
+
+  Future<void> _init(String id) async {
+    state = state.copyWith(loading: true, clearError: true);
+    try {
+      final results = await Future.wait([
+        _repo.summary(id),
+        _repo.graphData(id).catchError((_) => const BacktestGraphData()),
+        _repo.llmCost(id).catchError((_) => const LlmCost()),
+      ]);
+      state = state.copyWith(
+        summary: results[0] as BacktestSummary,
+        graphData: results[1] as BacktestGraphData,
+        llmCost: results[2] as LlmCost,
+        loading: false,
+        clearError: true,
+      );
+      final s = (state.summary?.status ?? '').toLowerCase();
+      if (_isActive(s)) {
+        await _fetchStatus(id);
+        _startPoll(id);
+      }
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  bool _isActive(String s) =>
+      s == 'running' || s == 'queued' || s == 'pending' ||
+      s == 'paused' || s == 'paused_llm_critical';
+
+  bool _isTerminal(String s) =>
+      s == 'completed' || s == 'finished' || s == 'stopped' ||
+      s == 'failed' || s == 'error' || s == 'cancelled';
+
+  void _startPoll(String id) {
+    if (_pollTimer != null) return;
+    _pollTimer = Timer.periodic(
+      const Duration(seconds: 3),
+      (_) => _tick(id),
+    );
+  }
+
+  void _stopPoll() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  Future<void> _tick(String id) async {
+    _llmCostTick = (_llmCostTick + 1) % 10;
+    if (_llmCostTick == 0) {
+      _refreshLlmCost(id);
+    }
+    await _fetchStatus(id);
+  }
+
+  Future<void> _fetchStatus(String id) async {
+    try {
+      final s = await _repo.status(id);
+      state = state.copyWith(statusData: s);
+      final st = (s.status ?? '').toLowerCase();
+      if (_isTerminal(st)) {
+        _stopPoll();
+        final results = await Future.wait([
+          _repo.summary(id),
+          _repo.graphData(id)
+              .catchError((_) => const BacktestGraphData()),
+          _repo.llmCost(id).catchError((_) => const LlmCost()),
+        ]);
+        state = state.copyWith(
+          summary: results[0] as BacktestSummary,
+          graphData: results[1] as BacktestGraphData,
+          llmCost: results[2] as LlmCost,
+        );
+      } else if (st == 'paused') {
+        _stopPoll();
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _refreshLlmCost(String id) async {
+    try {
+      final cost = await _repo.llmCost(id);
+      state = state.copyWith(llmCost: cost, clearLlmCostError: true);
+    } catch (_) {}
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  Future<void> refreshLlmCost() async {
+    state = state.copyWith(llmCostLoading: true, clearLlmCostError: true);
+    try {
+      final cost = await _repo.llmCost(_id);
+      state = state.copyWith(llmCost: cost, llmCostLoading: false);
+    } catch (e) {
+      state = state.copyWith(
+          llmCostLoading: false, llmCostError: e.toString());
+    }
+  }
+
+  Future<void> loadLogs() async {
+    if (state.logsLoading) return;
+    state = state.copyWith(logsLoading: true, clearLogsError: true);
+    try {
+      final data = await _repo.logs(_id);
+      final lines = (data['logs'] as List? ?? []).cast<String>();
+      state = state.copyWith(
+        logsLoading: false,
+        logLines: lines,
+        logSource: data['source']?.toString() ?? 'db',
+      );
+    } catch (e) {
+      state = state.copyWith(logsLoading: false, logsError: e.toString());
+    }
+  }
+
+  /// Returns error string or null on success.
+  Future<String?> performAction(String action) async {
+    try {
+      if (action == 'delete') {
+        await _repo.delete(_id);
+        _stopPoll();
+        return null;
+      }
+      await _repo.action(_id, action);
+      await _fetchStatus(_id);
+      if (action == 'stop') {
+        _stopPoll();
+      } else if (action == 'resume') {
+        _startPoll(_id);
+      }
+      return null;
+    } catch (e) {
+      return e.toString();
+    }
+  }
+
+  Future<Map<String, dynamic>> rerun() async {
+    final s = state.summary;
+    if (s == null) throw Exception('No summary loaded');
+    final body = <String, dynamic>{
+      if (s.instanceId != null) 'instance_id': s.instanceId,
+      'stocks': s.tickers,
+      'start_date': s.startDate,
+      'end_date': s.endDate,
+      'granularity': s.granularity ?? '60',
+      'initial_cash': s.initialCash ?? 100000,
+    };
+    return _repo.create(body);
+  }
+}
+
+final backtestDetailControllerProvider = AutoDisposeNotifierProvider.family<
+    BacktestDetailController, BacktestDetailState, String>(
+  BacktestDetailController.new,
+);

--- a/mobile/lib/features/backtests/application/backtest_playback_controller.dart
+++ b/mobile/lib/features/backtests/application/backtest_playback_controller.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../data/backtest_repository.dart';
+import '../data/models/backtest.dart';
+
+const List<double> kPlaybackSpeeds = [0.5, 1, 2, 5, 10];
+
+class BacktestPlaybackState {
+  const BacktestPlaybackState({
+    this.events = const [],
+    this.metadata = const PlaybackMetadata(),
+    this.frameIndex = -1,
+    this.isPlaying = false,
+    this.speedIndex = 1, // default 1x
+    this.loading = true,
+    this.error,
+  });
+
+  final List<PlaybackEvent> events;
+  final PlaybackMetadata metadata;
+  final int frameIndex;
+  final bool isPlaying;
+  final int speedIndex;
+  final bool loading;
+  final String? error;
+
+  double get speed => kPlaybackSpeeds[speedIndex];
+  bool get isFinished => frameIndex >= events.length - 1;
+  bool get isEmpty => !loading && events.isEmpty;
+
+  /// All events up to and including the current frame.
+  List<PlaybackEvent> get visibleEvents =>
+      frameIndex >= 0 ? events.sublist(0, frameIndex + 1) : const [];
+
+  /// Last portfolio event at or before frameIndex.
+  PlaybackEvent? get currentPortfolioEvent {
+    for (int i = frameIndex; i >= 0; i--) {
+      if (events[i].type == 'portfolio') return events[i];
+    }
+    return null;
+  }
+
+  num get currentPortfolioValue =>
+      currentPortfolioEvent?.portfolioValue ??
+      metadata.initialCash ??
+      100000;
+
+  List<PlaybackHolding> get currentHoldings =>
+      currentPortfolioEvent?.holdings ?? const [];
+
+  /// Current date label from the most recent 'date' event.
+  String get currentDateLabel {
+    for (int i = frameIndex; i >= 0; i--) {
+      if (events[i].type == 'date') {
+        final ev = events[i];
+        return '${ev.label ?? ''} — ${ev.time ?? ''}';
+      }
+    }
+    return '—';
+  }
+
+  /// All portfolio value data points from the start up to frameIndex.
+  List<({DateTime time, double value})> get portfolioHistory {
+    final pts = <({DateTime time, double value})>[];
+    for (int i = 0; i <= frameIndex && i < events.length; i++) {
+      final ev = events[i];
+      if (ev.type == 'portfolio' && ev.date != null) {
+        final dt = DateTime.tryParse(ev.date!);
+        if (dt != null && ev.portfolioValue != null) {
+          pts.add((
+            time: dt,
+            value: ev.portfolioValue!.toDouble(),
+          ));
+        }
+      }
+    }
+    return pts;
+  }
+
+  /// Full x-axis range (for fixed-range chart).
+  ({DateTime min, DateTime max}) get xRange {
+    DateTime? first;
+    DateTime? last;
+    for (final ev in events) {
+      if (ev.type == 'portfolio' && ev.date != null) {
+        final dt = DateTime.tryParse(ev.date!);
+        if (dt != null) {
+          first ??= dt;
+          last = dt;
+        }
+      }
+    }
+    final now = DateTime.now();
+    return (
+      min: first?.subtract(const Duration(days: 1)) ??
+          now.subtract(const Duration(days: 7)),
+      max: last ?? now,
+    );
+  }
+
+  BacktestPlaybackState copyWith({
+    List<PlaybackEvent>? events,
+    PlaybackMetadata? metadata,
+    int? frameIndex,
+    bool? isPlaying,
+    int? speedIndex,
+    bool? loading,
+    String? error,
+    bool clearError = false,
+  }) =>
+      BacktestPlaybackState(
+        events: events ?? this.events,
+        metadata: metadata ?? this.metadata,
+        frameIndex: frameIndex ?? this.frameIndex,
+        isPlaying: isPlaying ?? this.isPlaying,
+        speedIndex: speedIndex ?? this.speedIndex,
+        loading: loading ?? this.loading,
+        error: clearError ? null : (error ?? this.error),
+      );
+}
+
+class BacktestPlaybackController
+    extends AutoDisposeFamilyNotifier<BacktestPlaybackState, String> {
+  Timer? _frameTimer;
+
+  @override
+  BacktestPlaybackState build(String id) {
+    ref.onDispose(_cancelTimer);
+    Future.microtask(() => _load(id));
+    return const BacktestPlaybackState(loading: true);
+  }
+
+  BacktestRepository get _repo => ref.read(backtestRepositoryProvider);
+
+  Future<void> _load(String id) async {
+    try {
+      final data = await _repo.playbackData(id);
+      state = state.copyWith(
+        events: data.events,
+        metadata: data.metadata,
+        frameIndex: -1,
+        loading: false,
+        clearError: true,
+      );
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  void _cancelTimer() {
+    _frameTimer?.cancel();
+    _frameTimer = null;
+  }
+
+  void _scheduleFrame() {
+    _cancelTimer();
+    final delay =
+        Duration(milliseconds: (1000 / state.speed).round());
+    _frameTimer = Timer(delay, _advance);
+  }
+
+  void _advance() {
+    if (!state.isPlaying) return;
+    if (state.isFinished) {
+      state = state.copyWith(isPlaying: false);
+      return;
+    }
+    state = state.copyWith(frameIndex: state.frameIndex + 1);
+    _scheduleFrame();
+  }
+
+  // ── Public controls ───────────────────────────────────────────────────────
+
+  void togglePlay() {
+    if (state.isPlaying) {
+      _cancelTimer();
+      state = state.copyWith(isPlaying: false);
+    } else {
+      if (state.isFinished) {
+        state = state.copyWith(
+            frameIndex: state.events.isEmpty ? -1 : 0,
+            isPlaying: true);
+      } else {
+        state = state.copyWith(isPlaying: true);
+      }
+      _scheduleFrame();
+    }
+  }
+
+  void reset() {
+    _cancelTimer();
+    state = state.copyWith(
+      frameIndex: state.events.isEmpty ? -1 : 0,
+      isPlaying: false,
+    );
+  }
+
+  void cycleSpeed() {
+    final wasPlaying = state.isPlaying;
+    if (wasPlaying) _cancelTimer();
+    final next = (state.speedIndex + 1) % kPlaybackSpeeds.length;
+    state = state.copyWith(speedIndex: next);
+    if (wasPlaying) _scheduleFrame();
+  }
+}
+
+final backtestPlaybackControllerProvider =
+    AutoDisposeNotifierProvider.family<BacktestPlaybackController,
+        BacktestPlaybackState, String>(
+  BacktestPlaybackController.new,
+);

--- a/mobile/lib/features/backtests/application/backtests_list_controller.dart
+++ b/mobile/lib/features/backtests/application/backtests_list_controller.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../data/backtest_repository.dart';
+import '../data/models/backtest.dart';
+
+/// State for the backtests list screen.
+class BacktestsListState {
+  const BacktestsListState({
+    this.rows = const [],
+    this.total = 0,
+    this.totalPages = 1,
+    this.page = 1,
+    this.perPage = 15,
+    this.sortBy = 'completed_at',
+    this.sortOrder = 'desc',
+    this.loading = false,
+    this.error,
+    this.statusMap = const {},
+  });
+
+  final List<BacktestRow> rows;
+  final int total;
+  final int totalPages;
+  final int page;
+  final int perPage;
+  final String sortBy;
+  final String sortOrder;
+  final bool loading;
+  final String? error;
+  // Live status overlay keyed by backtest id
+  final Map<String, BacktestStatus> statusMap;
+
+  BacktestsListState copyWith({
+    List<BacktestRow>? rows,
+    int? total,
+    int? totalPages,
+    int? page,
+    int? perPage,
+    String? sortBy,
+    String? sortOrder,
+    bool? loading,
+    String? error,
+    bool clearError = false,
+    Map<String, BacktestStatus>? statusMap,
+  }) =>
+      BacktestsListState(
+        rows: rows ?? this.rows,
+        total: total ?? this.total,
+        totalPages: totalPages ?? this.totalPages,
+        page: page ?? this.page,
+        perPage: perPage ?? this.perPage,
+        sortBy: sortBy ?? this.sortBy,
+        sortOrder: sortOrder ?? this.sortOrder,
+        loading: loading ?? this.loading,
+        error: clearError ? null : (error ?? this.error),
+        statusMap: statusMap ?? this.statusMap,
+      );
+}
+
+class BacktestsListController extends AutoDisposeNotifier<BacktestsListState> {
+  Timer? _pollTimer;
+
+  @override
+  BacktestsListState build() {
+    ref.onDispose(_stopPoll);
+    // Initial load + start polling
+    Future.microtask(_loadPage);
+    return const BacktestsListState(loading: true);
+  }
+
+  BacktestRepository get _repo =>
+      ref.read(backtestRepositoryProvider);
+
+  Future<void> _loadPage({int? page}) async {
+    final s = state;
+    state = s.copyWith(loading: true, clearError: true);
+    try {
+      final resp = await _repo.list(
+        page: page ?? s.page,
+        perPage: s.perPage,
+        sortBy: s.sortBy,
+        sortOrder: s.sortOrder,
+      );
+      state = state.copyWith(
+        rows: resp.backtests,
+        total: resp.total,
+        totalPages: resp.totalPages,
+        page: resp.page,
+        loading: false,
+        clearError: true,
+      );
+      _managePoll();
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  void _managePoll() {
+    final hasRunning = state.rows.any((r) {
+      final live = state.statusMap[r.id]?.status ?? r.status ?? '';
+      return _isActive(live);
+    });
+    if (hasRunning) {
+      _startPoll();
+    } else {
+      _stopPoll();
+    }
+  }
+
+  bool _isActive(String s) {
+    final l = s.toLowerCase();
+    return l == 'running' || l == 'queued' || l == 'pending' || l == 'paused' || l == 'paused_llm_critical';
+  }
+
+  bool _isTerminal(String s) {
+    final l = s.toLowerCase();
+    return l == 'completed' || l == 'finished' || l == 'stopped' || l == 'failed' || l == 'error' || l == 'cancelled';
+  }
+
+  void _startPoll() {
+    if (_pollTimer != null) return;
+    _pollTimer = Timer.periodic(const Duration(seconds: 3), (_) => _pollRunning());
+  }
+
+  void _stopPoll() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  Future<void> _pollRunning() async {
+    final running = state.rows.where((r) {
+      final live = state.statusMap[r.id]?.status ?? r.status ?? '';
+      return _isActive(live);
+    }).toList();
+    if (running.isEmpty) {
+      _stopPoll();
+      return;
+    }
+    var updated = Map<String, BacktestStatus>.from(state.statusMap);
+    bool anyTerminated = false;
+    await Future.wait(running.map((bt) async {
+      try {
+        final s = await _repo.status(bt.id);
+        updated[bt.id] = s;
+        if (_isTerminal(s.status ?? '')) anyTerminated = true;
+      } catch (_) {}
+    }));
+    state = state.copyWith(statusMap: updated);
+    if (anyTerminated) {
+      await _loadPage(page: state.page);
+    }
+  }
+
+  // ── Public actions ────────────────────────────────────────────────────────
+
+  Future<void> refresh() => _loadPage();
+
+  Future<void> goToPage(int page) => _loadPage(page: page);
+
+  void setPerPage(int perPage) {
+    state = state.copyWith(perPage: perPage);
+    _loadPage(page: 1);
+  }
+
+  void toggleSort(String field) {
+    if (state.sortBy == field) {
+      state = state.copyWith(
+          sortOrder: state.sortOrder == 'asc' ? 'desc' : 'asc');
+    } else {
+      state = state.copyWith(sortBy: field, sortOrder: 'desc');
+    }
+    _loadPage(page: 1);
+  }
+
+  Future<String?> performAction(String id, String action) async {
+    try {
+      await _repo.action(id, action);
+      // Immediately refresh status for that item
+      try {
+        final s = await _repo.status(id);
+        final updated = Map<String, BacktestStatus>.from(state.statusMap);
+        updated[id] = s;
+        state = state.copyWith(statusMap: updated);
+      } catch (_) {}
+      _loadPage(page: state.page);
+      if (action == 'resume') _startPoll();
+      return null; // success
+    } catch (e) {
+      return e.toString();
+    }
+  }
+}
+
+final backtestsListControllerProvider =
+    AutoDisposeNotifierProvider<BacktestsListController, BacktestsListState>(
+  BacktestsListController.new,
+);

--- a/mobile/lib/features/backtests/data/backtest_repository.dart
+++ b/mobile/lib/features/backtests/data/backtest_repository.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/api_client.dart';
+import 'models/backtest.dart';
+
+class BacktestRepository {
+  const BacktestRepository(this._client);
+
+  final ApiClient _client;
+
+  /// GET /backtests?page=&per_page=&sort_by=&sort_order=
+  Future<BacktestListResponse> list({
+    int page = 1,
+    int perPage = 15,
+    String sortBy = 'completed_at',
+    String sortOrder = 'desc',
+  }) async {
+    final data = await _client.get<Map<String, dynamic>>(
+      '/backtests',
+      query: {
+        'page': page.toString(),
+        'per_page': perPage.toString(),
+        'sort_by': sortBy,
+        'sort_order': sortOrder,
+      },
+    );
+    return BacktestListResponse.fromJson(data);
+  }
+
+  /// GET /backtests/:id  (summary by default; fallback used as detail root)
+  Future<BacktestSummary> get(String id) async {
+    final data =
+        await _client.get<Map<String, dynamic>>('/backtests/$id');
+    return BacktestSummary.fromJson(data);
+  }
+
+  /// DELETE /backtests/:id
+  Future<void> delete(String id) =>
+      _client.delete<dynamic>('/backtests/$id');
+
+  /// GET /backtests/:id/status
+  Future<BacktestStatus> status(String id) async {
+    final data =
+        await _client.get<Map<String, dynamic>>('/backtests/$id/status');
+    return BacktestStatus.fromJson(data);
+  }
+
+  /// GET /backtests/:id/summary
+  Future<BacktestSummary> summary(String id) async {
+    final data =
+        await _client.get<Map<String, dynamic>>('/backtests/$id/summary');
+    return BacktestSummary.fromJson(data);
+  }
+
+  /// GET /backtests/:id/graph-data
+  Future<BacktestGraphData> graphData(String id) async {
+    final data =
+        await _client.get<Map<String, dynamic>>('/backtests/$id/graph-data');
+    return BacktestGraphData.fromJson(data);
+  }
+
+  /// GET /backtests/:id/playback-data
+  Future<PlaybackData> playbackData(String id) async {
+    final data = await _client
+        .get<Map<String, dynamic>>('/backtests/$id/playback-data');
+    return PlaybackData.fromJson(data);
+  }
+
+  /// GET /backtests/:id/logs?since_line=N
+  Future<Map<String, dynamic>> logs(String id, {int sinceLine = 0}) =>
+      _client.get<Map<String, dynamic>>(
+        '/backtests/$id/logs',
+        query: {'since_line': sinceLine.toString()},
+      );
+
+  /// GET /backtests/:id/llm-cost
+  Future<LlmCost> llmCost(String id) async {
+    final data =
+        await _client.get<Map<String, dynamic>>('/backtests/$id/llm-cost');
+    return LlmCost.fromJson(data);
+  }
+
+  /// POST /backtests/:id/:action  (pause | resume | stop)
+  Future<Map<String, dynamic>> action(String id, String name) =>
+      _client.post<Map<String, dynamic>>('/backtests/$id/$name');
+
+  /// POST /backtests
+  Future<Map<String, dynamic>> create(Map<String, dynamic> body) =>
+      _client.post<Map<String, dynamic>>('/backtests', body: body);
+}
+
+final backtestRepositoryProvider = Provider<BacktestRepository>(
+  (ref) => BacktestRepository(ref.watch(apiClientProvider)),
+);

--- a/mobile/lib/features/backtests/data/models/backtest.dart
+++ b/mobile/lib/features/backtests/data/models/backtest.dart
@@ -1,0 +1,743 @@
+// Plain immutable models for the backtests feature. No codegen.
+// All fromJson factories are nullable-tolerant (missing fields default to null).
+
+class BacktestRow {
+  const BacktestRow({
+    required this.id,
+    this.instanceId,
+    this.status,
+    this.stocks = const [],
+    this.startDate,
+    this.endDate,
+    this.completedAt,
+    this.pnl,
+    this.pnlPercent,
+    this.timeElapsedSeconds,
+  });
+
+  final String id;
+  final String? instanceId;
+  final String? status;
+  final List<String> stocks;
+  final String? startDate;
+  final String? endDate;
+  final dynamic completedAt; // epoch or ISO
+  final num? pnl;
+  final num? pnlPercent;
+  final num? timeElapsedSeconds;
+
+  factory BacktestRow.fromJson(Map<String, dynamic> j) => BacktestRow(
+        id: j['id']?.toString() ?? '',
+        instanceId:
+            (j['instance_id'] ?? j['instance'])?.toString(),
+        status: j['status']?.toString(),
+        stocks: _strList(j['stocks'] ?? j['tickers']),
+        startDate: j['start_date']?.toString(),
+        endDate: j['end_date']?.toString(),
+        completedAt: j['completed_at'],
+        pnl: _num(j['pnl']),
+        pnlPercent: _num(j['pnl_percent']),
+        timeElapsedSeconds: _num(j['time_elapsed_seconds']),
+      );
+}
+
+class BacktestStatus {
+  const BacktestStatus({
+    this.status,
+    this.progress,
+    this.nexusLookback,
+    this.timeElapsedSeconds,
+  });
+
+  final String? status;
+  final num? progress;
+  final NexusLookback? nexusLookback;
+  final num? timeElapsedSeconds;
+
+  factory BacktestStatus.fromJson(Map<String, dynamic> j) => BacktestStatus(
+        status: j['status']?.toString(),
+        progress: _num(j['progress']),
+        nexusLookback: j['nexus_lookback'] is Map
+            ? NexusLookback.fromJson(
+                Map<String, dynamic>.from(j['nexus_lookback'] as Map))
+            : null,
+        timeElapsedSeconds: _num(j['time_elapsed_seconds']),
+      );
+}
+
+class NexusLookback {
+  const NexusLookback({
+    required this.current,
+    required this.total,
+    this.currentDate,
+    this.startDate,
+    this.endDate,
+  });
+
+  final int current;
+  final int total;
+  final String? currentDate;
+  final String? startDate;
+  final String? endDate;
+
+  factory NexusLookback.fromJson(Map<String, dynamic> j) => NexusLookback(
+        current: (j['current'] as num?)?.toInt() ?? 0,
+        total: (j['total'] as num?)?.toInt() ?? 0,
+        currentDate: j['current_date']?.toString(),
+        startDate: j['start_date']?.toString(),
+        endDate: j['end_date']?.toString(),
+      );
+
+  double get fraction => total > 0 ? current / total : 0;
+}
+
+class BacktestSummary {
+  const BacktestSummary({
+    this.id,
+    this.status,
+    this.pnl,
+    this.pnlPercent,
+    this.portfolioStartValue,
+    this.portfolioEndValue,
+    this.totalTrades,
+    this.totalBuys,
+    this.totalSells,
+    this.timeElapsedSeconds,
+    this.winRatePercent,
+    this.winningRoundTrips,
+    this.losingRoundTrips,
+    this.portfolioValueHigh,
+    this.portfolioValueLow,
+    this.roundTrips,
+    this.pnlPerStock,
+    this.pnlPercentPerStock,
+    this.stockPriceChange,
+    this.tickers = const [],
+    this.startDate,
+    this.endDate,
+    this.strategySchema,
+    this.strategyId,
+    this.instanceId,
+    this.granularity,
+    this.initialCash,
+    // LLM pause fields
+    this.pauseReasonTag,
+    this.pauseProvider,
+    this.pauseModel,
+    this.pauseCallSite,
+    this.pauseAttempts,
+    this.pauseBarTime,
+    this.pausedAt,
+    this.pauseSample,
+    // round-trip extra
+    this.totalRoundTripPnl,
+    this.avgWinningRoundTrip,
+    this.avgLosingRoundTrip,
+  });
+
+  final String? id;
+  final String? status;
+  final num? pnl;
+  final num? pnlPercent;
+  final num? portfolioStartValue;
+  final num? portfolioEndValue;
+  final num? totalTrades;
+  final num? totalBuys;
+  final num? totalSells;
+  final num? timeElapsedSeconds;
+  final num? winRatePercent;
+  final num? winningRoundTrips;
+  final num? losingRoundTrips;
+  final num? portfolioValueHigh;
+  final num? portfolioValueLow;
+  final num? roundTrips;
+  final Map<String, num>? pnlPerStock;
+  final Map<String, num>? pnlPercentPerStock;
+  final Map<String, num>? stockPriceChange;
+  final List<String> tickers;
+  final String? startDate;
+  final String? endDate;
+  final StrategySchema? strategySchema;
+  final String? strategyId;
+  final String? instanceId;
+  final String? granularity;
+  final num? initialCash;
+  // LLM pause
+  final String? pauseReasonTag;
+  final String? pauseProvider;
+  final String? pauseModel;
+  final String? pauseCallSite;
+  final num? pauseAttempts;
+  final String? pauseBarTime;
+  final dynamic pausedAt;
+  final String? pauseSample;
+  // round-trips
+  final num? totalRoundTripPnl;
+  final num? avgWinningRoundTrip;
+  final num? avgLosingRoundTrip;
+
+  factory BacktestSummary.fromJson(Map<String, dynamic> j) => BacktestSummary(
+        id: j['id']?.toString(),
+        status: j['status']?.toString(),
+        pnl: _num(j['pnl']),
+        pnlPercent: _num(j['pnl_percent']),
+        portfolioStartValue: _num(j['portfolio_start_value']),
+        portfolioEndValue: _num(j['portfolio_end_value']),
+        totalTrades: _num(j['total_trades']),
+        totalBuys: _num(j['total_buys']),
+        totalSells: _num(j['total_sells']),
+        timeElapsedSeconds: _num(j['time_elapsed_seconds']),
+        winRatePercent: _num(j['win_rate_percent']),
+        winningRoundTrips: _num(j['winning_round_trips']),
+        losingRoundTrips: _num(j['losing_round_trips']),
+        portfolioValueHigh: _num(j['portfolio_value_high']),
+        portfolioValueLow: _num(j['portfolio_value_low']),
+        roundTrips: _num(j['round_trips']),
+        pnlPerStock: _numMap(j['pnl_per_stock']),
+        pnlPercentPerStock: _numMap(j['pnl_percent_per_stock']),
+        stockPriceChange: _numMap(j['stock_price_change']),
+        tickers: _strList(j['tickers']),
+        startDate: j['start_date']?.toString(),
+        endDate: j['end_date']?.toString(),
+        strategySchema: j['strategy_schema'] is Map
+            ? StrategySchema.fromJson(
+                Map<String, dynamic>.from(j['strategy_schema'] as Map))
+            : null,
+        strategyId: j['strategy_id']?.toString(),
+        instanceId: (j['instance_id'] ?? j['instance'])?.toString(),
+        granularity: j['granularity']?.toString(),
+        initialCash: _num(j['initial_cash']),
+        pauseReasonTag: j['pause_reason_tag']?.toString(),
+        pauseProvider: j['pause_provider']?.toString(),
+        pauseModel: j['pause_model']?.toString(),
+        pauseCallSite: j['pause_call_site']?.toString(),
+        pauseAttempts: _num(j['pause_attempts']),
+        pauseBarTime: j['pause_bar_time']?.toString(),
+        pausedAt: j['paused_at'],
+        pauseSample: j['pause_sample']?.toString(),
+        totalRoundTripPnl: _num(j['total_round_trip_pnl']),
+        avgWinningRoundTrip: _num(j['avg_winning_round_trip']),
+        avgLosingRoundTrip: _num(j['avg_losing_round_trip']),
+      );
+}
+
+class StrategySchema {
+  const StrategySchema({this.name, this.strategies = const []});
+
+  final String? name;
+  final List<SubStrategy> strategies;
+
+  factory StrategySchema.fromJson(Map<String, dynamic> j) => StrategySchema(
+        name: j['name']?.toString(),
+        strategies: (j['strategies'] as List? ?? [])
+            .whereType<Map>()
+            .map((s) =>
+                SubStrategy.fromJson(Map<String, dynamic>.from(s)))
+            .toList(),
+      );
+}
+
+class SubStrategy {
+  const SubStrategy({
+    this.strategy,
+    this.weight,
+    this.executionPosition,
+    this.decisionPhase,
+    this.executionScope,
+    this.conditions = const {},
+    this.config = const {},
+  });
+
+  final String? strategy;
+  final num? weight;
+  final num? executionPosition;
+  final String? decisionPhase;
+  final String? executionScope;
+  final Map<String, dynamic> conditions;
+  final Map<String, dynamic> config;
+
+  factory SubStrategy.fromJson(Map<String, dynamic> j) => SubStrategy(
+        strategy: j['strategy']?.toString(),
+        weight: _num(j['weight']),
+        executionPosition: _num(j['execution_position']),
+        decisionPhase: j['decision_phase']?.toString(),
+        executionScope: j['execution_scope']?.toString(),
+        conditions: j['conditions'] is Map
+            ? Map<String, dynamic>.from(j['conditions'] as Map)
+            : const {},
+        config: j['config'] is Map
+            ? Map<String, dynamic>.from(j['config'] as Map)
+            : const {},
+      );
+}
+
+class LlmCost {
+  const LlmCost({
+    this.totalCostUsd,
+    this.totalCalls,
+    this.okCalls,
+    this.failedCalls,
+    this.totalInputTokens,
+    this.totalOutputTokens,
+    this.totalReasoningTokens,
+    this.byModel = const [],
+    this.byCallSite = const [],
+    this.byProvider = const [],
+  });
+
+  final num? totalCostUsd;
+  final num? totalCalls;
+  final num? okCalls;
+  final num? failedCalls;
+  final num? totalInputTokens;
+  final num? totalOutputTokens;
+  final num? totalReasoningTokens;
+  final List<LlmCostRow> byModel;
+  final List<LlmCostRow> byCallSite;
+  final List<LlmCostRow> byProvider;
+
+  factory LlmCost.fromJson(Map<String, dynamic> j) => LlmCost(
+        totalCostUsd: _num(j['total_cost_usd']),
+        totalCalls: _num(j['total_calls']),
+        okCalls: _num(j['ok_calls']),
+        failedCalls: _num(j['failed_calls']),
+        totalInputTokens: _num(j['total_input_tokens']),
+        totalOutputTokens: _num(j['total_output_tokens']),
+        totalReasoningTokens: _num(j['total_reasoning_tokens']),
+        byModel: _costRows(j['by_model']),
+        byCallSite: _costRows(j['by_call_site']),
+        byProvider: _costRows(j['by_provider']),
+      );
+
+  static List<LlmCostRow> _costRows(dynamic v) {
+    if (v is! List) return const [];
+    return v
+        .whereType<Map>()
+        .map((m) => LlmCostRow.fromJson(Map<String, dynamic>.from(m)))
+        .toList();
+  }
+}
+
+class LlmCostRow {
+  const LlmCostRow({required this.key, this.costUsd});
+
+  final String key;
+  final num? costUsd;
+
+  factory LlmCostRow.fromJson(Map<String, dynamic> j) => LlmCostRow(
+        key: j['key']?.toString() ?? '?',
+        costUsd: _num(j['cost_usd']),
+      );
+}
+
+class PortfolioValuePoint {
+  const PortfolioValuePoint({required this.timestamp, required this.value});
+
+  final DateTime timestamp;
+  final double value;
+
+  factory PortfolioValuePoint.fromJson(Map<String, dynamic> j) {
+    final raw = j['timestamp'] ?? j['date'] ?? j['time'];
+    final dt = raw is num
+        ? DateTime.fromMillisecondsSinceEpoch(
+            raw > 1e12 ? raw.toInt() : (raw * 1000).toInt())
+        : (DateTime.tryParse(raw?.toString() ?? '') ?? DateTime.now());
+    return PortfolioValuePoint(
+      timestamp: dt,
+      value: (j['value'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+class BacktestTrade {
+  const BacktestTrade({
+    required this.ticker,
+    this.action,
+    this.timestamp,
+    this.price,
+    this.shares,
+    this.total,
+    this.cashAfter,
+  });
+
+  final String ticker;
+  final String? action;
+  final DateTime? timestamp;
+  final num? price;
+  final num? shares;
+  final num? total;
+  final num? cashAfter;
+
+  factory BacktestTrade.fromJson(Map<String, dynamic> j) => BacktestTrade(
+        ticker: (j['ticker'] ?? j['symbol'] ?? '').toString(),
+        action: j['action']?.toString(),
+        timestamp: DateTime.tryParse(j['timestamp']?.toString() ?? ''),
+        price: _num(j['price']),
+        shares: _num(j['shares']),
+        total: _num(j['total']),
+        cashAfter: _num(j['cash_after']),
+      );
+}
+
+class BacktestDecision {
+  const BacktestDecision({
+    this.symbol,
+    this.timestamp,
+    this.decision,
+    this.action,
+    this.normalizedScore,
+    this.finalReason,
+    this.overrideApplied,
+    this.preOverrideAction,
+    this.preOverrideDecision,
+    this.primaryStrategy,
+    this.primaryActionIntent,
+    this.strategies = const [],
+    this.postDecision = const [],
+    this.rawJson = const {},
+  });
+
+  final String? symbol;
+  final DateTime? timestamp;
+  final dynamic decision; // int or null
+  final String? action;
+  final num? normalizedScore;
+  final String? finalReason;
+  final bool? overrideApplied;
+  final String? preOverrideAction;
+  final dynamic preOverrideDecision;
+  final String? primaryStrategy;
+  final String? primaryActionIntent;
+  final List<DecisionStrategy> strategies;
+  final List<PostDecision> postDecision;
+  final Map<String, dynamic> rawJson;
+
+  factory BacktestDecision.fromJson(Map<String, dynamic> j) => BacktestDecision(
+        symbol: j['symbol']?.toString(),
+        timestamp: DateTime.tryParse(j['timestamp']?.toString() ?? ''),
+        decision: j['decision'],
+        action: j['action']?.toString(),
+        normalizedScore: _num(j['normalized_score']),
+        finalReason: j['final_reason']?.toString(),
+        overrideApplied: j['override_applied'] as bool?,
+        preOverrideAction: j['pre_override_action']?.toString(),
+        preOverrideDecision: j['pre_override_decision'],
+        primaryStrategy: j['primary_strategy']?.toString(),
+        primaryActionIntent: j['primary_action_intent']?.toString(),
+        strategies: (j['strategies'] as List? ?? [])
+            .whereType<Map>()
+            .map((s) =>
+                DecisionStrategy.fromJson(Map<String, dynamic>.from(s)))
+            .toList(),
+        postDecision: (j['post_decision'] as List? ?? [])
+            .whereType<Map>()
+            .map((p) =>
+                PostDecision.fromJson(Map<String, dynamic>.from(p)))
+            .toList(),
+        rawJson: j,
+      );
+
+  String decisionLabel() {
+    if (action != null && action!.isNotEmpty) return action!.toUpperCase();
+    switch (decision?.toString()) {
+      case '1':
+        return 'BUY';
+      case '-1':
+        return 'SELL';
+      default:
+        return 'HOLD';
+    }
+  }
+}
+
+class DecisionStrategy {
+  const DecisionStrategy({
+    this.strategy,
+    this.decision,
+    this.weight,
+    this.actionIntent,
+    this.reason,
+  });
+
+  final String? strategy;
+  final dynamic decision;
+  final num? weight;
+  final String? actionIntent;
+  final String? reason;
+
+  factory DecisionStrategy.fromJson(Map<String, dynamic> j) => DecisionStrategy(
+        strategy: j['strategy']?.toString(),
+        decision: j['decision'],
+        weight: _num(j['weight']),
+        actionIntent: j['action_intent']?.toString(),
+        reason: j['reason']?.toString(),
+      );
+
+  String decisionLabel() {
+    switch (decision?.toString()) {
+      case '1':
+        return 'BUY';
+      case '-1':
+        return 'SELL';
+      default:
+        return 'HOLD';
+    }
+  }
+}
+
+class PostDecision {
+  const PostDecision({this.strategy, this.decision, this.reason});
+
+  final String? strategy;
+  final dynamic decision;
+  final String? reason;
+
+  factory PostDecision.fromJson(Map<String, dynamic> j) => PostDecision(
+        strategy: j['strategy']?.toString(),
+        decision: j['decision'],
+        reason: j['reason']?.toString(),
+      );
+}
+
+class BacktestPrice {
+  const BacktestPrice({
+    required this.symbol,
+    required this.timestamp,
+    required this.close,
+  });
+
+  final String symbol;
+  final DateTime timestamp;
+  final double close;
+
+  factory BacktestPrice.fromJson(Map<String, dynamic> j) => BacktestPrice(
+        symbol: (j['symbol'] ?? '').toString(),
+        timestamp: DateTime.tryParse(j['timestamp']?.toString() ?? '') ??
+            DateTime.now(),
+        close: (j['close'] as num?)?.toDouble() ?? 0,
+      );
+}
+
+class BacktestGraphData {
+  const BacktestGraphData({
+    this.portfolioValueHistory = const [],
+    this.backtestPrices = const [],
+    this.backtestTrades = const [],
+    this.backtestDecisions = const [],
+  });
+
+  final List<PortfolioValuePoint> portfolioValueHistory;
+  final List<BacktestPrice> backtestPrices;
+  final List<BacktestTrade> backtestTrades;
+  final List<BacktestDecision> backtestDecisions;
+
+  factory BacktestGraphData.fromJson(Map<String, dynamic> j) =>
+      BacktestGraphData(
+        portfolioValueHistory: _mapList(
+            j['portfolio_value_history'], PortfolioValuePoint.fromJson),
+        backtestPrices:
+            _mapList(j['backtest_prices'], BacktestPrice.fromJson),
+        backtestTrades:
+            _mapList(j['backtest_trades'], BacktestTrade.fromJson),
+        backtestDecisions:
+            _mapList(j['backtest_decisions'], BacktestDecision.fromJson),
+      );
+}
+
+// ── Playback ──────────────────────────────────────────────────────────────────
+
+class PlaybackMetadata {
+  const PlaybackMetadata({this.initialCash, this.extra = const {}});
+
+  final num? initialCash;
+  final Map<String, dynamic> extra;
+
+  factory PlaybackMetadata.fromJson(Map<String, dynamic> j) => PlaybackMetadata(
+        initialCash: _num(j['initial_cash']),
+        extra: j,
+      );
+}
+
+class PlaybackEvent {
+  const PlaybackEvent({
+    required this.id,
+    required this.type,
+    this.label,
+    this.time,
+    this.name,
+    this.desc,
+    this.reason,
+    this.decision,
+    this.tickers = const [],
+    this.details,
+    this.buys = const [],
+    this.sells = const [],
+    this.portfolioValue,
+    this.holdings = const [],
+    this.date,
+    this.raw = const {},
+  });
+
+  final String id;
+  final String type; // 'date' | 'strategy' | 'outcome' | 'decision' | 'portfolio'
+  final String? label;
+  final String? time;
+  final String? name;
+  final String? desc;
+  final String? reason;
+  final String? decision;
+  final List<String> tickers;
+  final String? details;
+  final List<PlaybackTrade> buys;
+  final List<PlaybackTrade> sells;
+  final num? portfolioValue;
+  final List<PlaybackHolding> holdings;
+  final String? date;
+  final Map<String, dynamic> raw;
+
+  factory PlaybackEvent.fromJson(Map<String, dynamic> j, int index) =>
+      PlaybackEvent(
+        id: '${j['type']}_$index',
+        type: j['type']?.toString() ?? 'unknown',
+        label: j['label']?.toString(),
+        time: j['time']?.toString(),
+        name: j['name']?.toString(),
+        desc: j['desc']?.toString(),
+        reason: j['reason']?.toString(),
+        decision: j['decision']?.toString(),
+        tickers: _strList(j['tickers']),
+        details: j['details']?.toString(),
+        buys: _tradeList(j['buys']),
+        sells: _tradeList(j['sells']),
+        portfolioValue: _num(j['value']),
+        holdings: (j['holdings'] as List? ?? [])
+            .whereType<Map>()
+            .map((h) => PlaybackHolding.fromJson(Map<String, dynamic>.from(h)))
+            .toList(),
+        date: j['date']?.toString(),
+        raw: j,
+      );
+
+  static List<PlaybackTrade> _tradeList(dynamic v) {
+    if (v is! List) return const [];
+    return v
+        .whereType<Map>()
+        .map((m) => PlaybackTrade.fromJson(Map<String, dynamic>.from(m)))
+        .toList();
+  }
+}
+
+class PlaybackTrade {
+  const PlaybackTrade({this.ticker, this.qty, this.price, this.reason});
+
+  final String? ticker;
+  final num? qty;
+  final num? price;
+  final String? reason;
+
+  factory PlaybackTrade.fromJson(Map<String, dynamic> j) => PlaybackTrade(
+        ticker: j['ticker']?.toString(),
+        qty: _num(j['qty']),
+        price: _num(j['price']),
+        reason: j['reason']?.toString(),
+      );
+}
+
+class PlaybackHolding {
+  const PlaybackHolding(
+      {required this.ticker, this.qty, this.avg, this.curr});
+
+  final String ticker;
+  final num? qty;
+  final num? avg;
+  final num? curr;
+
+  factory PlaybackHolding.fromJson(Map<String, dynamic> j) => PlaybackHolding(
+        ticker: (j['ticker'] ?? j['symbol'] ?? '').toString(),
+        qty: _num(j['qty']),
+        avg: _num(j['avg']),
+        curr: _num(j['curr']),
+      );
+}
+
+class PlaybackData {
+  const PlaybackData({
+    required this.events,
+    required this.metadata,
+  });
+
+  final List<PlaybackEvent> events;
+  final PlaybackMetadata metadata;
+
+  factory PlaybackData.fromJson(Map<String, dynamic> j) => PlaybackData(
+        events: (j['events'] as List? ?? [])
+            .whereType<Map>()
+            .toList()
+            .asMap()
+            .entries
+            .map((e) => PlaybackEvent.fromJson(
+                Map<String, dynamic>.from(e.value), e.key))
+            .toList(),
+        metadata: j['metadata'] is Map
+            ? PlaybackMetadata.fromJson(
+                Map<String, dynamic>.from(j['metadata'] as Map))
+            : const PlaybackMetadata(),
+      );
+}
+
+class BacktestListResponse {
+  const BacktestListResponse({
+    required this.backtests,
+    required this.total,
+    required this.totalPages,
+    required this.page,
+  });
+
+  final List<BacktestRow> backtests;
+  final int total;
+  final int totalPages;
+  final int page;
+
+  factory BacktestListResponse.fromJson(Map<String, dynamic> j) =>
+      BacktestListResponse(
+        backtests: (j['backtests'] as List? ?? [])
+            .whereType<Map>()
+            .map((b) =>
+                BacktestRow.fromJson(Map<String, dynamic>.from(b)))
+            .toList(),
+        total: (j['total'] as num?)?.toInt() ?? 0,
+        totalPages: (j['total_pages'] as num?)?.toInt() ?? 1,
+        page: (j['page'] as num?)?.toInt() ?? 1,
+      );
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+num? _num(dynamic v) {
+  if (v == null) return null;
+  if (v is num) return v;
+  return num.tryParse(v.toString());
+}
+
+List<String> _strList(dynamic v) {
+  if (v is! List) return const [];
+  return v.map((e) => e.toString()).toList();
+}
+
+Map<String, num>? _numMap(dynamic v) {
+  if (v is! Map) return null;
+  final result = <String, num>{};
+  v.forEach((k, val) {
+    final n = _num(val);
+    if (n != null) result[k.toString()] = n;
+  });
+  return result.isEmpty ? null : result;
+}
+
+List<T> _mapList<T>(dynamic v, T Function(Map<String, dynamic>) fromJson) {
+  if (v is! List) return const [];
+  return v
+      .whereType<Map>()
+      .map((m) => fromJson(Map<String, dynamic>.from(m)))
+      .toList();
+}

--- a/mobile/lib/features/backtests/presentation/backtest_detail_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtest_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/charts/scrubbable_area_chart.dart';
 import '../../../core/formatters/formatters.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
@@ -894,30 +895,43 @@ class _LlmCostCard extends StatelessWidget {
               ),
             )
           else ...[
-            // Headline totals
+            // Headline totals — 2x2 grid so labels/values aren't cramped.
             Padding(
               padding: const EdgeInsets.all(16),
-              child: Row(
+              child: Column(
                 children: [
-                  Expanded(
-                      child: _CostTile(
-                          label: 'Total cost',
-                          value: fmtUsdCost(llmCost!.totalCostUsd))),
-                  Expanded(
-                      child: _CostTile(
-                          label: 'Calls',
-                          value: '${llmCost!.totalCalls ?? 0}',
-                          sub:
-                              '${llmCost!.okCalls ?? 0} ok · ${llmCost!.failedCalls ?? 0} failed')),
-                  Expanded(
-                      child: _CostTile(
-                          label: 'Input tokens',
-                          value: fmtTokens(llmCost!.totalInputTokens))),
-                  Expanded(
-                      child: _CostTile(
-                          label: 'Output tokens',
-                          value: fmtTokens(
-                              llmCost!.totalOutputTokens))),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                          child: _CostTile(
+                              label: 'Total cost',
+                              value: fmtUsdCost(llmCost!.totalCostUsd))),
+                      const SizedBox(width: 12),
+                      Expanded(
+                          child: _CostTile(
+                              label: 'Calls',
+                              value: '${llmCost!.totalCalls ?? 0}',
+                              sub:
+                                  '${llmCost!.okCalls ?? 0} ok · ${llmCost!.failedCalls ?? 0} failed')),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                          child: _CostTile(
+                              label: 'Input tokens',
+                              value: fmtTokens(llmCost!.totalInputTokens))),
+                      const SizedBox(width: 12),
+                      Expanded(
+                          child: _CostTile(
+                              label: 'Output tokens',
+                              value:
+                                  fmtTokens(llmCost!.totalOutputTokens))),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -1402,109 +1416,87 @@ class _PortfolioChart extends StatefulWidget {
 }
 
 class _PortfolioChartState extends State<_PortfolioChart> {
-  double? _hoveredValue;
-  DateTime? _hoveredDate;
+  // Scrub index drives only the header value (via this notifier), so scrubbing
+  // never rebuilds the chart.
+  final ValueNotifier<int?> _scrubIdx = ValueNotifier(null);
+
+  @override
+  void dispose() {
+    _scrubIdx.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final displayValue =
-        _hoveredValue ?? widget.history.last.value.toDouble();
-    final startVal = widget.startValue?.toDouble() ?? 0;
-    final pnl = displayValue - startVal;
+    final history = widget.history;
+    final timestamps = [for (final p in history) p.timestamp];
+    final values = [for (final p in history) p.value.toDouble()];
+    final startVal = widget.startValue?.toDouble() ??
+        (values.isNotEmpty ? values.first : 0.0);
+    final isUp = values.isNotEmpty && values.last >= startVal;
+    final lineColor = isUp ? AppColors.success : AppColors.danger;
 
     return GlassCard(
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 0),
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Portfolio Value Over Time',
-              style: AppTextStyles.eyebrow),
+          Text('Portfolio Value Over Time', style: AppTextStyles.eyebrow),
           const SizedBox(height: 4),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              Text(
-                fmtMoney(displayValue),
-                style: AppTextStyles.valueXl
-                    .copyWith(color: AppColors.textHi),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                fmtPnl(pnl),
-                style: AppTextStyles.value
-                    .copyWith(color: pnlColor(pnl)),
-              ),
-              const SizedBox(width: 4),
-              Text('vs start',
-                  style: AppTextStyles.meta
-                      .copyWith(color: AppColors.textDim)),
-            ],
-          ),
-          if (_hoveredDate != null)
-            Text(
-              fmtDateTime(_hoveredDate),
-              style: AppTextStyles.meta
-                  .copyWith(color: AppColors.textDim),
-            ),
-          const SizedBox(height: 12),
-          SfCartesianChart(
-            plotAreaBorderWidth: 0,
-            backgroundColor: Colors.transparent,
-            primaryXAxis: DateTimeAxis(
-              majorGridLines: const MajorGridLines(
-                  color: AppColors.chartGrid, width: 1),
-              axisLine: const AxisLine(width: 0),
-              labelStyle: const TextStyle(
-                  color: AppColors.chartAxis, fontSize: 10),
-            ),
-            primaryYAxis: NumericAxis(
-              isVisible: false,
-              majorGridLines: const MajorGridLines(width: 0),
-              axisLine: const AxisLine(width: 0),
-            ),
-            tooltipBehavior: TooltipBehavior(enable: false),
-            trackballBehavior: TrackballBehavior(
-              enable: true,
-              activationMode: ActivationMode.singleTap,
-              tooltipSettings: const InteractiveTooltip(enable: false),
-            ),
-            onTrackballPositionChanging: (args) {
-              final pt = args.chartPointInfo;
-              if (pt.chartPoint != null) {
-                setState(() {
-                  _hoveredValue =
-                      (pt.chartPoint!.y)?.toDouble();
-                  _hoveredDate = pt.chartPoint!.x as DateTime?;
-                });
-              }
-            },
-            annotations: widget.startValue != null
-                ? <CartesianChartAnnotation>[
-                    CartesianChartAnnotation(
-                      widget: Container(
-                        width: double.infinity,
-                        height: 1,
-                        color:
-                            AppColors.textFaint.withValues(alpha: 0.5),
+          ValueListenableBuilder<int?>(
+            valueListenable: _scrubIdx,
+            builder: (_, idx, _) {
+              final i = (idx != null && idx >= 0 && idx < values.length)
+                  ? idx
+                  : null;
+              final displayValue = i != null
+                  ? values[i]
+                  : (values.isNotEmpty ? values.last : 0.0);
+              final pnl = displayValue - startVal;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
+                    children: [
+                      Text(
+                        fmtMoney(displayValue),
+                        style: AppTextStyles.valueXl
+                            .copyWith(color: AppColors.textHi),
                       ),
-                      coordinateUnit: CoordinateUnit.point,
-                      x: widget.history.first.timestamp,
-                      y: widget.startValue!.toDouble(),
-                    ),
-                  ]
-                : null,
-            series: <CartesianSeries>[
-              SplineAreaSeries<PortfolioValuePoint, DateTime>(
-                dataSource: widget.history,
-                splineType: SplineType.monotonic,
-                xValueMapper: (d, _) => d.timestamp,
-                yValueMapper: (d, _) => d.value,
-                color: AppColors.chartLine.withValues(alpha: 0.3),
-                borderColor: AppColors.chartLine,
-                borderWidth: 2.5,
-              ),
-            ],
+                      const SizedBox(width: 8),
+                      Text(
+                        fmtPnl(pnl),
+                        style: AppTextStyles.value
+                            .copyWith(color: pnlColor(pnl)),
+                      ),
+                      const SizedBox(width: 4),
+                      Text('vs start',
+                          style: AppTextStyles.meta
+                              .copyWith(color: AppColors.textDim)),
+                    ],
+                  ),
+                  SizedBox(
+                    height: 16,
+                    child: i != null
+                        ? Text(fmtDateTime(timestamps[i]),
+                            style: AppTextStyles.meta
+                                .copyWith(color: AppColors.textDim))
+                        : null,
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 8),
+          ScrubbableAreaChart(
+            timestamps: timestamps,
+            values: values,
+            lineColor: lineColor,
+            height: 240,
+            baseline: widget.startValue?.toDouble(),
+            onScrub: (i) => _scrubIdx.value = i,
           ),
         ],
       ),
@@ -1713,60 +1705,36 @@ class _StockChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    if (prices.isEmpty) return const SizedBox(height: 220);
+    final timestamps = [for (final p in prices) p.timestamp];
+    final values = [for (final p in prices) p.value.toDouble()];
+
+    return ScrubbableAreaChart(
+      timestamps: timestamps,
+      values: values,
+      // Distinct line colour so it doesn't read as a buy/sell marker.
+      lineColor: AppColors.chartLineAlt,
       height: 220,
-      child: SfCartesianChart(
-        plotAreaBorderWidth: 0,
-        backgroundColor: Colors.transparent,
-        primaryXAxis: DateTimeAxis(
-          majorGridLines: const MajorGridLines(
-              color: AppColors.chartGrid, width: 1),
-          axisLine: const AxisLine(width: 0),
-          labelStyle: const TextStyle(
-              color: AppColors.chartAxis, fontSize: 10),
+      markerSeries: () => <CartesianSeries>[
+        ScatterSeries<BacktestTrade, DateTime>(
+          name: 'Buy',
+          dataSource: buys,
+          xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
+          yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
+          color: AppColors.success,
+          markerSettings:
+              const MarkerSettings(isVisible: true, height: 8, width: 8),
         ),
-        primaryYAxis: NumericAxis(
-          isVisible: false,
-          majorGridLines: const MajorGridLines(width: 0),
-          axisLine: const AxisLine(width: 0),
+        ScatterSeries<BacktestTrade, DateTime>(
+          name: 'Sell',
+          dataSource: sells,
+          xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
+          yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
+          color: AppColors.danger,
+          markerSettings:
+              const MarkerSettings(isVisible: true, height: 8, width: 8),
         ),
-        tooltipBehavior: TooltipBehavior(
-          enable: true,
-          color: AppColors.panel,
-          textStyle:
-              const TextStyle(color: AppColors.textMd, fontSize: 10),
-        ),
-        series: <CartesianSeries>[
-          SplineAreaSeries<PortfolioValuePoint, DateTime>(
-            name: sym,
-            dataSource: prices,
-            splineType: SplineType.monotonic,
-            xValueMapper: (d, _) => d.timestamp,
-            yValueMapper: (d, _) => d.value,
-            color: AppColors.chartLineAlt.withValues(alpha: 0.18),
-            borderColor: AppColors.chartLineAlt,
-            borderWidth: 2,
-          ),
-          ScatterSeries<BacktestTrade, DateTime>(
-            name: 'Buy',
-            dataSource: buys,
-            xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
-            yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
-            color: AppColors.success,
-            markerSettings:
-                const MarkerSettings(isVisible: true, height: 8, width: 8),
-          ),
-          ScatterSeries<BacktestTrade, DateTime>(
-            name: 'Sell',
-            dataSource: sells,
-            xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
-            yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
-            color: AppColors.danger,
-            markerSettings:
-                const MarkerSettings(isVisible: true, height: 8, width: 8),
-          ),
-        ],
-      ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/backtests/presentation/backtest_detail_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtest_detail_screen.dart
@@ -1,0 +1,2275 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/formatters/formatters.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/app_background.dart';
+import '../../../core/widgets/common_widgets.dart';
+import '../../../core/widgets/confirm_dialog.dart';
+import '../../../core/widgets/glass_card.dart';
+import '../../../core/widgets/material_symbols.dart';
+import '../../../core/widgets/skeleton.dart';
+import '../../../core/widgets/status_pill.dart';
+import '../application/backtest_detail_controller.dart';
+import '../data/models/backtest.dart';
+import 'backtest_llm_pause_banner.dart';
+
+class BacktestDetailScreen extends ConsumerStatefulWidget {
+  const BacktestDetailScreen({super.key, required this.id});
+
+  final String id;
+
+  @override
+  ConsumerState<BacktestDetailScreen> createState() =>
+      _BacktestDetailScreenState();
+}
+
+class _BacktestDetailScreenState
+    extends ConsumerState<BacktestDetailScreen> {
+  final Set<String> _expandedStocks = {};
+  final Map<String, int> _decisionLimits = {};
+  bool _logsOpen = false;
+  bool _strategyOpen = false;
+
+  static const int _decisionPage = 5;
+
+  @override
+  Widget build(BuildContext context) {
+    final state =
+        ref.watch(backtestDetailControllerProvider(widget.id));
+    final ctrl = ref.read(
+        backtestDetailControllerProvider(widget.id).notifier);
+
+    return Scaffold(
+      backgroundColor: AppColors.canvas,
+      body: AppBackground(
+        child: SafeArea(
+          child: CustomScrollView(
+            slivers: [
+              // ── Breadcrumb + back ───────────────────────────────────────────
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                  child: GestureDetector(
+                    onTap: () => context.canPop()
+                        ? context.pop()
+                        : context.go('/backtests'),
+                    child: Row(
+                      children: [
+                        Icon(symbol('arrow_back'),
+                            color: AppColors.textDim, size: 16),
+                        const SizedBox(width: 4),
+                        Text('Back',
+                            style: AppTextStyles.meta.copyWith(
+                                color: AppColors.textDim)),
+                        const SizedBox(width: 6),
+                        Text('/',
+                            style: AppTextStyles.meta.copyWith(
+                                color: AppColors.textFaint)),
+                        const SizedBox(width: 6),
+                        Text('Backtest #${widget.id}',
+                            style: AppTextStyles.meta.copyWith(
+                                color: AppColors.textMuted)),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+
+              // ── Loading ─────────────────────────────────────────────────────
+              if (state.loading)
+                const SliverToBoxAdapter(
+                  child: _BacktestDetailSkeleton(),
+                ),
+
+              // ── Error ───────────────────────────────────────────────────────
+              if (!state.loading && state.error != null)
+                SliverFillRemaining(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: ErrorBanner(
+                      message: state.error!,
+                      onRetry: () => ref.invalidate(
+                          backtestDetailControllerProvider(widget.id)),
+                    ),
+                  ),
+                ),
+
+              if (!state.loading && state.summary != null) ...[
+                // ── Header ────────────────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            IconTile(
+                                icon: symbol('analytics'),
+                                color: AppColors.info,
+                                size: 44),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment:
+                                    CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Text(
+                                        'Backtest #${widget.id}',
+                                        style: AppTextStyles.h2,
+                                      ),
+                                      const SizedBox(width: 8),
+                                      StatusPill(
+                                        label: state.currentStatus
+                                            .toUpperCase(),
+                                        color: StatusPill.colorForStatus(
+                                            state.currentStatus),
+                                        pulsing: state.isActive,
+                                      ),
+                                    ],
+                                  ),
+                                  Text(
+                                    '${state.summary!.startDate ?? '?'} → ${state.summary!.endDate ?? '?'}',
+                                    style: AppTextStyles.meta.copyWith(
+                                        color: AppColors.textDim),
+                                  ),
+                                  if (state.summary!.tickers.isNotEmpty)
+                                    Text(
+                                      state.summary!.tickers.join(', '),
+                                      style: AppTextStyles.mono(11,
+                                          color: AppColors.textDim),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        // Progress bar (running)
+                        if (state.progress != null && state.isActive)
+                          Column(
+                            children: [
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text('Progress',
+                                      style: AppTextStyles.meta.copyWith(
+                                          color: AppColors.textDim)),
+                                  Text(
+                                    '${state.progress!.round()}%',
+                                    style: AppTextStyles.mono(11,
+                                        color: AppColors.textDim),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 4),
+                              ClipRRect(
+                                borderRadius:
+                                    BorderRadius.circular(4),
+                                child: LinearProgressIndicator(
+                                  value: (state.progress!.toDouble() /
+                                          100)
+                                      .clamp(0, 1),
+                                  backgroundColor: AppColors.surface,
+                                  valueColor:
+                                      const AlwaysStoppedAnimation(
+                                          AppColors.info),
+                                  minHeight: 8,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
+                            ],
+                          ),
+                        // Action cluster
+                        _ActionCluster(
+                          id: widget.id,
+                          status: state.currentStatus,
+                          onAction: (action) =>
+                              _doAction(context, ctrl, action),
+                          onPlayback: () => context.push(
+                              '/backtests/${widget.id}/playback'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // ── LLM pause banner ─────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                    child: BacktestLlmPauseBanner(
+                        summary: state.summary!),
+                  ),
+                ),
+
+                // ── Nexus lookback banner ─────────────────────────────────────
+                if (state.nexusLookback != null)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                      child: _NexusLookbackBanner(
+                          lookback: state.nexusLookback!),
+                    ),
+                  ),
+
+                // ── Stat tiles (2-col) ────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: _StatGrid(
+                        summary: state.summary!,
+                        elapsed: state.elapsedSeconds),
+                  ),
+                ),
+
+                // ── AI Credits card ───────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: _LlmCostCard(
+                      llmCost: state.llmCost,
+                      loading: state.llmCostLoading,
+                      error: state.llmCostError,
+                      onRefresh: ctrl.refreshLlmCost,
+                    ),
+                  ),
+                ),
+
+                // ── Strategy collapsible ──────────────────────────────────────
+                if (state.summary!.strategySchema != null)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                      child: _StrategySection(
+                        schema: state.summary!.strategySchema!,
+                        strategyId: state.summary!.strategyId,
+                        open: _strategyOpen,
+                        onToggle: () => setState(
+                            () => _strategyOpen = !_strategyOpen),
+                      ),
+                    ),
+                  ),
+
+                // ── Logs panel ────────────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: _LogsPanel(
+                      open: _logsOpen,
+                      lines: state.logLines,
+                      loading: state.logsLoading,
+                      error: state.logsError,
+                      source: state.logSource,
+                      onToggle: () {
+                        setState(() => _logsOpen = !_logsOpen);
+                        if (!_logsOpen || state.logLines.isNotEmpty) {
+                          return;
+                        }
+                        ctrl.loadLogs();
+                      },
+                    ),
+                  ),
+                ),
+
+                // ── Portfolio chart ───────────────────────────────────────────
+                if (state.graphData != null &&
+                    state.graphData!.portfolioValueHistory.isNotEmpty)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                      child: _PortfolioChart(
+                        history:
+                            state.graphData!.portfolioValueHistory,
+                        startValue: state.summary!.portfolioStartValue,
+                      ),
+                    ),
+                  ),
+
+                // ── P&L per stock cards ───────────────────────────────────────
+                if (state.summary!.pnlPerStock != null &&
+                    state.summary!.pnlPerStock!.isNotEmpty)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                      child: _PnlPerStockCard(
+                          summary: state.summary!),
+                    ),
+                  ),
+
+                // ── Per-ticker accordions ─────────────────────────────────────
+                if (state.graphData != null &&
+                    state.summary!.tickers.isNotEmpty)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                      child: Column(
+                        crossAxisAlignment:
+                            CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment:
+                                MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                'Stock Charts & Trades',
+                                style: AppTextStyles.eyebrow,
+                              ),
+                              Row(
+                                children: [
+                                  TextButton(
+                                    onPressed: () => setState(() {
+                                      _expandedStocks.addAll(
+                                          state.summary!.tickers);
+                                    }),
+                                    child: Text('Expand All',
+                                        style: AppTextStyles.meta
+                                            .copyWith(
+                                                color: AppColors
+                                                    .textMuted)),
+                                  ),
+                                  if (_expandedStocks.isNotEmpty)
+                                    TextButton(
+                                      onPressed: () => setState(() {
+                                        _expandedStocks.clear();
+                                        _decisionLimits.clear();
+                                      }),
+                                      child: Text('Collapse All',
+                                          style:
+                                              AppTextStyles.meta.copyWith(
+                                                  color: AppColors
+                                                      .textMuted)),
+                                    ),
+                                ],
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          ...state.summary!.tickers.map((sym) =>
+                              _StockAccordion(
+                                key: ValueKey(sym),
+                                sym: sym,
+                                summary: state.summary!,
+                                graphData: state.graphData!,
+                                expanded: _expandedStocks.contains(sym),
+                                decisionLimit:
+                                    _decisionLimits[sym] ??
+                                        _decisionPage,
+                                onToggle: () => setState(() {
+                                  if (_expandedStocks.contains(sym)) {
+                                    _expandedStocks.remove(sym);
+                                  } else {
+                                    _expandedStocks.add(sym);
+                                  }
+                                }),
+                                onShowMoreDecisions: () =>
+                                    setState(() {
+                                  _decisionLimits[sym] =
+                                      (_decisionLimits[sym] ??
+                                              _decisionPage) +
+                                          _decisionPage;
+                                }),
+                              )),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                // ── Round-trip stats ──────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                    child: _RoundTripStats(
+                        summary: state.summary!),
+                  ),
+                ),
+              ],
+
+              // ── Pending / no summary ──────────────────────────────────────
+              if (!state.loading && state.summary == null)
+                SliverFillRemaining(
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(symbol('hourglass_empty'),
+                            color: AppColors.textFaint, size: 48),
+                        const SizedBox(height: 12),
+                        Text(
+                          'This backtest has not completed yet.',
+                          style: AppTextStyles.body.copyWith(
+                              color: AppColors.textMuted),
+                        ),
+                        if (state.progress != null) ...[
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: 200,
+                            child: Column(
+                              children: [
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(state.currentStatus,
+                                        style: AppTextStyles.meta
+                                            .copyWith(
+                                                color: AppColors
+                                                    .textDim)),
+                                    Text(
+                                        '${state.progress!.round()}%',
+                                        style: AppTextStyles.meta
+                                            .copyWith(
+                                                color: AppColors
+                                                    .textDim)),
+                                  ],
+                                ),
+                                const SizedBox(height: 4),
+                                ClipRRect(
+                                  borderRadius:
+                                      BorderRadius.circular(4),
+                                  child: LinearProgressIndicator(
+                                    value: (state.progress!
+                                                .toDouble() /
+                                            100)
+                                        .clamp(0, 1),
+                                    backgroundColor: AppColors.surface,
+                                    valueColor:
+                                        const AlwaysStoppedAnimation(
+                                            AppColors.info),
+                                    minHeight: 8,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _doAction(
+    BuildContext context,
+    BacktestDetailController ctrl,
+    String action,
+  ) async {
+    if (action == 'rerun') {
+      await _doRerun(context, ctrl);
+      return;
+    }
+    final meta = _actionMeta(action);
+    await showConfirmDialog(
+      context,
+      title: meta.$1,
+      body: '${meta.$2}\n\nBacktest #${widget.id}',
+      confirmLabel: meta.$1.split(' ').last,
+      confirmColor: meta.$3,
+      icon: symbol(meta.$4),
+      onConfirm: () async {
+        final err = await ctrl.performAction(action);
+        if (err != null) throw Exception(err);
+        if (action == 'delete' && context.mounted) {
+          context.canPop()
+              ? context.pop()
+              : context.go('/backtests');
+        }
+      },
+    );
+  }
+
+  Future<void> _doRerun(
+      BuildContext context, BacktestDetailController ctrl) async {
+    await showConfirmDialog(
+      context,
+      title: 'Rerun Backtest',
+      body:
+          'A new backtest will be created with the same settings.\n\nBacktest #${widget.id}',
+      confirmLabel: 'Rerun',
+      confirmColor: AppColors.success,
+      icon: symbol('replay'),
+      onConfirm: () async {
+        final data = await ctrl.rerun();
+        final newId =
+            (data['id'] ?? data['backtest_id'])?.toString();
+        if (newId != null && context.mounted) {
+          context.go('/backtests/$newId');
+        }
+      },
+    );
+  }
+
+  static (String, String, Color, String) _actionMeta(String action) {
+    switch (action) {
+      case 'pause':
+        return (
+          'Pause Backtest',
+          'The backtest will be paused and can be resumed later.',
+          AppColors.primary,
+          'pause_circle'
+        );
+      case 'resume':
+        return (
+          'Resume Backtest',
+          'The backtest will continue from where it was paused.',
+          AppColors.info,
+          'play_circle'
+        );
+      case 'stop':
+        return (
+          'Stop Backtest',
+          'This will permanently stop the backtest.',
+          AppColors.danger,
+          'stop_circle'
+        );
+      case 'delete':
+      default:
+        return (
+          'Delete Backtest',
+          'This will permanently delete all results and data.',
+          AppColors.danger,
+          'delete_forever'
+        );
+    }
+  }
+}
+
+// ── Action cluster ────────────────────────────────────────────────────────────
+
+class _ActionCluster extends StatelessWidget {
+  const _ActionCluster({
+    required this.id,
+    required this.status,
+    required this.onAction,
+    required this.onPlayback,
+  });
+
+  final String id;
+  final String status;
+  final void Function(String) onAction;
+  final VoidCallback onPlayback;
+
+  bool get _isRunning => status.toLowerCase() == 'running';
+  bool get _isPaused =>
+      status.toLowerCase() == 'paused' ||
+      status.toLowerCase() == 'paused_llm_critical';
+  bool get _canStop =>
+      _isRunning ||
+      _isPaused ||
+      status.toLowerCase() == 'queued';
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        if (_isRunning)
+          _ChipBtn(
+              label: 'Pause',
+              icon: symbol('pause_circle'),
+              color: AppColors.primary,
+              onTap: () => onAction('pause')),
+        if (_isPaused)
+          _ChipBtn(
+              label: 'Resume',
+              icon: symbol('play_circle'),
+              color: AppColors.info,
+              onTap: () => onAction('resume')),
+        if (_canStop)
+          _ChipBtn(
+              label: 'Stop',
+              icon: symbol('stop_circle'),
+              color: AppColors.danger,
+              onTap: () => onAction('stop')),
+        _ChipBtn(
+            label: 'Rerun',
+            icon: symbol('replay'),
+            color: AppColors.success,
+            onTap: () => onAction('rerun')),
+        _ChipBtn(
+            label: 'Playback',
+            icon: symbol('movie'),
+            color: AppColors.warning,
+            onTap: onPlayback),
+        _ChipBtn(
+            label: 'Delete',
+            icon: symbol('delete_forever'),
+            color: AppColors.danger,
+            onTap: () => onAction('delete')),
+      ],
+    );
+  }
+}
+
+class _ChipBtn extends StatelessWidget {
+  const _ChipBtn({
+    required this.label,
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: AppColors.fill(color),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.stroke(color)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: color, size: 14),
+              const SizedBox(width: 4),
+              Text(label,
+                  style: AppTextStyles.micro
+                      .copyWith(color: color, fontWeight: FontWeight.w600)),
+            ],
+          ),
+        ),
+      );
+}
+
+// ── Nexus lookback banner ─────────────────────────────────────────────────────
+
+class _NexusLookbackBanner extends StatelessWidget {
+  const _NexusLookbackBanner({required this.lookback});
+
+  final NexusLookback lookback;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppColors.fill(AppColors.primary),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: AppColors.stroke(AppColors.primary)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(symbol('hub'), color: AppColors.primary, size: 18),
+                const SizedBox(width: 8),
+                Text('Nexus Lookback Training',
+                    style: AppTextStyles.bodyHi
+                        .copyWith(color: AppColors.primary)),
+                const Spacer(),
+                Text(
+                  'Day ${lookback.current} / ${lookback.total}',
+                  style: AppTextStyles.mono(11,
+                      color: AppColors.textDim),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: lookback.fraction.clamp(0, 1),
+                backgroundColor: AppColors.surface,
+                valueColor:
+                    AlwaysStoppedAnimation(AppColors.primary),
+                minHeight: 8,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(lookback.startDate ?? '',
+                    style: AppTextStyles.nano
+                        .copyWith(color: AppColors.textDim)),
+                Text(lookback.currentDate ?? '',
+                    style: AppTextStyles.nano
+                        .copyWith(color: AppColors.primary)),
+                Text(lookback.endDate ?? '',
+                    style: AppTextStyles.nano
+                        .copyWith(color: AppColors.textDim)),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Building historical event context before trading begins. '
+              'This runs once per scope.',
+              style: AppTextStyles.nano
+                  .copyWith(color: AppColors.textDim),
+            ),
+          ],
+        ),
+      );
+}
+
+// ── Stat grid ─────────────────────────────────────────────────────────────────
+
+class _StatGrid extends StatelessWidget {
+  const _StatGrid({required this.summary, this.elapsed});
+
+  final BacktestSummary summary;
+  final num? elapsed;
+
+  @override
+  Widget build(BuildContext context) {
+    final tiles = [
+      (
+        'Total P&L',
+        fmtPnl(summary.pnl),
+        pnlColor(summary.pnl),
+        null
+      ),
+      (
+        'P&L %',
+        fmtPct(summary.pnlPercent),
+        pnlColor(summary.pnlPercent),
+        null
+      ),
+      (
+        'Portfolio',
+        fmtMoney(summary.portfolioEndValue),
+        pnlColor((summary.portfolioEndValue?.toDouble() ?? 0) -
+            (summary.portfolioStartValue?.toDouble() ?? 0)),
+        'From ${fmtMoney(summary.portfolioStartValue)}'
+      ),
+      (
+        'Trades',
+        '${summary.totalTrades ?? '—'}',
+        AppColors.textHi,
+        '${summary.totalBuys ?? 0} buy / ${summary.totalSells ?? 0} sell'
+      ),
+      (
+        'Elapsed',
+        fmtElapsed(elapsed),
+        AppColors.textHi,
+        null
+      ),
+      (
+        'Win Rate',
+        summary.winRatePercent != null
+            ? '${summary.winRatePercent!.toStringAsFixed(1)}%'
+            : '—',
+        (summary.winRatePercent ?? 0) >= 50
+            ? AppColors.success
+            : AppColors.danger,
+        '${summary.winningRoundTrips ?? 0}W / ${summary.losingRoundTrips ?? 0}L'
+      ),
+      (
+        'Portfolio High',
+        fmtMoney(summary.portfolioValueHigh),
+        AppColors.success,
+        'Low: ${fmtMoney(summary.portfolioValueLow)}'
+      ),
+    ];
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 10,
+        mainAxisSpacing: 10,
+        childAspectRatio: 2.2,
+      ),
+      itemCount: tiles.length,
+      itemBuilder: (_, i) => StatTile(
+        label: tiles[i].$1,
+        value: tiles[i].$2,
+        valueColor: tiles[i].$3,
+        sub: tiles[i].$4,
+      ),
+    );
+  }
+}
+
+// ── LLM Cost card ─────────────────────────────────────────────────────────────
+
+class _LlmCostCard extends StatelessWidget {
+  const _LlmCostCard({
+    this.llmCost,
+    required this.loading,
+    this.error,
+    required this.onRefresh,
+  });
+
+  final LlmCost? llmCost;
+  final bool loading;
+  final String? error;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 12, 14),
+            child: Row(
+              children: [
+                IconTile(
+                    icon: symbol('payments'),
+                    color: AppColors.primary,
+                    size: 32),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('AI CREDITS',
+                          style: AppTextStyles.eyebrow),
+                      Text('LLM cost for this backtest',
+                          style: AppTextStyles.meta),
+                    ],
+                  ),
+                ),
+                loading
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2))
+                    : IconButton(
+                        icon: Icon(symbol('refresh'),
+                            size: 18, color: AppColors.textMuted),
+                        onPressed: onRefresh,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+              ],
+            ),
+          ),
+          const Divider(color: AppColors.border, height: 1),
+
+          if (error != null)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(error!,
+                  style: AppTextStyles.meta
+                      .copyWith(color: AppColors.danger)),
+            )
+          else if (llmCost == null && loading)
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: _LlmCostSkeleton(),
+            )
+          else if (llmCost == null || (llmCost!.totalCalls ?? 0) == 0)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'No LLM calls were attributed to this backtest.',
+                style: AppTextStyles.meta
+                    .copyWith(color: AppColors.textDim),
+              ),
+            )
+          else ...[
+            // Headline totals
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Expanded(
+                      child: _CostTile(
+                          label: 'Total cost',
+                          value: fmtUsdCost(llmCost!.totalCostUsd))),
+                  Expanded(
+                      child: _CostTile(
+                          label: 'Calls',
+                          value: '${llmCost!.totalCalls ?? 0}',
+                          sub:
+                              '${llmCost!.okCalls ?? 0} ok · ${llmCost!.failedCalls ?? 0} failed')),
+                  Expanded(
+                      child: _CostTile(
+                          label: 'Input tokens',
+                          value: fmtTokens(llmCost!.totalInputTokens))),
+                  Expanded(
+                      child: _CostTile(
+                          label: 'Output tokens',
+                          value: fmtTokens(
+                              llmCost!.totalOutputTokens))),
+                ],
+              ),
+            ),
+            const Divider(color: AppColors.border, height: 1),
+            // Breakdown rows
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (llmCost!.byModel.isNotEmpty) ...[
+                    Text('By model',
+                        style: AppTextStyles.eyebrow),
+                    const SizedBox(height: 6),
+                    ...llmCost!.byModel.take(6).map(
+                          (r) => _CostRow(
+                              rowKey: r.key, value: r.costUsd),
+                        ),
+                    const SizedBox(height: 12),
+                  ],
+                  if (llmCost!.byCallSite.isNotEmpty) ...[
+                    Text('By call site',
+                        style: AppTextStyles.eyebrow),
+                    const SizedBox(height: 6),
+                    ...llmCost!.byCallSite.take(6).map(
+                          (r) => _CostRow(
+                              rowKey: r.key, value: r.costUsd),
+                        ),
+                    const SizedBox(height: 12),
+                  ],
+                  if (llmCost!.byProvider.isNotEmpty) ...[
+                    Text('By provider',
+                        style: AppTextStyles.eyebrow),
+                    const SizedBox(height: 6),
+                    ...llmCost!.byProvider.take(6).map(
+                          (r) => _CostRow(
+                              rowKey: r.key, value: r.costUsd),
+                        ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _CostTile extends StatelessWidget {
+  const _CostTile({required this.label, required this.value, this.sub});
+
+  final String label;
+  final String value;
+  final String? sub;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: AppTextStyles.eyebrow),
+          const SizedBox(height: 2),
+          Text(value,
+              style: AppTextStyles.valueLg
+                  .copyWith(color: AppColors.textHi)),
+          if (sub != null)
+            Text(sub!,
+                style: AppTextStyles.nano
+                    .copyWith(color: AppColors.textDim)),
+        ],
+      );
+}
+
+class _CostRow extends StatelessWidget {
+  const _CostRow({required this.rowKey, this.value});
+
+  final String rowKey;
+  final num? value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: Row(
+          children: [
+            Expanded(
+                child: Text(rowKey,
+                    style: AppTextStyles.mono(11,
+                        color: AppColors.textMuted),
+                    overflow: TextOverflow.ellipsis)),
+            Text(fmtUsdCost(value),
+                style: AppTextStyles.mono(11,
+                    color: AppColors.textHi)),
+          ],
+        ),
+      );
+}
+
+// ── Strategy section ──────────────────────────────────────────────────────────
+
+class _StrategySection extends StatelessWidget {
+  const _StrategySection({
+    required this.schema,
+    this.strategyId,
+    required this.open,
+    required this.onToggle,
+  });
+
+  final StrategySchema schema;
+  final String? strategyId;
+  final bool open;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        children: [
+          InkWell(
+            onTap: onToggle,
+            borderRadius: BorderRadius.circular(16),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  IconTile(
+                      icon: symbol('schema'),
+                      color: AppColors.primary,
+                      size: 32),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('STRATEGY', style: AppTextStyles.eyebrow),
+                        Text(schema.name ?? '—',
+                            style: AppTextStyles.cardTitle),
+                      ],
+                    ),
+                  ),
+                  AnimatedRotation(
+                    turns: open ? 0.5 : 0,
+                    duration: const Duration(milliseconds: 200),
+                    child: Icon(symbol('expand_more'),
+                        color: AppColors.textDim),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (open) ...[
+            const Divider(color: AppColors.border, height: 1),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (strategyId != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Text('ID: $strategyId',
+                          style: AppTextStyles.nano
+                              .copyWith(color: AppColors.textFaint)),
+                    ),
+                  Text('Sub-strategies',
+                      style: AppTextStyles.eyebrow),
+                  const SizedBox(height: 8),
+                  ...schema.strategies.asMap().entries.map(
+                        (e) => _SubStrategyCard(
+                            index: e.key, sub: e.value),
+                      ),
+                  if (schema.strategies.isEmpty)
+                    Text('No sub-strategies defined',
+                        style: AppTextStyles.meta
+                            .copyWith(color: AppColors.textDim)),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SubStrategyCard extends StatelessWidget {
+  const _SubStrategyCard(
+      {required this.index, required this.sub});
+
+  final int index;
+  final SubStrategy sub;
+
+  @override
+  Widget build(BuildContext context) {
+    final combined = {
+      ...sub.conditions,
+      ...sub.config,
+    };
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.surface.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 20,
+                height: 20,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: AppColors.fill(AppColors.primary),
+                  borderRadius: BorderRadius.circular(4),
+                  border: Border.all(
+                      color: AppColors.stroke(AppColors.primary)),
+                ),
+                child: Text('${index + 1}',
+                    style: AppTextStyles.nano.copyWith(
+                        color: AppColors.primary,
+                        fontWeight: FontWeight.w700)),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                  child: Text(sub.strategy ?? '?',
+                      style: AppTextStyles.bodyHi)),
+              if (sub.weight != null)
+                _Chip(
+                    label:
+                        '${(sub.weight! * 100).toStringAsFixed(0)}%'),
+              if (sub.decisionPhase != null)
+                _Chip(label: sub.decisionPhase!),
+            ],
+          ),
+          if (combined.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: combined.entries
+                  .map((e) => Container(
+                        padding:
+                            const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: AppColors.canvas,
+                          borderRadius: BorderRadius.circular(6),
+                          border:
+                              Border.all(color: AppColors.border),
+                        ),
+                        child: Column(
+                          crossAxisAlignment:
+                              CrossAxisAlignment.start,
+                          children: [
+                            Text(e.key,
+                                style: AppTextStyles.nano.copyWith(
+                                    color: AppColors.textFaint)),
+                            Text('${e.value ?? 'null'}',
+                                style: AppTextStyles.mono(11,
+                                    color: AppColors.textMuted)),
+                          ],
+                        ),
+                      ))
+                  .toList(),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        margin: const EdgeInsets.only(left: 4),
+        padding:
+            const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Text(label,
+            style: AppTextStyles.mono(10,
+                color: AppColors.textMuted)),
+      );
+}
+
+// ── Logs panel ────────────────────────────────────────────────────────────────
+
+class _LogsPanel extends StatelessWidget {
+  const _LogsPanel({
+    required this.open,
+    required this.lines,
+    required this.loading,
+    this.error,
+    required this.source,
+    required this.onToggle,
+  });
+
+  final bool open;
+  final List<String> lines;
+  final bool loading;
+  final String? error;
+  final String source;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: EdgeInsets.zero,
+      borderColor: AppColors.panelAlt,
+      child: Column(
+        children: [
+          // Header bar
+          Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: AppColors.panelAlt,
+              borderRadius: open
+                  ? const BorderRadius.vertical(
+                      top: Radius.circular(16))
+                  : BorderRadius.circular(16),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: open
+                        ? AppColors.success
+                        : AppColors.textFaint,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text('backtest-${lines.hashCode}.log',
+                    style: AppTextStyles.mono(11,
+                        color: AppColors.textMd)),
+                if (lines.isNotEmpty) ...[
+                  const SizedBox(width: 6),
+                  Text('${lines.length} lines',
+                      style: AppTextStyles.nano
+                          .copyWith(color: AppColors.textFaint)),
+                ],
+                if (source == 'db')
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4),
+                    child: Text('(last 500)',
+                        style: AppTextStyles.nano.copyWith(
+                            color: AppColors.warning
+                                .withValues(alpha: 0.7))),
+                  ),
+                const Spacer(),
+                InkWell(
+                  onTap: onToggle,
+                  borderRadius: BorderRadius.circular(6),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: open
+                          ? AppColors.fill(AppColors.info)
+                          : AppColors.fill(AppColors.border),
+                      borderRadius: BorderRadius.circular(6),
+                      border: Border.all(
+                          color: open
+                              ? AppColors.stroke(AppColors.info)
+                              : AppColors.border),
+                    ),
+                    child: Text(
+                      open ? 'Hide Logs' : 'View Logs',
+                      style: AppTextStyles.micro.copyWith(
+                          color: open
+                              ? AppColors.info
+                              : AppColors.textMuted,
+                          fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (open)
+            Container(
+              constraints:
+                  const BoxConstraints(maxHeight: 400),
+              child: loading
+                  ? const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: LoadingState(label: 'Loading logs…'))
+                  : error != null
+                      ? Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Text(error!,
+                              style: AppTextStyles.meta.copyWith(
+                                  color: AppColors.danger)))
+                      : lines.isEmpty
+                          ? Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: Text(
+                                  'No logs available.',
+                                  style: AppTextStyles.meta
+                                      .copyWith(
+                                          color:
+                                              AppColors.textDim)))
+                          : ListView.builder(
+                              padding: const EdgeInsets.all(8),
+                              itemCount: lines.length,
+                              itemBuilder: (_, i) =>
+                                  _LogLine(raw: lines[i]),
+                            ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LogLine extends StatelessWidget {
+  const _LogLine({required this.raw});
+
+  final String raw;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _levelColor(raw);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Text(
+        raw,
+        style: AppTextStyles.mono(10, color: color),
+      ),
+    );
+  }
+
+  static Color _levelColor(String line) {
+    final l = line.toLowerCase();
+    if (l.contains('error') ||
+        l.contains('fail') ||
+        l.contains('exception')) {
+      return AppColors.danger;
+    }
+    if (l.contains('warn') ||
+        l.contains('retry') ||
+        l.contains('skip')) {
+      return AppColors.warning;
+    }
+    if (l.contains('success') ||
+        l.contains('completed') ||
+        l.contains('profit') ||
+        l.contains('passed')) {
+      return AppColors.success;
+    }
+    if (l.contains('broker')) return AppColors.info;
+    return AppColors.textMuted;
+  }
+}
+
+// ── Portfolio chart ───────────────────────────────────────────────────────────
+
+class _PortfolioChart extends StatefulWidget {
+  const _PortfolioChart(
+      {required this.history, this.startValue});
+
+  final List<PortfolioValuePoint> history;
+  final num? startValue;
+
+  @override
+  State<_PortfolioChart> createState() => _PortfolioChartState();
+}
+
+class _PortfolioChartState extends State<_PortfolioChart> {
+  double? _hoveredValue;
+  DateTime? _hoveredDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayValue =
+        _hoveredValue ?? widget.history.last.value.toDouble();
+    final startVal = widget.startValue?.toDouble() ?? 0;
+    final pnl = displayValue - startVal;
+
+    return GlassCard(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Portfolio Value Over Time',
+              style: AppTextStyles.eyebrow),
+          const SizedBox(height: 4),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                fmtMoney(displayValue),
+                style: AppTextStyles.valueXl
+                    .copyWith(color: AppColors.textHi),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                fmtPnl(pnl),
+                style: AppTextStyles.value
+                    .copyWith(color: pnlColor(pnl)),
+              ),
+              const SizedBox(width: 4),
+              Text('vs start',
+                  style: AppTextStyles.meta
+                      .copyWith(color: AppColors.textDim)),
+            ],
+          ),
+          if (_hoveredDate != null)
+            Text(
+              fmtDateTime(_hoveredDate),
+              style: AppTextStyles.meta
+                  .copyWith(color: AppColors.textDim),
+            ),
+          const SizedBox(height: 12),
+          SfCartesianChart(
+            plotAreaBorderWidth: 0,
+            backgroundColor: Colors.transparent,
+            primaryXAxis: DateTimeAxis(
+              majorGridLines: const MajorGridLines(
+                  color: AppColors.chartGrid, width: 1),
+              axisLine: const AxisLine(width: 0),
+              labelStyle: const TextStyle(
+                  color: AppColors.chartAxis, fontSize: 10),
+            ),
+            primaryYAxis: NumericAxis(
+              isVisible: false,
+              majorGridLines: const MajorGridLines(width: 0),
+              axisLine: const AxisLine(width: 0),
+            ),
+            tooltipBehavior: TooltipBehavior(enable: false),
+            trackballBehavior: TrackballBehavior(
+              enable: true,
+              activationMode: ActivationMode.singleTap,
+              tooltipSettings: const InteractiveTooltip(enable: false),
+            ),
+            onTrackballPositionChanging: (args) {
+              final pt = args.chartPointInfo;
+              if (pt.chartPoint != null) {
+                setState(() {
+                  _hoveredValue =
+                      (pt.chartPoint!.y)?.toDouble();
+                  _hoveredDate = pt.chartPoint!.x as DateTime?;
+                });
+              }
+            },
+            annotations: widget.startValue != null
+                ? <CartesianChartAnnotation>[
+                    CartesianChartAnnotation(
+                      widget: Container(
+                        width: double.infinity,
+                        height: 1,
+                        color:
+                            AppColors.textFaint.withValues(alpha: 0.5),
+                      ),
+                      coordinateUnit: CoordinateUnit.point,
+                      x: widget.history.first.timestamp,
+                      y: widget.startValue!.toDouble(),
+                    ),
+                  ]
+                : null,
+            series: <CartesianSeries>[
+              SplineAreaSeries<PortfolioValuePoint, DateTime>(
+                dataSource: widget.history,
+                splineType: SplineType.monotonic,
+                xValueMapper: (d, _) => d.timestamp,
+                yValueMapper: (d, _) => d.value,
+                color: AppColors.chartLine.withValues(alpha: 0.3),
+                borderColor: AppColors.chartLine,
+                borderWidth: 2.5,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── P&L per stock card ────────────────────────────────────────────────────────
+
+class _PnlPerStockCard extends StatelessWidget {
+  const _PnlPerStockCard({required this.summary});
+
+  final BacktestSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text('P&L per Stock',
+                style: AppTextStyles.eyebrow),
+          ),
+          const Divider(color: AppColors.border, height: 1),
+          ...summary.tickers.map((sym) {
+            final p = summary.pnlPerStock?[sym];
+            final pp = summary.pnlPercentPerStock?[sym];
+            final pc = summary.stockPriceChange?[sym];
+            return Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 16, vertical: 10),
+              child: Row(
+                children: [
+                  Text(sym,
+                      style: AppTextStyles.mono(12,
+                          color: AppColors.textHi,
+                          weight: FontWeight.w700)),
+                  const Spacer(),
+                  Text(fmtPnl(p),
+                      style: AppTextStyles.mono(12,
+                          color: pnlColor(p),
+                          weight: FontWeight.w600)),
+                  const SizedBox(width: 12),
+                  Text(fmtPct(pp),
+                      style: AppTextStyles.mono(11,
+                          color: pnlColor(pp))),
+                  const SizedBox(width: 12),
+                  Text(fmtPct(pc),
+                      style: AppTextStyles.mono(11,
+                          color: pnlColor(pc))),
+                ],
+              ),
+            );
+          }).expand((w) => [
+                w,
+                const Divider(color: AppColors.border, height: 1)
+              ]),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Stock accordion ───────────────────────────────────────────────────────────
+
+class _StockAccordion extends StatelessWidget {
+  const _StockAccordion({
+    super.key,
+    required this.sym,
+    required this.summary,
+    required this.graphData,
+    required this.expanded,
+    required this.decisionLimit,
+    required this.onToggle,
+    required this.onShowMoreDecisions,
+  });
+
+  final String sym;
+  final BacktestSummary summary;
+  final BacktestGraphData graphData;
+  final bool expanded;
+  final int decisionLimit;
+  final VoidCallback onToggle;
+  final VoidCallback onShowMoreDecisions;
+
+  List<BacktestTrade> get _trades => graphData.backtestTrades
+      .where((t) => t.ticker == sym)
+      .toList()
+    ..sort((a, b) =>
+        (a.timestamp ?? DateTime(0))
+            .compareTo(b.timestamp ?? DateTime(0)));
+
+  List<BacktestDecision> get _decisions => graphData.backtestDecisions
+      .where((d) => d.symbol == sym)
+      .toList()
+    ..sort((a, b) =>
+        (b.timestamp ?? DateTime(0))
+            .compareTo(a.timestamp ?? DateTime(0)));
+
+  List<PortfolioValuePoint> get _prices => graphData.backtestPrices
+      .where((p) => p.symbol == sym)
+      .map((p) => PortfolioValuePoint(
+          timestamp: p.timestamp, value: p.close))
+      .toList()
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  List<BacktestTrade> get _buys =>
+      _trades.where((t) => (t.action ?? '').toLowerCase().contains('buy')).toList();
+
+  List<BacktestTrade> get _sells =>
+      _trades.where((t) => (t.action ?? '').toLowerCase().contains('sell')).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    final pnl = summary.pnlPerStock?[sym];
+    final pnlPct = summary.pnlPercentPerStock?[sym];
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      decoration: BoxDecoration(
+        color: AppColors.surface.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        children: [
+          // Clickable header
+          InkWell(
+            onTap: onToggle,
+            borderRadius: BorderRadius.circular(16),
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Row(
+                children: [
+                  Text(sym,
+                      style: AppTextStyles.mono(13,
+                          color: AppColors.textHi,
+                          weight: FontWeight.w700)),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${fmtPnl(pnl)} (${fmtPct(pnlPct)})',
+                    style: AppTextStyles.meta
+                        .copyWith(color: pnlColor(pnl)),
+                  ),
+                  const SizedBox(width: 8),
+                  Text('${_trades.length} trades',
+                      style: AppTextStyles.nano.copyWith(
+                          color: AppColors.textFaint)),
+                  const Spacer(),
+                  AnimatedRotation(
+                    turns: expanded ? 0.5 : 0,
+                    duration:
+                        const Duration(milliseconds: 200),
+                    child: Icon(symbol('expand_more'),
+                        color: AppColors.textDim, size: 18),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (expanded) ...[
+            const Divider(color: AppColors.border, height: 1),
+            // Price chart
+            if (_prices.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: _StockChart(
+                  sym: sym,
+                  prices: _prices,
+                  buys: _buys,
+                  sells: _sells,
+                ),
+              ),
+            // Trade table
+            if (_trades.isNotEmpty) _TradeTable(trades: _trades),
+            // Decision trace
+            if (_decisions.isNotEmpty)
+              _DecisionTrace(
+                sym: sym,
+                decisions: _decisions,
+                limit: decisionLimit,
+                onShowMore: onShowMoreDecisions,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _StockChart extends StatelessWidget {
+  const _StockChart({
+    required this.sym,
+    required this.prices,
+    required this.buys,
+    required this.sells,
+  });
+
+  final String sym;
+  final List<PortfolioValuePoint> prices;
+  final List<BacktestTrade> buys;
+  final List<BacktestTrade> sells;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 220,
+      child: SfCartesianChart(
+        plotAreaBorderWidth: 0,
+        backgroundColor: Colors.transparent,
+        primaryXAxis: DateTimeAxis(
+          majorGridLines: const MajorGridLines(
+              color: AppColors.chartGrid, width: 1),
+          axisLine: const AxisLine(width: 0),
+          labelStyle: const TextStyle(
+              color: AppColors.chartAxis, fontSize: 10),
+        ),
+        primaryYAxis: NumericAxis(
+          isVisible: false,
+          majorGridLines: const MajorGridLines(width: 0),
+          axisLine: const AxisLine(width: 0),
+        ),
+        tooltipBehavior: TooltipBehavior(
+          enable: true,
+          color: AppColors.panel,
+          textStyle:
+              const TextStyle(color: AppColors.textMd, fontSize: 10),
+        ),
+        series: <CartesianSeries>[
+          SplineAreaSeries<PortfolioValuePoint, DateTime>(
+            name: sym,
+            dataSource: prices,
+            splineType: SplineType.monotonic,
+            xValueMapper: (d, _) => d.timestamp,
+            yValueMapper: (d, _) => d.value,
+            color: AppColors.chartLineAlt.withValues(alpha: 0.18),
+            borderColor: AppColors.chartLineAlt,
+            borderWidth: 2,
+          ),
+          ScatterSeries<BacktestTrade, DateTime>(
+            name: 'Buy',
+            dataSource: buys,
+            xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
+            yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
+            color: AppColors.success,
+            markerSettings:
+                const MarkerSettings(isVisible: true, height: 8, width: 8),
+          ),
+          ScatterSeries<BacktestTrade, DateTime>(
+            name: 'Sell',
+            dataSource: sells,
+            xValueMapper: (t, _) => t.timestamp ?? DateTime.now(),
+            yValueMapper: (t, _) => t.price?.toDouble() ?? 0,
+            color: AppColors.danger,
+            markerSettings:
+                const MarkerSettings(isVisible: true, height: 8, width: 8),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TradeTable extends StatelessWidget {
+  const _TradeTable({required this.trades});
+
+  final List<BacktestTrade> trades;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(color: AppColors.border, height: 1),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+              horizontal: 12, vertical: 8),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              headingRowHeight: 32,
+              dataRowMinHeight: 30,
+              dataRowMaxHeight: 40,
+              horizontalMargin: 0,
+              columnSpacing: 16,
+              headingTextStyle: AppTextStyles.nano
+                  .copyWith(color: AppColors.textFaint),
+              dataTextStyle: AppTextStyles.mono(11,
+                  color: AppColors.textMuted),
+              columns: const [
+                DataColumn(label: Text('Time')),
+                DataColumn(label: Text('Action')),
+                DataColumn(label: Text('Shares'),
+                    numeric: true),
+                DataColumn(label: Text('Price'), numeric: true),
+                DataColumn(label: Text('Total'), numeric: true),
+                DataColumn(label: Text('Cash After'),
+                    numeric: true),
+              ],
+              rows: trades
+                  .map(
+                    (t) => DataRow(cells: [
+                      DataCell(Text(fmtDateTime(t.timestamp))),
+                      DataCell(_ActionBadge(
+                          action: t.action ?? '')),
+                      DataCell(Text(t.shares != null
+                          ? t.shares!
+                              .toStringAsFixed(4)
+                          : '—')),
+                      DataCell(Text(fmtMoney(t.price))),
+                      DataCell(Text(
+                        t.total != null
+                            ? fmtMoney(t.total!.abs())
+                            : '—',
+                        style: AppTextStyles.mono(11,
+                            color: (t.action ?? '')
+                                    .toLowerCase()
+                                    .contains('buy')
+                                ? AppColors.danger
+                                : AppColors.success),
+                      )),
+                      DataCell(Text(fmtMoney(t.cashAfter))),
+                    ]),
+                  )
+                  .toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionBadge extends StatelessWidget {
+  const _ActionBadge({required this.action});
+
+  final String action;
+
+  @override
+  Widget build(BuildContext context) {
+    final isBuy = action.toLowerCase().contains('buy');
+    final c = isBuy ? AppColors.success : AppColors.danger;
+    return Container(
+      padding:
+          const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.fill(c),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppColors.stroke(c)),
+      ),
+      child: Text(
+        action.toUpperCase(),
+        style: AppTextStyles.nano
+            .copyWith(color: c, fontWeight: FontWeight.w700),
+      ),
+    );
+  }
+}
+
+class _DecisionTrace extends StatelessWidget {
+  const _DecisionTrace({
+    required this.sym,
+    required this.decisions,
+    required this.limit,
+    required this.onShowMore,
+  });
+
+  final String sym;
+  final List<BacktestDecision> decisions;
+  final int limit;
+  final VoidCallback onShowMore;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = decisions.take(limit).toList();
+    final remaining = decisions.length - visible.length;
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Decision Trace',
+                  style: AppTextStyles.eyebrow),
+              Text('${decisions.length} evaluations',
+                  style: AppTextStyles.nano
+                      .copyWith(color: AppColors.textDim)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...visible.map((d) => _DecisionCard(d: d)),
+          if (remaining > 0)
+            InkWell(
+              onTap: onShowMore,
+              borderRadius: BorderRadius.circular(10),
+              child: Container(
+                width: double.infinity,
+                padding:
+                    const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: AppColors.surface.withValues(alpha: 0.4),
+                  borderRadius:
+                      BorderRadius.circular(10),
+                  border: Border.all(color: AppColors.border),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  'Show more ($remaining remaining)',
+                  style: AppTextStyles.meta
+                      .copyWith(color: AppColors.textMuted),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DecisionCard extends StatelessWidget {
+  const _DecisionCard({required this.d});
+
+  final BacktestDecision d;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = d.decisionLabel();
+    final labelColor = label == 'BUY'
+        ? AppColors.success
+        : label == 'SELL'
+            ? AppColors.danger
+            : AppColors.textMuted;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.surface.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(fmtDateTime(d.timestamp),
+                        style: AppTextStyles.nano
+                            .copyWith(color: AppColors.textDim)),
+                    const SizedBox(height: 4),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 4,
+                      children: [
+                        AppBadge(label: label, color: labelColor),
+                        if (d.overrideApplied == true)
+                          AppBadge(
+                              label: 'Override',
+                              color: AppColors.warning),
+                        if (d.primaryStrategy != null)
+                          _Chip(label: d.primaryStrategy!),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              if (d.normalizedScore != null)
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text('Weighted Score',
+                        style: AppTextStyles.nano.copyWith(
+                            color: AppColors.textFaint)),
+                    Text(
+                      d.normalizedScore!.toStringAsFixed(3),
+                      style: AppTextStyles.mono(12,
+                          color: AppColors.textMuted),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+          if (d.finalReason != null &&
+              d.finalReason!.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(d.finalReason!,
+                style: AppTextStyles.body
+                    .copyWith(color: AppColors.textMd)),
+          ],
+          if (d.strategies.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            ...d.strategies.map((s) => Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Row(
+                    crossAxisAlignment:
+                        CrossAxisAlignment.start,
+                    children: [
+                      AppBadge(
+                          label: s.decisionLabel(),
+                          color: s.decisionLabel() == 'BUY'
+                              ? AppColors.success
+                              : s.decisionLabel() == 'SELL'
+                                  ? AppColors.danger
+                                  : AppColors.textMuted),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment:
+                              CrossAxisAlignment.start,
+                          children: [
+                            Text(s.strategy ?? '?',
+                                style: AppTextStyles.bodyHi),
+                            if (s.reason != null)
+                              Text(
+                                s.reason!.length > 360
+                                    ? '${s.reason!.substring(0, 359)}…'
+                                    : s.reason!,
+                                style: AppTextStyles.meta.copyWith(
+                                    color: AppColors.textDim),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                )),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ── Backtest detail skeleton ──────────────────────────────────────────────────
+
+class _BacktestDetailSkeleton extends StatelessWidget {
+  const _BacktestDetailSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header: icon + title line + status pill + date line
+          Row(
+            children: [
+              Skeleton.circle(44),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Skeleton(width: 160, height: 20, radius: 6),
+                        const SizedBox(width: 8),
+                        Skeleton(width: 70, height: 20, radius: 999),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Skeleton.line(width: 140, height: 11),
+                    const SizedBox(height: 4),
+                    Skeleton.line(width: 100, height: 10),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          // Action chip row
+          Row(
+            children: [
+              Skeleton(width: 64, height: 28, radius: 8),
+              const SizedBox(width: 8),
+              Skeleton(width: 64, height: 28, radius: 8),
+              const SizedBox(width: 8),
+              Skeleton(width: 80, height: 28, radius: 8),
+            ],
+          ),
+          const SizedBox(height: 20),
+          // Stat grid: 2 cols x 4 rows = ~7 tiles
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 10,
+              mainAxisSpacing: 10,
+              childAspectRatio: 2.2,
+            ),
+            itemCount: 6,
+            itemBuilder: (_, __) => Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.surface.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: AppColors.border),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.line(width: 60, height: 9),
+                  const SizedBox(height: 6),
+                  Skeleton.line(width: 80, height: 14),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          // AI Credits card skeleton
+          GlassCard(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Skeleton.circle(32),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Skeleton.line(width: 80, height: 11),
+                          const SizedBox(height: 4),
+                          Skeleton.line(width: 140, height: 10),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Chart block skeleton
+          GlassCard(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Skeleton.line(width: 160, height: 11),
+                const SizedBox(height: 8),
+                Skeleton(height: 180, radius: 10),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Stock accordion rows (3)
+          ...List.generate(
+            3,
+            (_) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: AppColors.surface.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: AppColors.border),
+                ),
+                child: Row(
+                  children: [
+                    Skeleton(width: 50, height: 13, radius: 4),
+                    const SizedBox(width: 8),
+                    Skeleton(width: 90, height: 11, radius: 4),
+                    const Spacer(),
+                    Skeleton(width: 18, height: 18, radius: 4),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── LLM cost card skeleton ─────────────────────────────────────────────────────
+
+class _LlmCostSkeleton extends StatelessWidget {
+  const _LlmCostSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(child: Skeleton.line(width: 80, height: 13)),
+            const SizedBox(width: 16),
+            Expanded(child: Skeleton.line(width: 40, height: 13)),
+            const SizedBox(width: 16),
+            Expanded(child: Skeleton.line(width: 60, height: 13)),
+            const SizedBox(width: 16),
+            Expanded(child: Skeleton.line(width: 60, height: 13)),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Skeleton.line(height: 10),
+        const SizedBox(height: 6),
+        Skeleton.line(height: 10),
+      ],
+    );
+  }
+}
+
+// ── Round-trip stats ──────────────────────────────────────────────────────────
+
+class _RoundTripStats extends StatelessWidget {
+  const _RoundTripStats({required this.summary});
+
+  final BacktestSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Round Trip Statistics',
+              style: AppTextStyles.eyebrow),
+          const SizedBox(height: 12),
+          GridView.count(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisCount: 2,
+            crossAxisSpacing: 10,
+            mainAxisSpacing: 10,
+            childAspectRatio: 2.5,
+            children: [
+              StatTile(
+                  label: 'Round Trips',
+                  value: '${summary.roundTrips ?? '—'}'),
+              StatTile(
+                  label: 'Total RT P&L',
+                  value: fmtPnl(summary.totalRoundTripPnl),
+                  valueColor: pnlColor(summary.totalRoundTripPnl)),
+              StatTile(
+                  label: 'Avg Winning',
+                  value: fmtMoney(summary.avgWinningRoundTrip),
+                  valueColor: AppColors.success),
+              StatTile(
+                  label: 'Avg Losing',
+                  value: fmtMoney(summary.avgLosingRoundTrip),
+                  valueColor: AppColors.danger),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/backtests/presentation/backtest_llm_pause_banner.dart
+++ b/mobile/lib/features/backtests/presentation/backtest_llm_pause_banner.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import '../../../core/formatters/formatters.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../data/models/backtest.dart';
+
+/// Amber banner shown only when status == 'paused_llm_critical'.
+/// Mirrors BacktestLLMPauseBanner.vue exactly.
+class BacktestLlmPauseBanner extends StatelessWidget {
+  const BacktestLlmPauseBanner({super.key, required this.summary});
+
+  final BacktestSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    if ((summary.status ?? '').toLowerCase() != 'paused_llm_critical') {
+      return const SizedBox.shrink();
+    }
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.fill(AppColors.warning),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.stroke(AppColors.warning)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.pause_circle_outline,
+              color: AppColors.warning, size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Backtest paused: LLM critical failure',
+                  style: AppTextStyles.bodyHi
+                      .copyWith(color: AppColors.warning),
+                ),
+                const SizedBox(height: 8),
+                _row('Bar', _fmtBar(summary.pauseBarTime)),
+                _row(
+                  'Reason',
+                  '${summary.pauseReasonTag ?? 'unknown'}  '
+                      '(${summary.pauseAttempts ?? '?'} attempts)',
+                ),
+                _row(
+                  'Provider',
+                  '${summary.pauseProvider ?? '?'}  •  '
+                      'Model: ${summary.pauseModel ?? '?'}',
+                ),
+                _row('Call site', summary.pauseCallSite ?? 'unknown'),
+                _row('Paused at', _fmtPausedAt(summary.pausedAt)),
+                if (summary.pauseSample != null &&
+                    summary.pauseSample!.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.black26,
+                      borderRadius: BorderRadius.circular(6),
+                      border: Border.all(
+                          color: AppColors.stroke(AppColors.warning)),
+                    ),
+                    child: SelectableText(
+                      summary.pauseSample!,
+                      style: AppTextStyles.mono(10,
+                          color: AppColors.warning
+                              .withValues(alpha: 0.7)),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 8),
+                Text(
+                  'Tap "Resume" above when the provider is healthy again. '
+                  'The same bar will retry from the snapshot.',
+                  style: AppTextStyles.meta.copyWith(
+                      color:
+                          AppColors.warning.withValues(alpha: 0.6)),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _row(String label, String value) => Padding(
+        padding: const EdgeInsets.only(bottom: 3),
+        child: RichText(
+          text: TextSpan(
+            style: AppTextStyles.meta
+                .copyWith(color: AppColors.textMd),
+            children: [
+              TextSpan(
+                text: '$label:  ',
+                style: TextStyle(
+                    color: AppColors.warning.withValues(alpha: 0.7)),
+              ),
+              TextSpan(text: value),
+            ],
+          ),
+        ),
+      );
+
+  static String _fmtBar(String? s) {
+    if (s == null || s.isEmpty) return 'unknown';
+    return s.length >= 10 ? s.substring(0, 10) : s;
+  }
+
+  static String _fmtPausedAt(dynamic v) {
+    final dt = parseDateTime(v);
+    if (dt == null) return 'unknown';
+    return fmtDateTime(dt);
+  }
+}

--- a/mobile/lib/features/backtests/presentation/backtest_playback_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtest_playback_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/charts/scrubbable_area_chart.dart';
 import '../../../core/formatters/formatters.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
@@ -368,40 +368,15 @@ class _PortfolioPanel extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
-          SizedBox(
-            height: 150,
-            child: SfCartesianChart(
-              plotAreaBorderWidth: 0,
-              backgroundColor: Colors.transparent,
-              margin: EdgeInsets.zero,
-              primaryXAxis: DateTimeAxis(
-                minimum: range.min,
-                maximum: range.max,
-                majorGridLines: const MajorGridLines(
-                    color: AppColors.chartGrid, width: 1),
-                axisLine: const AxisLine(width: 0),
-                labelStyle: const TextStyle(
-                    color: AppColors.chartAxis, fontSize: 9),
-              ),
-              primaryYAxis: NumericAxis(
-                isVisible: false,
-                majorGridLines: const MajorGridLines(width: 0),
-                axisLine: const AxisLine(width: 0),
-              ),
-              tooltipBehavior: TooltipBehavior(enable: false),
-              series: <CartesianSeries>[
-                SplineAreaSeries<({DateTime time, double value}), DateTime>(
-                  dataSource: points,
-                  splineType: SplineType.monotonic,
-                  xValueMapper: (d, _) => d.time,
-                  yValueMapper: (d, _) => d.value,
-                  color: AppColors.chartLine.withValues(alpha: 0.25),
-                  borderColor: AppColors.chartLine,
-                  borderWidth: 2,
-                  animationDuration: 500,
-                ),
-              ],
-            ),
+          ScrubbableAreaChart(
+            timestamps: [for (final p in points) p.time],
+            values: [for (final p in points) p.value],
+            lineColor: AppColors.chartLine,
+            height: 170,
+            baseline: state.metadata.initialCash?.toDouble(),
+            // Live playback updates every tick — don't replay the entry
+            // animation on each frame.
+            animate: false,
           ),
         ],
       ),

--- a/mobile/lib/features/backtests/presentation/backtest_playback_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtest_playback_screen.dart
@@ -1,0 +1,1127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/formatters/formatters.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/app_background.dart';
+import '../../../core/widgets/glass_card.dart';
+import '../../../core/widgets/material_symbols.dart';
+import '../../../core/widgets/skeleton.dart';
+import '../application/backtest_playback_controller.dart';
+import '../data/models/backtest.dart';
+
+class BacktestPlaybackScreen extends ConsumerWidget {
+  const BacktestPlaybackScreen({super.key, required this.id});
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state =
+        ref.watch(backtestPlaybackControllerProvider(id));
+    final ctrl = ref
+        .read(backtestPlaybackControllerProvider(id).notifier);
+
+    return Scaffold(
+      backgroundColor: AppColors.canvas,
+      body: AppBackground(
+        child: SafeArea(
+          child: state.loading
+              ? const _PlaybackSkeleton()
+              : state.error != null
+                  ? _ErrorView(
+                      message: state.error!,
+                      onBack: () => context.canPop()
+                          ? context.pop()
+                          : context.go('/backtests/$id'))
+                  : state.isEmpty
+                      ? _EmptyView(
+                          onBack: () => context.canPop()
+                              ? context.pop()
+                              : context.go('/backtests/$id'))
+                      : _PlaybackBody(
+                          id: id,
+                          state: state,
+                          ctrl: ctrl,
+                          onBack: () => context.canPop()
+                              ? context.pop()
+                              : context.go('/backtests/$id'),
+                        ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Main playback body ────────────────────────────────────────────────────────
+
+class _PlaybackBody extends StatefulWidget {
+  const _PlaybackBody({
+    required this.id,
+    required this.state,
+    required this.ctrl,
+    required this.onBack,
+  });
+
+  final String id;
+  final BacktestPlaybackState state;
+  final BacktestPlaybackController ctrl;
+  final VoidCallback onBack;
+
+  @override
+  State<_PlaybackBody> createState() => _PlaybackBodyState();
+}
+
+class _PlaybackBodyState extends State<_PlaybackBody> {
+  final ScrollController _eventScroll = ScrollController();
+
+  @override
+  void didUpdateWidget(_PlaybackBody old) {
+    super.didUpdateWidget(old);
+    // Auto-scroll event log when new frame is added
+    if (old.state.frameIndex != widget.state.frameIndex) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_eventScroll.hasClients) {
+          _eventScroll.animateTo(
+            _eventScroll.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOut,
+          );
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _eventScroll.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = widget.state;
+    final ctrl = widget.ctrl;
+
+    return Column(
+      children: [
+        // ── Top header ────────────────────────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+          child: Row(
+            children: [
+              // Back button
+              InkWell(
+                onTap: widget.onBack,
+                borderRadius: BorderRadius.circular(8),
+                child: Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: Icon(symbol('arrow_back'),
+                      color: AppColors.textMuted, size: 16),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text('Backtest Playback',
+                            style: AppTextStyles.h3),
+                        const SizedBox(width: 6),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: AppColors.fill(AppColors.warning),
+                            borderRadius: BorderRadius.circular(4),
+                            border: Border.all(
+                                color: AppColors.stroke(
+                                    AppColors.warning)),
+                          ),
+                          child: Text('LIVE',
+                              style: AppTextStyles.nano.copyWith(
+                                  color: AppColors.warning,
+                                  fontWeight: FontWeight.w700,
+                                  fontFamily: 'monospace')),
+                        ),
+                      ],
+                    ),
+                    Text('Backtest #${widget.id}',
+                        style: AppTextStyles.nano
+                            .copyWith(color: AppColors.textDim)),
+                  ],
+                ),
+              ),
+              // Current date pill
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 10, vertical: 5),
+                decoration: BoxDecoration(
+                  color: AppColors.panelAlt,
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: AppColors.border),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(symbol('calendar_today'),
+                        color: AppColors.info, size: 12),
+                    const SizedBox(width: 5),
+                    Text(
+                      s.currentDateLabel,
+                      style: AppTextStyles.mono(11,
+                          color: AppColors.textMd,
+                          weight: FontWeight.w600),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              // Controls
+              _ControlBar(
+                isPlaying: s.isPlaying,
+                speed: s.speed,
+                onPlay: ctrl.togglePlay,
+                onReset: ctrl.reset,
+                onSpeed: ctrl.cycleSpeed,
+              ),
+            ],
+          ),
+        ),
+
+        // ── Main content: event stepper + sidebar ─────────────────────────────
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+            child: Column(
+              children: [
+                // Portfolio chart + holdings (top on mobile)
+                _PortfolioPanel(state: s),
+                const SizedBox(height: 10),
+                // Event stepper (scrollable)
+                Expanded(
+                  child: _EventStepper(
+                    events: s.visibleEvents,
+                    isPlaying: s.isPlaying,
+                    scrollController: _eventScroll,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Control bar ───────────────────────────────────────────────────────────────
+
+class _ControlBar extends StatelessWidget {
+  const _ControlBar({
+    required this.isPlaying,
+    required this.speed,
+    required this.onPlay,
+    required this.onReset,
+    required this.onSpeed,
+  });
+
+  final bool isPlaying;
+  final double speed;
+  final VoidCallback onPlay;
+  final VoidCallback onReset;
+  final VoidCallback onSpeed;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(
+            horizontal: 6, vertical: 4),
+        decoration: BoxDecoration(
+          color: AppColors.panelAlt,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Play/pause
+            _CtrlBtn(
+              icon: isPlaying ? symbol('pause') : symbol('play_arrow'),
+              color: isPlaying ? AppColors.warning : AppColors.success,
+              onTap: onPlay,
+            ),
+            const SizedBox(width: 4),
+            // Reset
+            _CtrlBtn(
+              icon: symbol('replay'),
+              color: AppColors.textMuted,
+              onTap: onReset,
+            ),
+            const SizedBox(width: 4),
+            // Speed
+            InkWell(
+              onTap: onSpeed,
+              borderRadius: BorderRadius.circular(6),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 8, vertical: 5),
+                decoration: BoxDecoration(
+                  color: AppColors.surface,
+                  borderRadius: BorderRadius.circular(6),
+                  border: Border.all(color: AppColors.border),
+                ),
+                child: Text(
+                  '${speed % 1 == 0 ? speed.toInt() : speed}x',
+                  style: AppTextStyles.mono(11,
+                      color: AppColors.textMd,
+                      weight: FontWeight.w700),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
+class _CtrlBtn extends StatelessWidget {
+  const _CtrlBtn({
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            color: AppColors.fill(color),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.stroke(color)),
+          ),
+          child: Icon(icon, color: color, size: 18),
+        ),
+      );
+}
+
+// ── Portfolio panel ───────────────────────────────────────────────────────────
+
+class _PortfolioPanel extends StatelessWidget {
+  const _PortfolioPanel({required this.state});
+
+  final BacktestPlaybackState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final history = state.portfolioHistory;
+    final range = state.xRange;
+
+    // Build series with a leading anchor point
+    final points = [
+      (
+        time: range.min,
+        value: (state.metadata.initialCash?.toDouble() ?? 0.0)
+      ),
+      ...history,
+    ];
+
+    return GlassCard(
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('PORTFOLIO VALUE',
+                        style: AppTextStyles.eyebrow),
+                    Text(
+                      fmtMoney(state.currentPortfolioValue),
+                      style: AppTextStyles.valueXl
+                          .copyWith(color: AppColors.textHi),
+                    ),
+                  ],
+                ),
+              ),
+              // Holdings grid (compact)
+              if (state.currentHoldings.isNotEmpty)
+                _HoldingsMini(holdings: state.currentHoldings),
+            ],
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            height: 150,
+            child: SfCartesianChart(
+              plotAreaBorderWidth: 0,
+              backgroundColor: Colors.transparent,
+              margin: EdgeInsets.zero,
+              primaryXAxis: DateTimeAxis(
+                minimum: range.min,
+                maximum: range.max,
+                majorGridLines: const MajorGridLines(
+                    color: AppColors.chartGrid, width: 1),
+                axisLine: const AxisLine(width: 0),
+                labelStyle: const TextStyle(
+                    color: AppColors.chartAxis, fontSize: 9),
+              ),
+              primaryYAxis: NumericAxis(
+                isVisible: false,
+                majorGridLines: const MajorGridLines(width: 0),
+                axisLine: const AxisLine(width: 0),
+              ),
+              tooltipBehavior: TooltipBehavior(enable: false),
+              series: <CartesianSeries>[
+                SplineAreaSeries<({DateTime time, double value}), DateTime>(
+                  dataSource: points,
+                  splineType: SplineType.monotonic,
+                  xValueMapper: (d, _) => d.time,
+                  yValueMapper: (d, _) => d.value,
+                  color: AppColors.chartLine.withValues(alpha: 0.25),
+                  borderColor: AppColors.chartLine,
+                  borderWidth: 2,
+                  animationDuration: 500,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HoldingsMini extends StatelessWidget {
+  const _HoldingsMini({required this.holdings});
+
+  final List<PlaybackHolding> holdings;
+
+  @override
+  Widget build(BuildContext context) => Wrap(
+        spacing: 4,
+        runSpacing: 4,
+        children: holdings
+            .take(6)
+            .map(
+              (h) => Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 6, vertical: 3),
+                decoration: BoxDecoration(
+                  color: AppColors.canvas,
+                  borderRadius: BorderRadius.circular(6),
+                  border: Border.all(color: AppColors.border),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      h.ticker,
+                      style: AppTextStyles.mono(10,
+                          color: AppColors.textHi,
+                          weight: FontWeight.w700),
+                    ),
+                    if (h.qty != null)
+                      Text(
+                        '${h.qty!.toStringAsFixed(0)} sh',
+                        style: AppTextStyles.nano
+                            .copyWith(color: AppColors.textDim),
+                      ),
+                    if (h.curr != null && h.avg != null)
+                      Text(
+                        fmtMoney(h.curr),
+                        style: AppTextStyles.nano.copyWith(
+                          color: h.curr! > h.avg!
+                              ? AppColors.success
+                              : h.curr! < h.avg!
+                                  ? AppColors.danger
+                                  : AppColors.textDim,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            )
+            .toList(),
+      );
+}
+
+// ── Event stepper ─────────────────────────────────────────────────────────────
+
+class _EventStepper extends StatelessWidget {
+  const _EventStepper({
+    required this.events,
+    required this.isPlaying,
+    required this.scrollController,
+  });
+
+  final List<PlaybackEvent> events;
+  final bool isPlaying;
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: EdgeInsets.zero,
+      borderColor: AppColors.border,
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 14, vertical: 10),
+            decoration: const BoxDecoration(
+              color: AppColors.canvas,
+              borderRadius: BorderRadius.vertical(
+                  top: Radius.circular(16)),
+            ),
+            child: Row(
+              children: [
+                Text('Execution Log',
+                    style: AppTextStyles.cardTitle),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              controller: scrollController,
+              padding: const EdgeInsets.all(12),
+              itemCount: events.length + (isPlaying ? 1 : 0),
+              itemBuilder: (_, i) {
+                if (i == events.length) {
+                  // Typing indicator
+                  return const _TypingNode();
+                }
+                return _EventNode(event: events[i], index: i);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventNode extends StatelessWidget {
+  const _EventNode({required this.event, required this.index});
+
+  final PlaybackEvent event;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (event.type) {
+      case 'date':
+        return _DateMarker(event: event);
+      case 'strategy':
+        return _StrategyNode(event: event);
+      case 'outcome':
+        return _OutcomeNode(event: event);
+      case 'decision':
+        return _DecisionNode(event: event);
+      case 'portfolio':
+        return const SizedBox.shrink(); // hidden in stepper
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+class _DateMarker extends StatelessWidget {
+  const _DateMarker({required this.event});
+
+  final PlaybackEvent event;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          children: [
+            Expanded(
+                child: Divider(
+                    color: AppColors.border, thickness: 1)),
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: AppColors.fill(AppColors.primary),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(
+                    color: AppColors.stroke(AppColors.primary)),
+                boxShadow: [
+                  BoxShadow(
+                      color: AppColors.primary
+                          .withValues(alpha: 0.2),
+                      blurRadius: 10),
+                ],
+              ),
+              child: Text(
+                '${event.label ?? ''} — ${event.time ?? ''}',
+                style: AppTextStyles.nano.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w700),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+                child: Divider(
+                    color: AppColors.border, thickness: 1)),
+          ],
+        ),
+      );
+}
+
+class _StrategyNode extends StatelessWidget {
+  const _StrategyNode({required this.event});
+
+  final PlaybackEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    final desc = event.desc ?? '';
+    final parts = desc.contains(' → ') ? desc.split(' → ') : null;
+
+    return _StepRow(
+      icon: symbol('psychology'),
+      color: const Color(0xFF818CF8), // indigo-400
+      child: GlassCard(
+        padding: const EdgeInsets.all(12),
+        borderColor: const Color(0xFF818CF8).withValues(alpha: 0.2),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (parts != null) ...[
+              Row(
+                children: [
+                  Text(parts[0],
+                      style: AppTextStyles.mono(11,
+                          color: AppColors.textMd,
+                          weight: FontWeight.w700)),
+                  const SizedBox(width: 6),
+                  _ActionBadge(action: parts[1]),
+                ],
+              ),
+            ] else
+              Text(
+                desc.toUpperCase(),
+                style: AppTextStyles.nano.copyWith(
+                    color: const Color(0xFF818CF8),
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.5),
+              ),
+            const SizedBox(height: 4),
+            Text(event.name ?? '',
+                style: AppTextStyles.bodyHi),
+            if (event.reason != null &&
+                event.reason!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(event.reason!,
+                  style: AppTextStyles.meta
+                      .copyWith(color: AppColors.textDim)),
+            ],
+            if (event.tickers.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: [
+                  Text('Scanning:',
+                      style: AppTextStyles.nano.copyWith(
+                          color: AppColors.textFaint,
+                          fontWeight: FontWeight.w700)),
+                  ...event.tickers.map((t) => Container(
+                        padding:
+                            const EdgeInsets.symmetric(
+                                horizontal: 5, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: AppColors.surface,
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(
+                              color: AppColors.border),
+                        ),
+                        child: Text(t,
+                            style: AppTextStyles.mono(10,
+                                color: AppColors.textMuted)),
+                      )),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OutcomeNode extends StatelessWidget {
+  const _OutcomeNode({required this.event});
+
+  final PlaybackEvent event;
+
+  @override
+  Widget build(BuildContext context) => _StepRow(
+        icon: symbol('score'),
+        color: AppColors.info,
+        child: Container(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            border: const Border(
+                left: BorderSide(
+                    color: AppColors.info, width: 2)),
+            color: AppColors.fill(AppColors.info),
+            borderRadius: const BorderRadius.horizontal(
+                right: Radius.circular(10)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(event.name ?? '',
+                  style: AppTextStyles.bodyHi
+                      .copyWith(color: AppColors.info)),
+              if (event.details != null)
+                Text(event.details!,
+                    style: AppTextStyles.mono(10,
+                        color: AppColors.textDim)),
+            ],
+          ),
+        ),
+      );
+}
+
+class _DecisionNode extends StatelessWidget {
+  const _DecisionNode({required this.event});
+
+  final PlaybackEvent event;
+
+  @override
+  Widget build(BuildContext context) => _StepRow(
+        icon: symbol('gavel'),
+        color: AppColors.warning,
+        child: GlassCard(
+          padding: const EdgeInsets.all(12),
+          borderColor: AppColors.warning.withValues(alpha: 0.2),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('EXECUTION DECISIONS',
+                  style: AppTextStyles.nano.copyWith(
+                      color: AppColors.warning,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.5)),
+              const SizedBox(height: 8),
+              if (event.buys.isEmpty && event.sells.isEmpty)
+                Text('No actions taken.',
+                    style: AppTextStyles.meta
+                        .copyWith(color: AppColors.textDim))
+              else ...[
+                ...event.buys.map((b) => _TradeRow(
+                    trade: b, isBuy: true)),
+                ...event.sells.map((s) => _TradeRow(
+                    trade: s, isBuy: false)),
+              ],
+            ],
+          ),
+        ),
+      );
+}
+
+class _TradeRow extends StatelessWidget {
+  const _TradeRow({required this.trade, required this.isBuy});
+
+  final PlaybackTrade trade;
+  final bool isBuy;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = isBuy ? AppColors.success : AppColors.danger;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 4),
+      padding:
+          const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppColors.fill(c),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.stroke(c)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+            decoration: BoxDecoration(
+              color: AppColors.fill(c).withValues(alpha: 0.3),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(isBuy ? 'Buy' : 'Sell',
+                style: AppTextStyles.nano.copyWith(
+                    color: c, fontWeight: FontWeight.w700)),
+          ),
+          const SizedBox(width: 8),
+          Text(trade.ticker ?? '?',
+              style: AppTextStyles.mono(12,
+                  color: AppColors.textHi,
+                  weight: FontWeight.w700)),
+          const SizedBox(width: 6),
+          Text(
+            '${trade.qty != null ? trade.qty!.toStringAsFixed(0) : '?'} @ ${fmtMoney(trade.price)}',
+            style: AppTextStyles.meta
+                .copyWith(color: AppColors.textDim),
+          ),
+          const Spacer(),
+          if (trade.reason != null)
+            Flexible(
+              child: Text(
+                trade.reason!,
+                style: AppTextStyles.nano
+                    .copyWith(color: AppColors.textFaint),
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepRow extends StatelessWidget {
+  const _StepRow({
+    required this.icon,
+    required this.color,
+    required this.child,
+  });
+
+  final IconData icon;
+  final Color color;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Column(
+              children: [
+                Container(
+                  width: 30,
+                  height: 30,
+                  decoration: BoxDecoration(
+                    color: AppColors.fill(color),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                        color: AppColors.stroke(color)),
+                    boxShadow: [
+                      BoxShadow(
+                          color: color.withValues(alpha: 0.25),
+                          blurRadius: 8),
+                    ],
+                  ),
+                  child: Icon(icon, color: color, size: 14),
+                ),
+              ],
+            ),
+            const SizedBox(width: 8),
+            Expanded(child: child),
+          ],
+        ),
+      );
+}
+
+class _TypingNode extends StatelessWidget {
+  const _TypingNode();
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Row(
+          children: [
+            Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                color: AppColors.fill(AppColors.border),
+                shape: BoxShape.circle,
+                border: Border.all(color: AppColors.border),
+              ),
+              child: const Icon(Icons.more_horiz,
+                  color: AppColors.textFaint, size: 14),
+            ),
+            const SizedBox(width: 8),
+            const SizedBox(
+              width: 80,
+              height: 28,
+              // The "loading bar" placeholder (no animation to avoid State)
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius:
+                        BorderRadius.all(Radius.circular(10))),
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
+class _ActionBadge extends StatelessWidget {
+  const _ActionBadge({required this.action});
+
+  final String action;
+
+  @override
+  Widget build(BuildContext context) {
+    Color c;
+    switch (action.toUpperCase()) {
+      case 'BUY':
+        c = AppColors.success;
+        break;
+      case 'SELL':
+        c = AppColors.danger;
+        break;
+      default:
+        c = AppColors.textMuted;
+    }
+    return Container(
+      padding:
+          const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.fill(c),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppColors.stroke(c)),
+      ),
+      child: Text(action.toUpperCase(),
+          style: AppTextStyles.nano
+              .copyWith(color: c, fontWeight: FontWeight.w700)),
+    );
+  }
+}
+
+// ── Playback skeleton ─────────────────────────────────────────────────────────
+
+class _PlaybackSkeleton extends StatelessWidget {
+  const _PlaybackSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Top header bar
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+          child: Row(
+            children: [
+              Skeleton(width: 32, height: 32, radius: 8),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Skeleton(width: 160, height: 16, radius: 6),
+                    const SizedBox(height: 4),
+                    Skeleton(width: 90, height: 10, radius: 4),
+                  ],
+                ),
+              ),
+              Skeleton(width: 80, height: 28, radius: 10),
+              const SizedBox(width: 8),
+              Skeleton(width: 88, height: 32, radius: 12),
+            ],
+          ),
+        ),
+        // Main area
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+            child: Column(
+              children: [
+                // Portfolio panel skeleton
+                GlassCard(
+                  padding: const EdgeInsets.all(14),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Skeleton.line(width: 110, height: 10),
+                                const SizedBox(height: 6),
+                                Skeleton(width: 150, height: 22, radius: 6),
+                              ],
+                            ),
+                          ),
+                          // Holdings mini chips
+                          Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: List.generate(
+                              3,
+                              (_) => Skeleton(
+                                  width: 46, height: 42, radius: 6),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      // Chart block
+                      Skeleton(height: 150, radius: 8),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 10),
+                // Event log skeleton
+                Expanded(
+                  child: GlassCard(
+                    padding: EdgeInsets.zero,
+                    borderColor: AppColors.border,
+                    child: Column(
+                      children: [
+                        // Log header
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 14, vertical: 10),
+                          decoration: const BoxDecoration(
+                            color: AppColors.canvas,
+                            borderRadius: BorderRadius.vertical(
+                                top: Radius.circular(16)),
+                          ),
+                          child: Skeleton.line(width: 100, height: 14),
+                        ),
+                        // Skeleton event rows
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.all(12),
+                            child: Column(
+                              children: List.generate(
+                                5,
+                                (i) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 10),
+                                  child: Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Skeleton.circle(30),
+                                      const SizedBox(width: 8),
+                                      Expanded(
+                                        child: Skeleton(
+                                          height: 44 + (i % 2) * 14.0,
+                                          radius: 10,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Error / empty ─────────────────────────────────────────────────────────────
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onBack});
+
+  final String message;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(symbol('error'), color: AppColors.danger, size: 48),
+              const SizedBox(height: 12),
+              Text('Failed to load playback',
+                  style: AppTextStyles.cardTitle),
+              const SizedBox(height: 6),
+              Text(message,
+                  style: AppTextStyles.meta
+                      .copyWith(color: AppColors.textDim),
+                  textAlign: TextAlign.center),
+              const SizedBox(height: 20),
+              TextButton.icon(
+                onPressed: onBack,
+                icon: Icon(symbol('arrow_back'),
+                    color: AppColors.textMuted, size: 16),
+                label: Text('Back to Backtest',
+                    style: AppTextStyles.body
+                        .copyWith(color: AppColors.textMuted)),
+              ),
+            ],
+          ),
+        ),
+      );
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(symbol('play_disabled'),
+                  color: AppColors.textFaint, size: 48),
+              const SizedBox(height: 12),
+              Text('No playback data',
+                  style: AppTextStyles.cardTitle),
+              const SizedBox(height: 6),
+              Text(
+                'This backtest has no portfolio snapshots or trades to replay.',
+                style: AppTextStyles.meta
+                    .copyWith(color: AppColors.textDim),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              TextButton.icon(
+                onPressed: onBack,
+                icon: Icon(symbol('arrow_back'),
+                    color: AppColors.textMuted, size: 16),
+                label: Text('Back to Backtest',
+                    style: AppTextStyles.body
+                        .copyWith(color: AppColors.textMuted)),
+              ),
+            ],
+          ),
+        ),
+      );
+}

--- a/mobile/lib/features/backtests/presentation/backtests_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtests_screen.dart
@@ -1,0 +1,808 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/formatters/formatters.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/common_widgets.dart';
+import '../../../core/widgets/glass_card.dart';
+import '../../../core/widgets/status_pill.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/confirm_dialog.dart';
+import '../../../core/widgets/material_symbols.dart';
+import '../../../core/widgets/skeleton.dart';
+import '../application/backtests_list_controller.dart';
+import '../data/models/backtest.dart';
+
+const _perPageOptions = [10, 15, 25, 50, 100];
+
+class BacktestsScreen extends ConsumerWidget {
+  const BacktestsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(backtestsListControllerProvider);
+    final ctrl = ref.read(backtestsListControllerProvider.notifier);
+
+    return Scaffold(
+      backgroundColor: AppColors.canvas,
+      body: SafeArea(
+        child: RefreshIndicator(
+          color: AppColors.primary,
+          backgroundColor: AppColors.surface,
+          onRefresh: ctrl.refresh,
+          child: CustomScrollView(
+            slivers: [
+              // ── Header ──────────────────────────────────────────────────────
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding:
+                      const EdgeInsets.fromLTRB(16, 20, 16, 0),
+                  child: Row(
+                    children: [
+                      IconTile(
+                          icon: symbol('analytics'),
+                          color: AppColors.primary),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment:
+                              CrossAxisAlignment.start,
+                          children: [
+                            Text('All Backtests',
+                                style: AppTextStyles.h2),
+                            Text(
+                              '${s.total} total',
+                              style: AppTextStyles.meta
+                                  .copyWith(
+                                      color: AppColors.textDim),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: s.loading
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                    strokeWidth: 2),
+                              )
+                            : Icon(symbol('refresh'),
+                                color: AppColors.textMuted),
+                        onPressed: s.loading
+                            ? null
+                            : ctrl.refresh,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+              // ── Toolbar ─────────────────────────────────────────────────────
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding:
+                      const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Row(
+                    children: [
+                      Text(
+                        'Backtests (${s.total})',
+                        style: AppTextStyles.eyebrow,
+                      ),
+                      const Spacer(),
+                      Text('Per page  ',
+                          style: AppTextStyles.meta
+                              .copyWith(color: AppColors.textDim)),
+                      _PerPageSelector(
+                        value: s.perPage,
+                        onChanged: ctrl.setPerPage,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+              // ── Loading (initial) ───────────────────────────────────────────
+              if (s.loading && s.rows.isEmpty)
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 8),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (_, __) => const _BacktestCardSkeleton(),
+                      childCount: 5,
+                    ),
+                  ),
+                ),
+
+              // ── Error ────────────────────────────────────────────────────────
+              if (!s.loading && s.error != null && s.rows.isEmpty)
+                SliverFillRemaining(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.all(16),
+                    child: ErrorBanner(
+                        message: s.error!,
+                        onRetry: ctrl.refresh),
+                  ),
+                ),
+
+              // ── Empty ────────────────────────────────────────────────────────
+              if (!s.loading && s.rows.isEmpty && s.error == null)
+                SliverFillRemaining(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.all(24),
+                    child: EmptyState(
+                      icon: symbol('analytics'),
+                      title: 'No backtests found',
+                      subtitle: 'Run a backtest to see results here.',
+                    ),
+                  ),
+                ),
+
+              // ── Cards ─────────────────────────────────────────────────────────
+              if (s.rows.isNotEmpty)
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 8),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (context, i) {
+                        final bt = s.rows[i];
+                        final live = s.statusMap[bt.id];
+                        return _BacktestCard(
+                          key: ValueKey(bt.id),
+                          bt: bt,
+                          liveStatus: live,
+                          onAction: (action) => _doAction(
+                              context, ref, bt, action),
+                          onView: () => context
+                              .push('/backtests/${bt.id}'),
+                          onInstanceTap: bt.instanceId != null
+                              ? () => context.push(
+                                  '/instances/${bt.instanceId}')
+                              : null,
+                        );
+                      },
+                      childCount: s.rows.length,
+                    ),
+                  ),
+                ),
+
+              // ── Pagination ───────────────────────────────────────────────────
+              if (s.rows.isNotEmpty)
+                SliverToBoxAdapter(
+                  child: _Pagination(
+                    page: s.page,
+                    totalPages: s.totalPages,
+                    total: s.total,
+                    loading: s.loading,
+                    onPage: ctrl.goToPage,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _doAction(
+    BuildContext context,
+    WidgetRef ref,
+    BacktestRow bt,
+    String action,
+  ) async {
+    final meta = _actionMeta(action);
+    await showConfirmDialog(
+      context,
+      title: '${meta.$1} Backtest',
+      body: '${meta.$2}\n\nBacktest ID: ${bt.id}',
+      confirmLabel: meta.$1,
+      confirmColor: meta.$3,
+      icon: symbol(meta.$4),
+      onConfirm: () async {
+        final err = await ref
+            .read(backtestsListControllerProvider.notifier)
+            .performAction(bt.id, action);
+        if (err != null) throw Exception(err);
+      },
+    );
+  }
+
+  static (String, String, Color, String) _actionMeta(String action) {
+    switch (action) {
+      case 'pause':
+        return (
+          'Pause',
+          'The backtest will be paused and can be resumed later.',
+          AppColors.primary,
+          'pause_circle'
+        );
+      case 'resume':
+        return (
+          'Resume',
+          'The backtest will continue from where it was paused.',
+          AppColors.info,
+          'play_circle'
+        );
+      case 'stop':
+      default:
+        return (
+          'Stop',
+          'This will permanently stop the backtest.',
+          AppColors.danger,
+          'stop_circle'
+        );
+    }
+  }
+}
+
+// ── Backtest Card Skeleton ────────────────────────────────────────────────────
+
+class _BacktestCardSkeleton extends StatelessWidget {
+  const _BacktestCardSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: GlassCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ID line + status pill
+            Row(
+              children: [
+                Expanded(child: Skeleton.line(height: 11)),
+                const SizedBox(width: 12),
+                Skeleton(width: 72, height: 20, radius: 999),
+              ],
+            ),
+            const SizedBox(height: 10),
+            // Stock chips row
+            Row(
+              children: [
+                Skeleton(width: 44, height: 20, radius: 4),
+                const SizedBox(width: 6),
+                Skeleton(width: 44, height: 20, radius: 4),
+                const SizedBox(width: 6),
+                Skeleton(width: 44, height: 20, radius: 4),
+                const SizedBox(width: 6),
+                Skeleton(width: 30, height: 20, radius: 4),
+              ],
+            ),
+            const SizedBox(height: 10),
+            // Period line
+            Skeleton.line(width: 180, height: 11),
+            const SizedBox(height: 6),
+            // Completed-at line
+            Skeleton.line(width: 120, height: 10),
+            const SizedBox(height: 12),
+            // Elapsed + P&L row
+            Row(
+              children: [
+                Skeleton(width: 80, height: 12, radius: 4),
+                const Spacer(),
+                Skeleton(width: 70, height: 14, radius: 4),
+                const SizedBox(width: 8),
+                Skeleton(width: 50, height: 12, radius: 4),
+              ],
+            ),
+            const SizedBox(height: 12),
+            // Action buttons row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Skeleton(width: 70, height: 30, radius: 8),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Backtest Card ─────────────────────────────────────────────────────────────
+
+class _BacktestCard extends StatelessWidget {
+  const _BacktestCard({
+    super.key,
+    required this.bt,
+    this.liveStatus,
+    required this.onAction,
+    required this.onView,
+    this.onInstanceTap,
+  });
+
+  final BacktestRow bt;
+  final BacktestStatus? liveStatus;
+  final void Function(String action) onAction;
+  final VoidCallback onView;
+  final VoidCallback? onInstanceTap;
+
+  String get _status =>
+      liveStatus?.status ?? bt.status ?? 'queued';
+
+  num? get _progress => liveStatus?.progress;
+  NexusLookback? get _lookback => liveStatus?.nexusLookback;
+  num? get _elapsed =>
+      liveStatus?.timeElapsedSeconds ?? bt.timeElapsedSeconds;
+
+  bool get _isActive {
+    final s = _status.toLowerCase();
+    return s == 'running' || s == 'queued' || s == 'pending';
+  }
+
+  bool get _isPaused {
+    final s = _status.toLowerCase();
+    return s == 'paused' || s == 'paused_llm_critical';
+  }
+
+  bool get _canStop => _isActive || _isPaused;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: GlassCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Top row: ID + status ────────────────────────────────────────
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    bt.id,
+                    style: AppTextStyles.mono(12,
+                        color: AppColors.textMuted),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                StatusPill(
+                  label: _status.toUpperCase(),
+                  color: StatusPill.colorForStatus(_status),
+                  pulsing: _isActive,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            // ── Instance link ───────────────────────────────────────────────
+            if (bt.instanceId != null)
+              GestureDetector(
+                onTap: onInstanceTap,
+                child: Text(
+                  bt.instanceId!,
+                  style: AppTextStyles.meta.copyWith(
+                    color: AppColors.primary,
+                    decoration: TextDecoration.underline,
+                    decorationColor: AppColors.primary,
+                  ),
+                ),
+              ),
+
+            // ── Stock chips ─────────────────────────────────────────────────
+            if (bt.stocks.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  ...bt.stocks.take(4).map((s) => Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: AppColors.surface,
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(color: AppColors.border),
+                        ),
+                        child: Text(
+                          s,
+                          style: AppTextStyles.mono(11,
+                              color: AppColors.textMd),
+                        ),
+                      )),
+                  if (bt.stocks.length > 4)
+                    Text(
+                      '+${bt.stocks.length - 4}',
+                      style: AppTextStyles.meta
+                          .copyWith(color: AppColors.textFaint),
+                    ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 8),
+
+            // ── Period ──────────────────────────────────────────────────────
+            Text(
+              '${bt.startDate ?? '?'} → ${bt.endDate ?? '?'}',
+              style: AppTextStyles.meta
+                  .copyWith(color: AppColors.textDim),
+            ),
+
+            // ── Completed at ────────────────────────────────────────────────
+            if (bt.completedAt != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  fmtDateTime(bt.completedAt),
+                  style: AppTextStyles.mono(11,
+                      color: AppColors.textMuted),
+                ),
+              ),
+            const SizedBox(height: 8),
+
+            // ── Progress bar (running) ──────────────────────────────────────
+            if (_isActive && _progress != null) ...[
+              Row(
+                children: [
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value:
+                            (_progress!.toDouble() / 100).clamp(0, 1),
+                        backgroundColor: AppColors.surface,
+                        valueColor: const AlwaysStoppedAnimation(
+                            AppColors.info),
+                        minHeight: 6,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${_progress!.round()}%',
+                    style: AppTextStyles.mono(10,
+                        color: AppColors.textDim),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+            ],
+
+            // ── Nexus lookback bar ──────────────────────────────────────────
+            if (_lookback != null) ...[
+              Row(
+                children: [
+                  Icon(symbol('hub'),
+                      color: AppColors.primary, size: 12),
+                  const SizedBox(width: 4),
+                  Text('Lookback',
+                      style: AppTextStyles.nano.copyWith(
+                          color: AppColors.primary,
+                          fontWeight: FontWeight.w600)),
+                  const Spacer(),
+                  Text(
+                    '${_lookback!.current}/${_lookback!.total}d',
+                    style: AppTextStyles.mono(10,
+                        color: AppColors.textDim),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: _lookback!.fraction.clamp(0, 1),
+                  backgroundColor: AppColors.surface,
+                  valueColor: AlwaysStoppedAnimation(
+                      AppColors.primary.withValues(alpha: 0.7)),
+                  minHeight: 6,
+                ),
+              ),
+              const SizedBox(height: 6),
+            ],
+
+            // ── Elapsed + P&L row ───────────────────────────────────────────
+            Row(
+              children: [
+                Icon(symbol('timer'),
+                    color: AppColors.textFaint, size: 14),
+                const SizedBox(width: 4),
+                Text(
+                  fmtElapsed(_elapsed),
+                  style: AppTextStyles.mono(12,
+                      color: AppColors.textMuted),
+                ),
+                const Spacer(),
+                Text(
+                  fmtPnl(bt.pnl),
+                  style: AppTextStyles.mono(13,
+                      color: pnlColor(bt.pnl),
+                      weight: FontWeight.w700),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  bt.pnlPercent != null
+                      ? fmtPct(bt.pnlPercent)
+                      : '—',
+                  style: AppTextStyles.mono(11,
+                      color: pnlColor(bt.pnlPercent)),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+
+            // ── Action buttons ──────────────────────────────────────────────
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (_isActive)
+                  _ActionBtn(
+                    icon: symbol('pause_circle'),
+                    color: AppColors.primary,
+                    tooltip: 'Pause',
+                    onTap: () => onAction('pause'),
+                  ),
+                if (_isPaused)
+                  _ActionBtn(
+                    icon: symbol('play_circle'),
+                    color: AppColors.info,
+                    tooltip: 'Resume',
+                    onTap: () => onAction('resume'),
+                  ),
+                if (_canStop)
+                  _ActionBtn(
+                    icon: symbol('stop_circle'),
+                    color: AppColors.danger,
+                    tooltip: 'Stop',
+                    onTap: () => onAction('stop'),
+                  ),
+                const SizedBox(width: 4),
+                AppButton.primary(
+                  label: 'View',
+                  icon: symbol('open_in_new'),
+                  onPressed: onView,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionBtn extends StatelessWidget {
+  const _ActionBtn({
+    required this.icon,
+    required this.color,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => Tooltip(
+        message: tooltip,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.all(6),
+            child: Icon(icon, color: color, size: 22),
+          ),
+        ),
+      );
+}
+
+// ── Per-page selector ──────────────────────────────────────────────────────────
+
+class _PerPageSelector extends StatelessWidget {
+  const _PerPageSelector(
+      {required this.value, required this.onChanged});
+
+  final int value;
+  final void Function(int) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: value,
+          dropdownColor: AppColors.panel,
+          style: AppTextStyles.meta.copyWith(color: AppColors.textMd),
+          isDense: true,
+          items: _perPageOptions
+              .map((o) => DropdownMenuItem(
+                    value: o,
+                    child: Text('$o'),
+                  ))
+              .toList(),
+          onChanged: (v) {
+            if (v != null) onChanged(v);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+class _Pagination extends StatelessWidget {
+  const _Pagination({
+    required this.page,
+    required this.totalPages,
+    required this.total,
+    required this.loading,
+    required this.onPage,
+  });
+
+  final int page;
+  final int totalPages;
+  final int total;
+  final bool loading;
+  final void Function(int) onPage;
+
+  @override
+  Widget build(BuildContext context) {
+    if (totalPages <= 1) return const SizedBox(height: 16);
+    final pages = _buildPages(page, totalPages);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 24),
+      child: Column(
+        children: [
+          Text(
+            'Page $page of $totalPages  ($total total)',
+            style: AppTextStyles.meta
+                .copyWith(color: AppColors.textDim),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _NavBtn(
+                icon: Icons.chevron_left,
+                enabled: page > 1 && !loading,
+                onTap: () => onPage(page - 1),
+              ),
+              const SizedBox(width: 4),
+              ...pages.map((p) {
+                if (p == null) {
+                  return Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 2),
+                    child: Text('…',
+                        style: AppTextStyles.meta
+                            .copyWith(color: AppColors.textFaint)),
+                  );
+                }
+                final active = p == page;
+                return _PageBtn(
+                  page: p,
+                  active: active,
+                  disabled: loading,
+                  onTap: () => onPage(p),
+                );
+              }),
+              const SizedBox(width: 4),
+              _NavBtn(
+                icon: Icons.chevron_right,
+                enabled: page < totalPages && !loading,
+                onTap: () => onPage(page + 1),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Returns page numbers with nulls for ellipsis gaps.
+  static List<int?> _buildPages(int current, int total) {
+    if (total <= 7) {
+      return List<int?>.generate(total, (i) => i + 1);
+    }
+    final result = <int?>{};
+    result.add(1);
+    result.add(total);
+    for (int p = current - 1; p <= current + 1; p++) {
+      if (p >= 1 && p <= total) result.add(p);
+    }
+    final sorted = result.toList()..sort((a, b) => a! - b!);
+    final out = <int?>[];
+    for (int i = 0; i < sorted.length; i++) {
+      if (i > 0 && sorted[i]! - sorted[i - 1]! > 1) {
+        out.add(null); // ellipsis
+      }
+      out.add(sorted[i]);
+    }
+    return out;
+  }
+}
+
+class _NavBtn extends StatelessWidget {
+  const _NavBtn(
+      {required this.icon,
+      required this.enabled,
+      required this.onTap});
+
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => InkWell(
+        onTap: enabled ? onTap : null,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            border: Border.all(color: AppColors.border),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(icon,
+              color: enabled ? AppColors.textMuted : AppColors.textFaint,
+              size: 18),
+        ),
+      );
+}
+
+class _PageBtn extends StatelessWidget {
+  const _PageBtn({
+    required this.page,
+    required this.active,
+    required this.disabled,
+    required this.onTap,
+  });
+
+  final int page;
+  final bool active;
+  final bool disabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        child: InkWell(
+          onTap: disabled ? null : onTap,
+          borderRadius: BorderRadius.circular(8),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: active
+                  ? AppColors.fill(AppColors.primary)
+                  : Colors.transparent,
+              border: Border.all(
+                  color: active
+                      ? AppColors.stroke(AppColors.primary)
+                      : Colors.transparent),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '$page',
+              style: AppTextStyles.meta.copyWith(
+                color:
+                    active ? AppColors.primary : AppColors.textMuted,
+                fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/mobile/lib/features/backtests/presentation/backtests_screen.dart
+++ b/mobile/lib/features/backtests/presentation/backtests_screen.dart
@@ -7,7 +7,6 @@ import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/common_widgets.dart';
 import '../../../core/widgets/glass_card.dart';
 import '../../../core/widgets/status_pill.dart';
-import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/confirm_dialog.dart';
 import '../../../core/widgets/material_symbols.dart';
 import '../../../core/widgets/skeleton.dart';
@@ -347,224 +346,267 @@ class _BacktestCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final pnlC = pnlColor(bt.pnl);
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: GlassCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // ── Top row: ID + status ────────────────────────────────────────
-            Row(
+        padding: EdgeInsets.zero,
+        // Tap anywhere on the card to open it (replaces the bulky View button).
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onView,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(
-                  child: Text(
-                    bt.id,
-                    style: AppTextStyles.mono(12,
-                        color: AppColors.textMuted),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                StatusPill(
-                  label: _status.toUpperCase(),
-                  color: StatusPill.colorForStatus(_status),
-                  pulsing: _isActive,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-
-            // ── Instance link ───────────────────────────────────────────────
-            if (bt.instanceId != null)
-              GestureDetector(
-                onTap: onInstanceTap,
-                child: Text(
-                  bt.instanceId!,
-                  style: AppTextStyles.meta.copyWith(
-                    color: AppColors.primary,
-                    decoration: TextDecoration.underline,
-                    decorationColor: AppColors.primary,
-                  ),
-                ),
-              ),
-
-            // ── Stock chips ─────────────────────────────────────────────────
-            if (bt.stocks.isNotEmpty) ...[
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 6,
-                runSpacing: 4,
-                children: [
-                  ...bt.stocks.take(4).map((s) => Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 6, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: AppColors.surface,
-                          borderRadius: BorderRadius.circular(4),
-                          border: Border.all(color: AppColors.border),
-                        ),
-                        child: Text(
-                          s,
-                          style: AppTextStyles.mono(11,
-                              color: AppColors.textMd),
-                        ),
-                      )),
-                  if (bt.stocks.length > 4)
-                    Text(
-                      '+${bt.stocks.length - 4}',
-                      style: AppTextStyles.meta
-                          .copyWith(color: AppColors.textFaint),
-                    ),
-                ],
-              ),
-            ],
-            const SizedBox(height: 8),
-
-            // ── Period ──────────────────────────────────────────────────────
-            Text(
-              '${bt.startDate ?? '?'} → ${bt.endDate ?? '?'}',
-              style: AppTextStyles.meta
-                  .copyWith(color: AppColors.textDim),
-            ),
-
-            // ── Completed at ────────────────────────────────────────────────
-            if (bt.completedAt != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Text(
-                  fmtDateTime(bt.completedAt),
-                  style: AppTextStyles.mono(11,
-                      color: AppColors.textMuted),
-                ),
-              ),
-            const SizedBox(height: 8),
-
-            // ── Progress bar (running) ──────────────────────────────────────
-            if (_isActive && _progress != null) ...[
-              Row(
-                children: [
-                  Expanded(
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(4),
-                      child: LinearProgressIndicator(
-                        value:
-                            (_progress!.toDouble() / 100).clamp(0, 1),
-                        backgroundColor: AppColors.surface,
-                        valueColor: const AlwaysStoppedAnimation(
-                            AppColors.info),
-                        minHeight: 6,
+                // ── Header: instance / id + status ──────────────────────────
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (bt.instanceId != null)
+                            GestureDetector(
+                              onTap: onInstanceTap,
+                              child: Text(
+                                bt.instanceId!,
+                                style: AppTextStyles.bodyHi
+                                    .copyWith(color: AppColors.primary),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            )
+                          else
+                            Text('Backtest',
+                                style: AppTextStyles.bodyHi
+                                    .copyWith(color: AppColors.textHi)),
+                          const SizedBox(height: 2),
+                          Text(
+                            '#${bt.id}',
+                            style: AppTextStyles.mono(11,
+                                color: AppColors.textFaint),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    '${_progress!.round()}%',
-                    style: AppTextStyles.mono(10,
-                        color: AppColors.textDim),
+                    const SizedBox(width: 8),
+                    StatusPill(
+                      label: _status.toUpperCase(),
+                      color: StatusPill.colorForStatus(_status),
+                      pulsing: _isActive,
+                    ),
+                  ],
+                ),
+
+                // ── Stock chips ─────────────────────────────────────────────
+                if (bt.stocks.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      ...bt.stocks.take(4).map((s) => Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 7, vertical: 3),
+                            decoration: BoxDecoration(
+                              color: AppColors.surface,
+                              borderRadius: BorderRadius.circular(6),
+                              border: Border.all(color: AppColors.border),
+                            ),
+                            child: Text(
+                              s,
+                              style: AppTextStyles.mono(11,
+                                  color: AppColors.textMd),
+                            ),
+                          )),
+                      if (bt.stocks.length > 4)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 7, vertical: 3),
+                          child: Text(
+                            '+${bt.stocks.length - 4}',
+                            style: AppTextStyles.meta
+                                .copyWith(color: AppColors.textFaint),
+                          ),
+                        ),
+                    ],
                   ),
                 ],
-              ),
-              const SizedBox(height: 6),
-            ],
 
-            // ── Nexus lookback bar ──────────────────────────────────────────
-            if (_lookback != null) ...[
-              Row(
-                children: [
-                  Icon(symbol('hub'),
-                      color: AppColors.primary, size: 12),
-                  const SizedBox(width: 4),
-                  Text('Lookback',
-                      style: AppTextStyles.nano.copyWith(
+                const SizedBox(height: 14),
+
+                // ── P&L (emphasised, left) + open hint ──────────────────────
+                Row(
+                  children: [
+                    Expanded(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.baseline,
+                        textBaseline: TextBaseline.alphabetic,
+                        children: [
+                          Flexible(
+                            child: Text(
+                              bt.pnl != null ? fmtPnl(bt.pnl) : '—',
+                              style: AppTextStyles.valueLg.copyWith(color: pnlC),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (bt.pnlPercent != null) ...[
+                            const SizedBox(width: 8),
+                            Text(
+                              fmtPct(bt.pnlPercent),
+                              style: AppTextStyles.meta.copyWith(
+                                  color: pnlC, fontWeight: FontWeight.w600),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Container(
+                      width: 32,
+                      height: 32,
+                      decoration: BoxDecoration(
+                        color: AppColors.fill(AppColors.primary),
+                        borderRadius: BorderRadius.circular(8),
+                        border:
+                            Border.all(color: AppColors.stroke(AppColors.primary)),
+                      ),
+                      child: Icon(symbol('arrow_forward'),
+                          size: 16, color: AppColors.primary),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 10),
+                const Divider(color: AppColors.border, height: 1),
+                const SizedBox(height: 10),
+
+                // ── Meta line: period + elapsed ─────────────────────────────
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '${bt.startDate ?? '?'} → ${bt.endDate ?? '?'}',
+                        style: AppTextStyles.meta
+                            .copyWith(color: AppColors.textDim),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Icon(symbol('timer'),
+                        color: AppColors.textFaint, size: 13),
+                    const SizedBox(width: 4),
+                    Text(
+                      fmtElapsed(_elapsed),
+                      style: AppTextStyles.mono(11, color: AppColors.textMuted),
+                    ),
+                  ],
+                ),
+                if (bt.completedAt != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    'Completed ${fmtDateTime(bt.completedAt)}',
+                    style: AppTextStyles.nano.copyWith(color: AppColors.textFaint),
+                  ),
+                ],
+
+                // ── Progress bar (running) ──────────────────────────────────
+                if (_isActive && _progress != null) ...[
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: (_progress!.toDouble() / 100).clamp(0, 1),
+                            backgroundColor: AppColors.surface,
+                            valueColor:
+                                const AlwaysStoppedAnimation(AppColors.info),
+                            minHeight: 6,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '${_progress!.round()}%',
+                        style: AppTextStyles.mono(10, color: AppColors.textDim),
+                      ),
+                    ],
+                  ),
+                ],
+
+                // ── Nexus lookback bar ──────────────────────────────────────
+                if (_lookback != null) ...[
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Icon(symbol('hub'), color: AppColors.primary, size: 12),
+                      const SizedBox(width: 4),
+                      Text('Lookback',
+                          style: AppTextStyles.nano.copyWith(
+                              color: AppColors.primary,
+                              fontWeight: FontWeight.w600)),
+                      const Spacer(),
+                      Text(
+                        '${_lookback!.current}/${_lookback!.total}d',
+                        style: AppTextStyles.mono(10, color: AppColors.textDim),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: _lookback!.fraction.clamp(0, 1),
+                      backgroundColor: AppColors.surface,
+                      valueColor: AlwaysStoppedAnimation(
+                          AppColors.primary.withValues(alpha: 0.7)),
+                      minHeight: 6,
+                    ),
+                  ),
+                ],
+
+                // ── Lifecycle controls (only when running / paused) ─────────
+                if (_canStop) ...[
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      if (_isActive)
+                        _ActionBtn(
+                          icon: symbol('pause_circle'),
                           color: AppColors.primary,
-                          fontWeight: FontWeight.w600)),
-                  const Spacer(),
-                  Text(
-                    '${_lookback!.current}/${_lookback!.total}d',
-                    style: AppTextStyles.mono(10,
-                        color: AppColors.textDim),
+                          tooltip: 'Pause',
+                          onTap: () => onAction('pause'),
+                        ),
+                      if (_isPaused)
+                        _ActionBtn(
+                          icon: symbol('play_circle'),
+                          color: AppColors.info,
+                          tooltip: 'Resume',
+                          onTap: () => onAction('resume'),
+                        ),
+                      if (_canStop)
+                        _ActionBtn(
+                          icon: symbol('stop_circle'),
+                          color: AppColors.danger,
+                          tooltip: 'Stop',
+                          onTap: () => onAction('stop'),
+                        ),
+                    ],
                   ),
                 ],
-              ),
-              const SizedBox(height: 4),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(4),
-                child: LinearProgressIndicator(
-                  value: _lookback!.fraction.clamp(0, 1),
-                  backgroundColor: AppColors.surface,
-                  valueColor: AlwaysStoppedAnimation(
-                      AppColors.primary.withValues(alpha: 0.7)),
-                  minHeight: 6,
-                ),
-              ),
-              const SizedBox(height: 6),
-            ],
-
-            // ── Elapsed + P&L row ───────────────────────────────────────────
-            Row(
-              children: [
-                Icon(symbol('timer'),
-                    color: AppColors.textFaint, size: 14),
-                const SizedBox(width: 4),
-                Text(
-                  fmtElapsed(_elapsed),
-                  style: AppTextStyles.mono(12,
-                      color: AppColors.textMuted),
-                ),
-                const Spacer(),
-                Text(
-                  fmtPnl(bt.pnl),
-                  style: AppTextStyles.mono(13,
-                      color: pnlColor(bt.pnl),
-                      weight: FontWeight.w700),
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  bt.pnlPercent != null
-                      ? fmtPct(bt.pnlPercent)
-                      : '—',
-                  style: AppTextStyles.mono(11,
-                      color: pnlColor(bt.pnlPercent)),
-                ),
               ],
             ),
-            const SizedBox(height: 12),
-
-            // ── Action buttons ──────────────────────────────────────────────
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (_isActive)
-                  _ActionBtn(
-                    icon: symbol('pause_circle'),
-                    color: AppColors.primary,
-                    tooltip: 'Pause',
-                    onTap: () => onAction('pause'),
-                  ),
-                if (_isPaused)
-                  _ActionBtn(
-                    icon: symbol('play_circle'),
-                    color: AppColors.info,
-                    tooltip: 'Resume',
-                    onTap: () => onAction('resume'),
-                  ),
-                if (_canStop)
-                  _ActionBtn(
-                    icon: symbol('stop_circle'),
-                    color: AppColors.danger,
-                    tooltip: 'Stop',
-                    onTap: () => onAction('stop'),
-                  ),
-                const SizedBox(width: 4),
-                AppButton.primary(
-                  label: 'View',
-                  icon: symbol('open_in_new'),
-                  onPressed: onView,
-                ),
-              ],
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/chatbot/data/models/chat.dart
+++ b/mobile/lib/features/chatbot/data/models/chat.dart
@@ -169,13 +169,21 @@ class Conversation {
             .toList()
         : const [];
 
+    // The backend stores this under `settings.auto_confirm_safe_tools`; some
+    // responses may also carry it at the top level. Check both.
+    final settings = j['settings'];
+    final autoConfirm = j['auto_confirm_safe_tools'] is bool
+        ? j['auto_confirm_safe_tools'] as bool
+        : (settings is Map && settings['auto_confirm_safe_tools'] is bool
+            ? settings['auto_confirm_safe_tools'] as bool
+            : false);
+
     return Conversation(
       id: (j['id'] ?? '').toString(),
       title: j['title']?.toString(),
       modelId: j['model_id']?.toString(),
       modelName: j['model_name']?.toString(),
-      autoConfirmSafeTools:
-          j['auto_confirm_safe_tools'] == true,
+      autoConfirmSafeTools: autoConfirm,
       messages: messages,
       messageCount: (j['message_count'] as num?)?.toInt() ?? messages.length,
     );

--- a/mobile/lib/features/chatbot/presentation/chat_message.dart
+++ b/mobile/lib/features/chatbot/presentation/chat_message.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../data/models/chat.dart';
@@ -170,8 +171,9 @@ class _Bubble extends StatelessWidget {
   }
 }
 
-/// For assistant messages, prefer rendering markdown if there are markdown
-/// blocks in message.blocks; otherwise render as plain text.
+/// Renders assistant message text as markdown (bold, italics, lists, headings,
+/// inline code / code blocks, links, blockquotes). Mirrors the styleSheet used
+/// for `markdown` rich blocks so inline prose and blocks look consistent.
 class _RichText extends StatelessWidget {
   const _RichText({required this.content, required this.textColor});
   final String content;
@@ -179,9 +181,36 @@ class _RichText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      content,
-      style: AppTextStyles.body.copyWith(color: textColor),
+    return MarkdownBody(
+      data: content,
+      selectable: false,
+      styleSheet: MarkdownStyleSheet(
+        p: AppTextStyles.body.copyWith(color: textColor),
+        pPadding: EdgeInsets.zero,
+        strong: AppTextStyles.body
+            .copyWith(color: textColor, fontWeight: FontWeight.w700),
+        em: AppTextStyles.body
+            .copyWith(color: textColor, fontStyle: FontStyle.italic),
+        listBullet: AppTextStyles.body.copyWith(color: textColor),
+        code: AppTextStyles.mono(12, color: const Color(0xFFD8B4FE)),
+        codeblockPadding: const EdgeInsets.all(10),
+        codeblockDecoration: BoxDecoration(
+          color: AppColors.canvas.withValues(alpha: 0.6),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: AppColors.border),
+        ),
+        blockquote: AppTextStyles.body.copyWith(color: AppColors.textDim),
+        blockquoteDecoration: const BoxDecoration(
+          border: Border(left: BorderSide(color: AppColors.border, width: 2)),
+        ),
+        h1: AppTextStyles.h3.copyWith(color: AppColors.textHi),
+        h2: AppTextStyles.cardTitle.copyWith(color: AppColors.textHi),
+        h3: AppTextStyles.bodyHi.copyWith(color: AppColors.textHi),
+        a: AppTextStyles.body.copyWith(
+          color: AppColors.primary,
+          decoration: TextDecoration.underline,
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
+++ b/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
@@ -4,40 +4,200 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/common_widgets.dart';
-import '../../../core/widgets/confirm_dialog.dart';
 import '../application/chatbot_controller.dart';
 import '../data/models/chat.dart';
 
-/// Opens the chat settings sheet. Mirrors the web `ChatSettings.vue`:
-/// model selection, the auto-run-safe-tools toggle, conversation actions
-/// (new / delete), and an informational list of the tools the assistant can
-/// use, grouped by safety.
-Future<void> showChatSettings(BuildContext context) {
-  return showModalBottomSheet<void>(
-    context: context,
-    // ChatbotDock is mounted in the MaterialApp.router `builder`, above
-    // go_router's Navigator — so there is no *nearest* Navigator to host the
-    // sheet. Use the root navigator (same as showConfirmDialog) or the sheet
-    // silently never opens.
-    useRootNavigator: true,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    builder: (_) => const _ChatSettingsSheet(),
-  );
+// ── In-tree confirm overlay ───────────────────────────────────────────────────
+//
+// ChatbotDock is mounted in MaterialApp.router's `builder`, ABOVE go_router's
+// Navigator, so it has no Navigator ancestor — showDialog / showModalBottomSheet
+// silently do nothing. Everything modal therefore renders in-tree inside the
+// dock's own Stack (just like the chat panel itself).
+
+/// A pending confirmation, rendered by [ChatConfirmOverlay].
+class ChatConfirmRequest {
+  const ChatConfirmRequest({
+    required this.title,
+    required this.body,
+    required this.confirmLabel,
+    required this.confirmColor,
+    required this.icon,
+    required this.onConfirm,
+  });
+
+  final String title;
+  final String body;
+  final String confirmLabel;
+  final Color confirmColor;
+  final IconData icon;
+  final VoidCallback onConfirm;
 }
 
-class _ChatSettingsSheet extends ConsumerStatefulWidget {
-  const _ChatSettingsSheet();
+/// Scrim + centered confirm card. Returns a [Positioned.fill] — mount it as a
+/// direct child of the dock's Stack.
+class ChatConfirmOverlay extends StatelessWidget {
+  const ChatConfirmOverlay({
+    super.key,
+    required this.request,
+    required this.onDismiss,
+  });
+
+  final ChatConfirmRequest request;
+  final VoidCallback onDismiss;
 
   @override
-  ConsumerState<_ChatSettingsSheet> createState() => _ChatSettingsSheetState();
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Material(
+        color: Colors.black.withValues(alpha: 0.6),
+        child: GestureDetector(
+          onTap: onDismiss,
+          child: Center(
+            child: GestureDetector(
+              onTap: () {}, // swallow taps on the card
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 360),
+                child: Container(
+                  margin: const EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF0a0716),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.fromLTRB(18, 16, 18, 14),
+                        decoration: BoxDecoration(
+                          border: Border(
+                            top: BorderSide(color: request.confirmColor, width: 2),
+                            bottom: const BorderSide(color: AppColors.border),
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(request.icon,
+                                color: request.confirmColor, size: 20),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Text(
+                                request.title,
+                                style: AppTextStyles.bodyHi
+                                    .copyWith(color: AppColors.textHi),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(18),
+                        child: Text(
+                          request.body,
+                          style:
+                              AppTextStyles.body.copyWith(color: AppColors.textMd),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(18, 0, 18, 18),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: _ConfirmBtn(
+                                label: 'Cancel',
+                                color: AppColors.textMuted,
+                                filled: false,
+                                onTap: onDismiss,
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: _ConfirmBtn(
+                                label: request.confirmLabel,
+                                color: request.confirmColor,
+                                filled: true,
+                                onTap: () {
+                                  request.onConfirm();
+                                  onDismiss();
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
-class _ChatSettingsSheetState extends ConsumerState<_ChatSettingsSheet> {
+class _ConfirmBtn extends StatelessWidget {
+  const _ConfirmBtn({
+    required this.label,
+    required this.color,
+    required this.filled,
+    required this.onTap,
+  });
+
+  final String label;
+  final Color color;
+  final bool filled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 11),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: filled ? color.withValues(alpha: 0.15) : Colors.transparent,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: filled ? color.withValues(alpha: 0.5) : AppColors.border,
+          ),
+        ),
+        child: Text(
+          label,
+          style: AppTextStyles.micro
+              .copyWith(color: color, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Settings sheet (in-tree) ──────────────────────────────────────────────────
+
+/// In-tree settings sheet: scrim + bottom panel. Mirrors the web `ChatSettings`
+/// — model selection, auto-run-safe-tools toggle, conversation actions, and an
+/// informational tool catalog. Mount as a direct child of the dock's Stack.
+class ChatSettingsSheet extends ConsumerStatefulWidget {
+  const ChatSettingsSheet({
+    super.key,
+    required this.onClose,
+    required this.onConfirm,
+  });
+
+  final VoidCallback onClose;
+  final void Function(ChatConfirmRequest) onConfirm;
+
+  @override
+  ConsumerState<ChatSettingsSheet> createState() => _ChatSettingsSheetState();
+}
+
+class _ChatSettingsSheetState extends ConsumerState<ChatSettingsSheet> {
   @override
   void initState() {
     super.initState();
-    // Load the model list (no-op if already loaded).
     Future.microtask(() => ref.read(chatbotProvider.notifier).loadModels());
   }
 
@@ -48,70 +208,100 @@ class _ChatSettingsSheetState extends ConsumerState<_ChatSettingsSheet> {
     final convo = st.activeConversation;
     final mq = MediaQuery.of(context);
 
-    return Container(
-      constraints: BoxConstraints(maxHeight: mq.size.height * 0.85),
-      decoration: const BoxDecoration(
-        color: Color(0xFF0a0716),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        border: Border(
-          top: BorderSide(color: AppColors.border),
-          left: BorderSide(color: AppColors.border),
-          right: BorderSide(color: AppColors.border),
-        ),
-      ),
-      child: SafeArea(
-        top: false,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Grab handle.
-            Container(
-              width: 36,
-              height: 4,
-              margin: const EdgeInsets.only(top: 10, bottom: 6),
-              decoration: BoxDecoration(
-                color: AppColors.border,
-                borderRadius: BorderRadius.circular(2),
-              ),
+    return Positioned.fill(
+      child: Stack(
+        children: [
+          // Scrim
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: widget.onClose,
+              child: ColoredBox(color: Colors.black.withValues(alpha: 0.55)),
             ),
-            // Title row.
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
-              child: Row(
-                children: [
-                  Icon(Icons.settings, size: 18, color: AppColors.primary),
-                  const SizedBox(width: 8),
-                  Text(
-                    'Chat settings',
-                    style:
-                        AppTextStyles.bodyHi.copyWith(color: AppColors.textHi),
+          ),
+          // Bottom sheet
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: GestureDetector(
+              onTap: () {}, // swallow taps so they don't hit the scrim
+              child: Container(
+                constraints: BoxConstraints(maxHeight: mq.size.height * 0.85),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF0a0716),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                  border: Border(
+                    top: BorderSide(color: AppColors.border),
+                    left: BorderSide(color: AppColors.border),
+                    right: BorderSide(color: AppColors.border),
                   ),
-                  const Spacer(),
-                  IconButton(
-                    icon: Icon(Icons.close, size: 20, color: AppColors.textMuted),
-                    onPressed: () => Navigator.of(context).pop(),
-                    tooltip: 'Close',
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        width: 36,
+                        height: 4,
+                        margin: const EdgeInsets.only(top: 10, bottom: 6),
+                        decoration: BoxDecoration(
+                          color: AppColors.border,
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
+                        child: Row(
+                          children: [
+                            Icon(Icons.settings,
+                                size: 18, color: AppColors.primary),
+                            const SizedBox(width: 8),
+                            Text(
+                              'Chat settings',
+                              style: AppTextStyles.bodyHi
+                                  .copyWith(color: AppColors.textHi),
+                            ),
+                            const Spacer(),
+                            IconButton(
+                              icon: Icon(Icons.close,
+                                  size: 20, color: AppColors.textMuted),
+                              onPressed: widget.onClose,
+                              tooltip: 'Close',
+                            ),
+                          ],
+                        ),
+                      ),
+                      const Divider(height: 1, color: AppColors.border),
+                      Flexible(
+                        child: ListView(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+                          children: [
+                            _ModelSection(
+                                st: st, convo: convo, notifier: notifier),
+                            const SizedBox(height: 20),
+                            _AutoConfirmSection(
+                                convo: convo, notifier: notifier),
+                            const SizedBox(height: 20),
+                            _ConversationSection(
+                              convo: convo,
+                              notifier: notifier,
+                              onClose: widget.onClose,
+                              onConfirm: widget.onConfirm,
+                            ),
+                            const SizedBox(height: 20),
+                            _ToolsSection(toolCatalog: st.toolCatalog),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
-            const Divider(height: 1, color: AppColors.border),
-            Flexible(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
-                children: [
-                  _ModelSection(st: st, convo: convo, notifier: notifier),
-                  const SizedBox(height: 20),
-                  _AutoConfirmSection(convo: convo, notifier: notifier),
-                  const SizedBox(height: 20),
-                  _ConversationSection(convo: convo, notifier: notifier),
-                  const SizedBox(height: 20),
-                  _ToolsSection(toolCatalog: st.toolCatalog),
-                ],
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -310,10 +500,17 @@ class _AutoConfirmSection extends StatelessWidget {
 // ── Conversation actions ──────────────────────────────────────────────────────
 
 class _ConversationSection extends StatelessWidget {
-  const _ConversationSection({required this.convo, required this.notifier});
+  const _ConversationSection({
+    required this.convo,
+    required this.notifier,
+    required this.onClose,
+    required this.onConfirm,
+  });
 
   final Conversation? convo;
   final ChatbotNotifier notifier;
+  final VoidCallback onClose;
+  final void Function(ChatConfirmRequest) onConfirm;
 
   @override
   Widget build(BuildContext context) {
@@ -326,15 +523,38 @@ class _ConversationSection extends StatelessWidget {
             Expanded(
               child: _ActionButton(
                 icon: Icons.add,
-                label: 'New conversation',
+                label: 'New',
                 color: AppColors.primary,
-                onTap: () async {
-                  await notifier.startNewConversation();
-                  if (context.mounted) Navigator.of(context).pop();
+                onTap: () {
+                  notifier.startNewConversation();
+                  onClose();
                 },
               ),
             ),
-            const SizedBox(width: 10),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _ActionButton(
+                icon: Icons.delete_sweep,
+                label: 'Clear',
+                color: AppColors.warning,
+                onTap: convo == null
+                    ? null
+                    : () {
+                        onConfirm(ChatConfirmRequest(
+                          title: 'Clear conversation',
+                          body:
+                              'This deletes all messages in this conversation. '
+                              'This cannot be undone.',
+                          confirmLabel: 'Clear',
+                          confirmColor: AppColors.warning,
+                          icon: Icons.delete_sweep,
+                          onConfirm: notifier.clearConversation,
+                        ));
+                        onClose();
+                      },
+              ),
+            ),
+            const SizedBox(width: 8),
             Expanded(
               child: _ActionButton(
                 icon: Icons.delete_outline,
@@ -342,9 +562,8 @@ class _ConversationSection extends StatelessWidget {
                 color: AppColors.danger,
                 onTap: convo == null
                     ? null
-                    : () async {
-                        final ok = await showConfirmDialog(
-                          context,
+                    : () {
+                        onConfirm(ChatConfirmRequest(
                           title: 'Delete conversation',
                           body:
                               'This permanently deletes this conversation. '
@@ -352,10 +571,9 @@ class _ConversationSection extends StatelessWidget {
                           confirmLabel: 'Delete',
                           confirmColor: AppColors.danger,
                           icon: Icons.delete_outline,
-                        );
-                        if (!ok) return;
-                        await notifier.deleteConversation();
-                        if (context.mounted) Navigator.of(context).pop();
+                          onConfirm: notifier.deleteConversation,
+                        ));
+                        onClose();
                       },
               ),
             ),
@@ -395,12 +613,15 @@ class _ActionButton extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon, size: 16, color: c),
-            const SizedBox(width: 6),
-            Text(
-              label,
-              style: AppTextStyles.micro
-                  .copyWith(color: c, fontWeight: FontWeight.w600),
+            Icon(icon, size: 15, color: c),
+            const SizedBox(width: 5),
+            Flexible(
+              child: Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.micro
+                    .copyWith(color: c, fontWeight: FontWeight.w600),
+              ),
             ),
           ],
         ),

--- a/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
+++ b/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
@@ -209,8 +209,12 @@ class _ChatSettingsSheetState extends ConsumerState<ChatSettingsSheet> {
     final mq = MediaQuery.of(context);
 
     return Positioned.fill(
-      child: Stack(
-        children: [
+      // Material ancestor — without it Text shows yellow underlines and
+      // Switch / IconButton / ExpansionTile render in fallback mode.
+      child: Material(
+        type: MaterialType.transparency,
+        child: Stack(
+          children: [
           // Scrim
           Positioned.fill(
             child: GestureDetector(
@@ -302,6 +306,7 @@ class _ChatSettingsSheetState extends ConsumerState<ChatSettingsSheet> {
             ),
           ),
         ],
+        ),
       ),
     );
   }

--- a/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
+++ b/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
@@ -15,6 +15,11 @@ import '../data/models/chat.dart';
 Future<void> showChatSettings(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
+    // ChatbotDock is mounted in the MaterialApp.router `builder`, above
+    // go_router's Navigator — so there is no *nearest* Navigator to host the
+    // sheet. Use the root navigator (same as showConfirmDialog) or the sheet
+    // silently never opens.
+    useRootNavigator: true,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     builder: (_) => const _ChatSettingsSheet(),

--- a/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
+++ b/mobile/lib/features/chatbot/presentation/chat_settings_sheet.dart
@@ -1,0 +1,525 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/common_widgets.dart';
+import '../../../core/widgets/confirm_dialog.dart';
+import '../application/chatbot_controller.dart';
+import '../data/models/chat.dart';
+
+/// Opens the chat settings sheet. Mirrors the web `ChatSettings.vue`:
+/// model selection, the auto-run-safe-tools toggle, conversation actions
+/// (new / delete), and an informational list of the tools the assistant can
+/// use, grouped by safety.
+Future<void> showChatSettings(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => const _ChatSettingsSheet(),
+  );
+}
+
+class _ChatSettingsSheet extends ConsumerStatefulWidget {
+  const _ChatSettingsSheet();
+
+  @override
+  ConsumerState<_ChatSettingsSheet> createState() => _ChatSettingsSheetState();
+}
+
+class _ChatSettingsSheetState extends ConsumerState<_ChatSettingsSheet> {
+  @override
+  void initState() {
+    super.initState();
+    // Load the model list (no-op if already loaded).
+    Future.microtask(() => ref.read(chatbotProvider.notifier).loadModels());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final st = ref.watch(chatbotProvider);
+    final notifier = ref.read(chatbotProvider.notifier);
+    final convo = st.activeConversation;
+    final mq = MediaQuery.of(context);
+
+    return Container(
+      constraints: BoxConstraints(maxHeight: mq.size.height * 0.85),
+      decoration: const BoxDecoration(
+        color: Color(0xFF0a0716),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        border: Border(
+          top: BorderSide(color: AppColors.border),
+          left: BorderSide(color: AppColors.border),
+          right: BorderSide(color: AppColors.border),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Grab handle.
+            Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(top: 10, bottom: 6),
+              decoration: BoxDecoration(
+                color: AppColors.border,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            // Title row.
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
+              child: Row(
+                children: [
+                  Icon(Icons.settings, size: 18, color: AppColors.primary),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Chat settings',
+                    style:
+                        AppTextStyles.bodyHi.copyWith(color: AppColors.textHi),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    icon: Icon(Icons.close, size: 20, color: AppColors.textMuted),
+                    onPressed: () => Navigator.of(context).pop(),
+                    tooltip: 'Close',
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1, color: AppColors.border),
+            Flexible(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+                children: [
+                  _ModelSection(st: st, convo: convo, notifier: notifier),
+                  const SizedBox(height: 20),
+                  _AutoConfirmSection(convo: convo, notifier: notifier),
+                  const SizedBox(height: 20),
+                  _ConversationSection(convo: convo, notifier: notifier),
+                  const SizedBox(height: 20),
+                  _ToolsSection(toolCatalog: st.toolCatalog),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Section header ──────────────────────────────────────────────────────────
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(
+          text,
+          style: AppTextStyles.eyebrow.copyWith(color: AppColors.textDim),
+        ),
+      );
+}
+
+// ── Model ─────────────────────────────────────────────────────────────────────
+
+class _ModelSection extends StatelessWidget {
+  const _ModelSection({
+    required this.st,
+    required this.convo,
+    required this.notifier,
+  });
+
+  final ChatbotState st;
+  final Conversation? convo;
+  final ChatbotNotifier notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    final models = st.models;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionLabel('MODEL'),
+        if (!st.modelsLoaded && models.isEmpty)
+          const LoadingState(label: 'Loading models…')
+        else if (st.modelsLoaded && models.isEmpty)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: AppColors.warning.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(12),
+              border:
+                  Border.all(color: AppColors.warning.withValues(alpha: 0.3)),
+            ),
+            child: Text(
+              'No models configured yet. Add one on the Models page.',
+              style: AppTextStyles.body.copyWith(color: AppColors.warning),
+            ),
+          )
+        else
+          for (final m in models)
+            _ModelRow(
+              model: m,
+              selected: convo?.modelId == m.id,
+              busy: st.busy,
+              onTap: convo?.modelId == m.id || st.busy
+                  ? null
+                  : () => notifier.setModel(m.id),
+            ),
+      ],
+    );
+  }
+}
+
+class _ModelRow extends StatelessWidget {
+  const _ModelRow({
+    required this.model,
+    required this.selected,
+    required this.busy,
+    required this.onTap,
+  });
+
+  final ChatModel model;
+  final bool selected;
+  final bool busy;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final sub = '${model.provider} · ${model.model}'
+        .trim()
+        .replaceAll(RegExp(r'^·\s*|·\s*$'), '');
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppColors.primary.withValues(alpha: 0.12)
+                : AppColors.surface.withValues(alpha: 0.5),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: selected
+                  ? AppColors.primary.withValues(alpha: 0.5)
+                  : AppColors.border,
+            ),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      model.name,
+                      style: AppTextStyles.bodyHi.copyWith(
+                        color: selected ? AppColors.primary : AppColors.textHi,
+                      ),
+                    ),
+                    if (sub.isNotEmpty)
+                      Text(
+                        sub,
+                        style: AppTextStyles.micro
+                            .copyWith(color: AppColors.textDim),
+                      ),
+                  ],
+                ),
+              ),
+              if (selected)
+                Icon(Icons.check_circle, color: AppColors.primary, size: 18),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Auto-confirm safe tools ───────────────────────────────────────────────────
+
+class _AutoConfirmSection extends StatelessWidget {
+  const _AutoConfirmSection({required this.convo, required this.notifier});
+
+  final Conversation? convo;
+  final ChatbotNotifier notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = convo != null;
+    final value = convo?.autoConfirmSafeTools ?? false;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionLabel('TOOLS'),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Auto-run safe (read-only) tools',
+                    style:
+                        AppTextStyles.body.copyWith(color: AppColors.textMd),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'When on, the assistant can call read-only tools like '
+                    'list_instances without asking. Mutating tools always '
+                    'require approval.',
+                    style: AppTextStyles.nano.copyWith(
+                      color: AppColors.textFaint,
+                      height: 1.4,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Switch.adaptive(
+              value: value,
+              activeThumbColor: AppColors.primary,
+              onChanged: enabled
+                  ? (v) => notifier.setAutoConfirmSafe(value: v)
+                  : null,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+// ── Conversation actions ──────────────────────────────────────────────────────
+
+class _ConversationSection extends StatelessWidget {
+  const _ConversationSection({required this.convo, required this.notifier});
+
+  final Conversation? convo;
+  final ChatbotNotifier notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionLabel('CONVERSATION'),
+        Row(
+          children: [
+            Expanded(
+              child: _ActionButton(
+                icon: Icons.add,
+                label: 'New conversation',
+                color: AppColors.primary,
+                onTap: () async {
+                  await notifier.startNewConversation();
+                  if (context.mounted) Navigator.of(context).pop();
+                },
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: _ActionButton(
+                icon: Icons.delete_outline,
+                label: 'Delete',
+                color: AppColors.danger,
+                onTap: convo == null
+                    ? null
+                    : () async {
+                        final ok = await showConfirmDialog(
+                          context,
+                          title: 'Delete conversation',
+                          body:
+                              'This permanently deletes this conversation. '
+                              'This cannot be undone.',
+                          confirmLabel: 'Delete',
+                          confirmColor: AppColors.danger,
+                          icon: Icons.delete_outline,
+                        );
+                        if (!ok) return;
+                        await notifier.deleteConversation();
+                        if (context.mounted) Navigator.of(context).pop();
+                      },
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final disabled = onTap == null;
+    final c = disabled ? AppColors.textFaint : color;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 11),
+        decoration: BoxDecoration(
+          color: c.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: c.withValues(alpha: 0.35)),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 16, color: c),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: AppTextStyles.micro
+                  .copyWith(color: c, fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Tool catalog (informational) ──────────────────────────────────────────────
+
+class _ToolsSection extends StatelessWidget {
+  const _ToolsSection({required this.toolCatalog});
+
+  final List<Map<String, dynamic>> toolCatalog;
+
+  @override
+  Widget build(BuildContext context) {
+    if (toolCatalog.isEmpty) return const SizedBox.shrink();
+
+    String nameOf(Map<String, dynamic> t) =>
+        (t['name'] ?? t['function'] ?? t['tool'] ?? '').toString();
+    String safetyOf(Map<String, dynamic> t) =>
+        (t['safety'] ?? 'write').toString();
+
+    final safe = <String>[];
+    final confirm = <String>[];
+    final destructive = <String>[];
+    for (final t in toolCatalog) {
+      final n = nameOf(t);
+      if (n.isEmpty) continue;
+      switch (safetyOf(t)) {
+        case 'safe':
+          safe.add(n);
+        case 'destructive':
+          destructive.add(n);
+        default:
+          confirm.add(n);
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionLabel('TOOLS THE ASSISTANT CAN USE'),
+        if (safe.isNotEmpty)
+          _ToolGroup(
+            title: 'Read-only · auto-runnable',
+            color: AppColors.success,
+            tools: safe,
+          ),
+        if (confirm.isNotEmpty)
+          _ToolGroup(
+            title: 'Confirm to run',
+            color: AppColors.warning,
+            tools: confirm,
+          ),
+        if (destructive.isNotEmpty)
+          _ToolGroup(
+            title: 'Destructive · always confirm',
+            color: AppColors.danger,
+            tools: destructive,
+          ),
+      ],
+    );
+  }
+}
+
+class _ToolGroup extends StatelessWidget {
+  const _ToolGroup({
+    required this.title,
+    required this.color,
+    required this.tools,
+  });
+
+  final String title;
+  final Color color;
+  final List<String> tools;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: const EdgeInsets.only(left: 16, bottom: 8),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        dense: true,
+        leading: Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        title: Text(
+          '$title (${tools.length})',
+          style: AppTextStyles.micro.copyWith(color: AppColors.textMd),
+        ),
+        iconColor: AppColors.textDim,
+        collapsedIconColor: AppColors.textDim,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final t in tools)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: AppColors.surface.withValues(alpha: 0.6),
+                    borderRadius: BorderRadius.circular(6),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: Text(
+                    t,
+                    style: AppTextStyles.nano.copyWith(
+                      color: AppColors.textDim,
+                      fontFamily: 'monospace',
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/chatbot/presentation/chatbot_dock.dart
+++ b/mobile/lib/features/chatbot/presentation/chatbot_dock.dart
@@ -11,6 +11,7 @@ import '../data/models/chat.dart';
 import 'chat_composer.dart';
 import 'chat_message.dart';
 import 'chat_model_picker.dart';
+import 'chat_settings_sheet.dart';
 import 'chat_tool_call.dart';
 
 /// Global chatbot overlay widget.
@@ -267,6 +268,7 @@ class _ExpandedPanel extends ConsumerWidget {
                   _ChatHeader(
                     title: st.activeConversation?.title ?? 'Assistant',
                     modelName: st.activeConversation?.modelName ?? '',
+                    onSettings: () => showChatSettings(context),
                     onClear: () async {
                       final ok = await showConfirmDialog(
                         context,
@@ -322,12 +324,14 @@ class _ChatHeader extends StatelessWidget {
   const _ChatHeader({
     required this.title,
     required this.modelName,
+    required this.onSettings,
     required this.onClear,
     required this.onMinimise,
   });
 
   final String title;
   final String modelName;
+  final VoidCallback onSettings;
   final VoidCallback onClear;
   final VoidCallback onMinimise;
 
@@ -378,6 +382,13 @@ class _ChatHeader extends StatelessWidget {
                   ),
               ],
             ),
+          ),
+
+          // Settings
+          _HeaderBtn(
+            icon: Icons.settings,
+            tooltip: 'Settings',
+            onTap: onSettings,
           ),
 
           // Clear

--- a/mobile/lib/features/chatbot/presentation/chatbot_dock.dart
+++ b/mobile/lib/features/chatbot/presentation/chatbot_dock.dart
@@ -5,7 +5,6 @@ import '../../../core/network/session.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/common_widgets.dart';
-import '../../../core/widgets/confirm_dialog.dart';
 import '../application/chatbot_controller.dart';
 import '../data/models/chat.dart';
 import 'chat_composer.dart';
@@ -60,6 +59,16 @@ class _ChatbotDockState extends ConsumerState<ChatbotDock>
 
   bool _wasOpen = false;
   double _lastKbInset = 0;
+
+  // In-tree overlays: the dock is mounted in MaterialApp.builder, ABOVE
+  // go_router's Navigator, so it has no Navigator ancestor — modal routes
+  // (showDialog / showModalBottomSheet) silently fail. Settings and confirms
+  // therefore render inside this widget's own Stack, like the chat panel.
+  bool _settingsOpen = false;
+  ChatConfirmRequest? _confirm;
+
+  void _requestConfirm(ChatConfirmRequest r) =>
+      setState(() => _confirm = r);
 
   void _scrollToBottom({bool animate = true}) {
     void run() {
@@ -176,7 +185,26 @@ class _ChatbotDockState extends ConsumerState<ChatbotDock>
         ),
 
         // Expanded panel
-        if (st.isOpen) _ExpandedPanel(scrollCtrl: _scrollCtrl),
+        if (st.isOpen)
+          _ExpandedPanel(
+            scrollCtrl: _scrollCtrl,
+            onOpenSettings: () => setState(() => _settingsOpen = true),
+            onConfirm: _requestConfirm,
+          ),
+
+        // Settings sheet (in-tree overlay, above the panel)
+        if (st.isOpen && _settingsOpen)
+          ChatSettingsSheet(
+            onClose: () => setState(() => _settingsOpen = false),
+            onConfirm: _requestConfirm,
+          ),
+
+        // Confirm overlay (above everything)
+        if (_confirm != null)
+          ChatConfirmOverlay(
+            request: _confirm!,
+            onDismiss: () => setState(() => _confirm = null),
+          ),
       ],
     );
   }
@@ -227,8 +255,14 @@ class _CollapsedFab extends StatelessWidget {
 // ── Expanded panel ────────────────────────────────────────────────────────────
 
 class _ExpandedPanel extends ConsumerWidget {
-  const _ExpandedPanel({required this.scrollCtrl});
+  const _ExpandedPanel({
+    required this.scrollCtrl,
+    required this.onOpenSettings,
+    required this.onConfirm,
+  });
   final ScrollController scrollCtrl;
+  final VoidCallback onOpenSettings;
+  final void Function(ChatConfirmRequest) onConfirm;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -268,19 +302,16 @@ class _ExpandedPanel extends ConsumerWidget {
                   _ChatHeader(
                     title: st.activeConversation?.title ?? 'Assistant',
                     modelName: st.activeConversation?.modelName ?? '',
-                    onSettings: () => showChatSettings(context),
-                    onClear: () async {
-                      final ok = await showConfirmDialog(
-                        context,
-                        title: 'Clear conversation',
-                        body:
-                            'This will delete all messages. This cannot be undone.',
-                        confirmLabel: 'Clear',
-                        confirmColor: AppColors.danger,
-                        icon: Icons.delete_sweep,
-                      );
-                      if (ok) notifier.clearConversation();
-                    },
+                    onSettings: onOpenSettings,
+                    onClear: () => onConfirm(ChatConfirmRequest(
+                      title: 'Clear conversation',
+                      body:
+                          'This will delete all messages. This cannot be undone.',
+                      confirmLabel: 'Clear',
+                      confirmColor: AppColors.danger,
+                      icon: Icons.delete_sweep,
+                      onConfirm: notifier.clearConversation,
+                    )),
                     onMinimise: () => notifier.minimise(),
                   ),
 

--- a/mobile/lib/features/dashboard/presentation/portfolio_chart.dart
+++ b/mobile/lib/features/dashboard/presentation/portfolio_chart.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/charts/chart_decorations.dart';
+import '../../../core/charts/chart_geometry.dart';
+import '../../../core/charts/scrub_controller.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
 import '../../../core/widgets/glass_card.dart';
@@ -40,26 +43,6 @@ class _HistoryNotifier
   @override
   Future<PortfolioHistory> build(_HistoryArgs arg) =>
       ref.read(dashboardRepositoryProvider).portfolioHistory(arg.id, arg.range);
-}
-
-// ── Scrubber state ────────────────────────────────────────────────────────────
-
-/// Holds the pan-gesture scrubber state for one chart.
-class _ScrubState {
-  const _ScrubState({this.index, this.linePercent});
-
-  final int? index;
-
-  /// 0..100, the % x-position of the vertical hairline.
-  final double? linePercent;
-
-  _ScrubState copyWith({int? index, double? linePercent, bool clearIndex = false}) =>
-      _ScrubState(
-        index: clearIndex ? null : (index ?? this.index),
-        linePercent: linePercent ?? this.linePercent,
-      );
-
-  static const empty = _ScrubState();
 }
 
 // ── Change % helper (pure, also tested) ──────────────────────────────────────
@@ -129,7 +112,11 @@ class PortfolioChart extends ConsumerStatefulWidget {
 class _PortfolioChartState extends ConsumerState<PortfolioChart>
     with AutomaticKeepAliveClientMixin {
   String _range = '1M';
-  _ScrubState _scrub = _ScrubState.empty;
+
+  // Scrub state lives in a ValueNotifier so dragging repaints only the hairline
+  // + header value, never the (expensive) Syncfusion chart — that's what made
+  // the old setState-per-frame scrubber jank.
+  final ScrubController _scrub = ScrubController();
 
   // Animate the chart only on first reveal — not every time it scrolls back
   // into view or polls.
@@ -140,32 +127,18 @@ class _PortfolioChartState extends ConsumerState<PortfolioChart>
   @override
   bool get wantKeepAlive => true;
 
-  // chart render key so we can get its RenderBox during scrub
-  final _chartKey = GlobalKey();
+  @override
+  void dispose() {
+    _scrub.dispose();
+    super.dispose();
+  }
 
   _HistoryArgs get _args => _HistoryArgs(widget.account.id as String, _range);
 
   void _setRange(String r) {
     if (r == _range) return;
-    setState(() {
-      _range = r;
-      _scrub = _ScrubState.empty;
-    });
-  }
-
-  void _onPanUpdate(DragUpdateDetails d, PortfolioHistory history) {
-    final box = _chartKey.currentContext?.findRenderObject() as RenderBox?;
-    if (box == null || history.isEmpty) return;
-    final local = box.globalToLocal(d.globalPosition);
-    final frac = (local.dx / box.size.width).clamp(0.0, 1.0);
-    final idx = nearestIndex(history.timestamps, frac);
-    setState(() {
-      _scrub = _ScrubState(index: idx, linePercent: frac * 100);
-    });
-  }
-
-  void _onPanEnd(PortfolioHistory history) {
-    setState(() => _scrub = _ScrubState.empty);
+    _scrub.clear();
+    setState(() => _range = r);
   }
 
   @override
@@ -191,9 +164,12 @@ class _PortfolioChartState extends ConsumerState<PortfolioChart>
                     style:
                         AppTextStyles.micro.copyWith(color: AppColors.danger),
                   ),
-                  data: (h) => _ValueRow(
-                    history: h,
-                    scrubIndex: _scrub.index,
+                  data: (h) => ValueListenableBuilder<ScrubSample?>(
+                    valueListenable: _scrub,
+                    builder: (_, sample, _) => _ValueRow(
+                      history: h,
+                      scrubIndex: sample?.index,
+                    ),
                   ),
                 ),
                 const SizedBox(height: 12),
@@ -219,12 +195,10 @@ class _PortfolioChartState extends ConsumerState<PortfolioChart>
                 );
               }
               return _ChartArea(
-                chartKey: _chartKey,
                 history: history,
                 scrub: _scrub,
+                range: _range,
                 animate: shouldAnimate,
-                onPanUpdate: (d) => _onPanUpdate(d, history),
-                onPanEnd: () => _onPanEnd(history),
               );
             },
           ),
@@ -429,25 +403,32 @@ class _ChartEmpty extends StatelessWidget {
 
 class _ChartArea extends StatelessWidget {
   const _ChartArea({
-    required this.chartKey,
     required this.history,
     required this.scrub,
+    required this.range,
     required this.animate,
-    required this.onPanUpdate,
-    required this.onPanEnd,
   });
 
-  final GlobalKey chartKey;
   final PortfolioHistory history;
-  final _ScrubState scrub;
+  final ScrubController scrub;
+  final String range;
 
   /// Whether the area series should play its entrance animation. Only true on
   /// the chart's first build; suppressed afterwards so scrolling away and back
   /// doesn't re-animate.
   final bool animate;
 
-  final void Function(DragUpdateDetails) onPanUpdate;
-  final VoidCallback onPanEnd;
+  static const double _plotHeight = 172;
+
+  void _onDrag(double localDx, double width) {
+    if (history.values.isEmpty || width <= 0) return;
+    final n = history.values.length;
+    final frac = (localDx / width).clamp(0.0, 1.0);
+    final idx = fractionToIndex(frac, n);
+    // Draw the hairline + dot at the data point's own fraction so they sit
+    // exactly on the curve and match the value the header reports.
+    scrub.update(idx, indexToFraction(idx, n));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -455,101 +436,111 @@ class _ChartArea extends StatelessWidget {
     final positive = (changeAbs ?? 0) >= 0;
     final lineColor = positive ? AppColors.success : AppColors.danger;
 
-    // Build Syncfusion chart data points
-    final dataSource = List<_ChartPoint>.generate(history.values.length, (i) {
-      return _ChartPoint(
-        x: history.timestamps[i].millisecondsSinceEpoch.toDouble(),
-        y: history.values[i],
-      );
-    });
+    final n = history.values.length;
+    final bounds = paddedBounds(history.values);
 
-    return SizedBox(
-      height: 192,
-      child: Stack(
+    // Index-based points (gapless across weekends/closed sessions).
+    final dataSource = List<_ChartPoint>.generate(
+      n,
+      (i) => _ChartPoint(x: i.toDouble(), y: history.values[i]),
+    );
+
+    final labels = [
+      for (final i in evenlySpacedLabelIndices(n, 4))
+        formatChartDate(history.timestamps[i], range),
+    ];
+
+    final chart = SfCartesianChart(
+      plotAreaBorderWidth: 0,
+      margin: EdgeInsets.zero,
+      primaryXAxis: edgeToEdgeIndexAxis(n),
+      primaryYAxis: hiddenValueAxis(minimum: bounds.min, maximum: bounds.max),
+      tooltipBehavior: TooltipBehavior(enable: false),
+      series: <CartesianSeries<_ChartPoint, double>>[
+        SplineAreaSeries<_ChartPoint, double>(
+          dataSource: dataSource,
+          splineType: SplineType.monotonic,
+          animationDuration: animate ? 900 : 0,
+          xValueMapper: (pt, _) => pt.x,
+          yValueMapper: (pt, _) => pt.y,
+          color: lineColor.withValues(alpha: 0.12),
+          borderColor: lineColor,
+          borderWidth: 2,
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              lineColor.withValues(alpha: 0.35),
+              lineColor.withValues(alpha: 0.0),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Positioned.fill(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(4, 0, 4, 12),
-              child: SfCartesianChart(
-                key: chartKey,
-                plotAreaBorderWidth: 0,
-                margin: EdgeInsets.zero,
-                primaryXAxis: NumericAxis(
-                  isVisible: true,
-                  majorGridLines: const MajorGridLines(width: 0),
-                  minorGridLines: const MinorGridLines(width: 0),
-                  axisLine: const AxisLine(width: 0),
-                  majorTickLines: const MajorTickLines(size: 0),
-                  labelStyle: TextStyle(
-                    color: AppColors.chartAxis,
-                    fontSize: 10,
-                  ),
-                  numberFormat: null,
-                  labelFormat: '',
-                ),
-                primaryYAxis: NumericAxis(
-                  isVisible: true,
-                  axisLine: const AxisLine(width: 0),
-                  majorTickLines: const MajorTickLines(size: 0),
-                  majorGridLines: MajorGridLines(
-                    color: AppColors.chartGrid,
-                    dashArray: const [4, 4],
-                  ),
-                  labelStyle: TextStyle(
-                    color: AppColors.chartAxis,
-                    fontSize: 10,
-                  ),
-                  desiredIntervals: 4,
-                  numberFormat: null,
-                  labelFormat: '\${value}',
-                ),
-                tooltipBehavior: TooltipBehavior(enable: false),
-                series: <CartesianSeries<_ChartPoint, double>>[
-                  AreaSeries<_ChartPoint, double>(
-                    dataSource: dataSource,
-                    animationDuration: animate ? 900 : 0,
-                    xValueMapper: (pt, _) => pt.x,
-                    yValueMapper: (pt, _) => pt.y,
-                    color: lineColor.withValues(alpha: 0.12),
-                    borderColor: lineColor,
-                    borderWidth: 2,
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        lineColor.withValues(alpha: 0.35),
-                        lineColor.withValues(alpha: 0.0),
-                      ],
+          SizedBox(
+            height: _plotHeight,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final width = constraints.maxWidth;
+                return Stack(
+                  children: [
+                    // The chart never repaints during a scrub: it isn't wrapped
+                    // in the ValueListenableBuilder below, so notifier ticks
+                    // don't reach it.
+                    Positioned.fill(child: RepaintBoundary(child: chart)),
+                    // Hairline + dot — repaints only on scrub.
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: ValueListenableBuilder<ScrubSample?>(
+                          valueListenable: scrub,
+                          builder: (_, sample, _) {
+                            if (sample == null ||
+                                sample.index < 0 ||
+                                sample.index >= n) {
+                              return const SizedBox.shrink();
+                            }
+                            final dotY = valueToY(
+                              history.values[sample.index],
+                              bounds.min,
+                              bounds.max,
+                              _plotHeight,
+                            );
+                            return CustomPaint(
+                              painter: ScrubPainter(
+                                fraction: sample.fraction,
+                                dotY: dotY,
+                                color: lineColor,
+                              ),
+                            );
+                          },
+                        ),
+                      ),
                     ),
-                  ),
-                ],
-              ),
+                    // Gesture overlay.
+                    Positioned.fill(
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onHorizontalDragStart: (d) =>
+                            _onDrag(d.localPosition.dx, width),
+                        onHorizontalDragUpdate: (d) =>
+                            _onDrag(d.localPosition.dx, width),
+                        onHorizontalDragEnd: (_) => scrub.clear(),
+                        onHorizontalDragCancel: scrub.clear,
+                      ),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
-          // Scrubber hairline
-          if (scrub.linePercent != null)
-            Positioned(
-              top: 0,
-              bottom: 12,
-              left: (scrub.linePercent! / 100) *
-                  (MediaQuery.of(context).size.width - 8),
-              width: 1,
-              child: IgnorePointer(
-                child: Container(
-                  color: AppColors.primary.withValues(alpha: 0.5),
-                ),
-              ),
-            ),
-          // Gesture overlay
-          Positioned.fill(
-            child: GestureDetector(
-              behavior: HitTestBehavior.translucent,
-              onHorizontalDragUpdate: onPanUpdate,
-              onHorizontalDragEnd: (_) => onPanEnd(),
-              onHorizontalDragCancel: onPanEnd,
-              child: const SizedBox.expand(),
-            ),
-          ),
+          ChartDateLabels(labels: labels),
+          const SizedBox(height: 8),
         ],
       ),
     );

--- a/mobile/lib/features/live_trading/presentation/equity_chart.dart
+++ b/mobile/lib/features/live_trading/presentation/equity_chart.dart
@@ -127,8 +127,6 @@ class _EquityChartState extends State<EquityChart> {
                 final width = constraints.maxWidth;
                 return GestureDetector(
                   behavior: HitTestBehavior.opaque,
-                  onTapDown: (d) => _handleScrub(d.localPosition.dx, width, n),
-                  onTapUp: (_) => _endScrub(),
                   onHorizontalDragStart: (d) =>
                       _handleScrub(d.localPosition.dx, width, n),
                   onHorizontalDragUpdate: (d) =>

--- a/mobile/lib/features/live_trading/presentation/equity_chart.dart
+++ b/mobile/lib/features/live_trading/presentation/equity_chart.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+import '../../../core/charts/chart_decorations.dart';
+import '../../../core/charts/chart_geometry.dart';
+import '../../../core/charts/scrub_controller.dart';
 import '../../../core/models/portfolio_history.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_text_styles.dart';
@@ -32,7 +35,23 @@ class EquityChart extends StatefulWidget {
 }
 
 class _EquityChartState extends State<EquityChart> {
-  int? _scrubIndex;
+  final ScrubController _scrub = ScrubController();
+
+  // Cached Syncfusion chart so a parent rebuild (e.g. the header showing the
+  // scrubbed value) doesn't rebuild the expensive chart — only the thin overlay
+  // repaints while scrubbing.
+  Widget? _cachedChart;
+  PortfolioHistory? _cacheHistory;
+  ChartStyle? _cacheStyle;
+  String? _cacheRange;
+
+  static const double _labelRowHeight = 20;
+
+  @override
+  void dispose() {
+    _scrub.dispose();
+    super.dispose();
+  }
 
   List<_ChartPoint> get _points {
     final ts = widget.history.timestamps;
@@ -68,30 +87,6 @@ class _EquityChartState extends State<EquityChart> {
 
   Color get _lineColor => _isUp ? AppColors.chartUp : AppColors.chartDown;
 
-  String _formatLabel(DateTime ts) {
-    switch (widget.range) {
-      case '1D':
-        return '${ts.hour.toString().padLeft(2, '0')}:${ts.minute.toString().padLeft(2, '0')}';
-      case '1W':
-        const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-        return days[(ts.weekday - 1).clamp(0, 6)];
-      case '1M':
-      case '3M':
-      case 'YTD':
-        const m = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-        return '${m[ts.month - 1]} ${ts.day}';
-      default:
-        const m = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-        return "${m[ts.month - 1]} '${ts.year.toString().substring(2)}";
-    }
-  }
-
-  String _formatMoney(double v) {
-    if (v.abs() >= 1000000) return '\$${(v / 1000000).toStringAsFixed(1)}M';
-    if (v.abs() >= 1000) return '\$${(v / 1000).toStringAsFixed(1)}k';
-    return '\$${v.toStringAsFixed(0)}';
-  }
-
   @override
   Widget build(BuildContext context) {
     final pts = _points;
@@ -108,46 +103,117 @@ class _EquityChartState extends State<EquityChart> {
     }
 
     final color = _lineColor;
+    final n = pts.length;
+    final plotHeight =
+        (widget.height - _labelRowHeight).clamp(40.0, widget.height);
+    final bounds = paddedBounds([for (final p in pts) p.value]);
 
-    Widget chartWidget;
+    final chart = _chartFor(pts, color, bounds);
+
+    final labels = [
+      for (final i in evenlySpacedLabelIndices(n, 4))
+        formatChartDate(pts[i].ts, widget.range),
+    ];
+
+    return SizedBox(
+      height: widget.height,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            height: plotHeight,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final width = constraints.maxWidth;
+                return GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTapDown: (d) => _handleScrub(d.localPosition.dx, width, n),
+                  onTapUp: (_) => _endScrub(),
+                  onHorizontalDragStart: (d) =>
+                      _handleScrub(d.localPosition.dx, width, n),
+                  onHorizontalDragUpdate: (d) =>
+                      _handleScrub(d.localPosition.dx, width, n),
+                  onHorizontalDragEnd: (_) => _endScrub(),
+                  onHorizontalDragCancel: _endScrub,
+                  child: Stack(
+                    children: [
+                      // The chart is cached and wrapped in a RepaintBoundary, so
+                      // a scrub never repaints it.
+                      Positioned.fill(child: RepaintBoundary(child: chart)),
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: ValueListenableBuilder<ScrubSample?>(
+                            valueListenable: _scrub,
+                            builder: (_, sample, _) {
+                              if (sample == null ||
+                                  sample.index < 0 ||
+                                  sample.index >= n) {
+                                return const SizedBox.shrink();
+                              }
+                              final dotY = widget.style == ChartStyle.candle
+                                  ? null
+                                  : valueToY(
+                                      pts[sample.index].value,
+                                      bounds.min,
+                                      bounds.max,
+                                      plotHeight,
+                                    );
+                              return CustomPaint(
+                                painter: ScrubPainter(
+                                  fraction: sample.fraction,
+                                  dotY: dotY,
+                                  color: color,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          ChartDateLabels(labels: labels),
+        ],
+      ),
+    );
+  }
+
+  /// Returns the cached Syncfusion chart, rebuilding only when the data, style,
+  /// or range changes.
+  Widget _chartFor(
+    List<_ChartPoint> pts,
+    Color color,
+    ({double min, double max}) bounds,
+  ) {
+    if (_cachedChart != null &&
+        identical(_cacheHistory, widget.history) &&
+        _cacheStyle == widget.style &&
+        _cacheRange == widget.range) {
+      return _cachedChart!;
+    }
+    _cacheHistory = widget.history;
+    _cacheStyle = widget.style;
+    _cacheRange = widget.range;
+    return _cachedChart = _buildSyncfusionChart(pts, color, bounds);
+  }
+
+  Widget _buildSyncfusionChart(
+    List<_ChartPoint> pts,
+    Color color,
+    ({double min, double max}) bounds,
+  ) {
     if (widget.style == ChartStyle.candle) {
       final candles = _bucketCandles(pts);
-      if (candles.isEmpty) {
-        return SizedBox(height: widget.height);
-      }
-      chartWidget = SfCartesianChart(
+      if (candles.isEmpty) return const SizedBox.shrink();
+      return SfCartesianChart(
         backgroundColor: Colors.transparent,
         plotAreaBorderWidth: 0,
         margin: EdgeInsets.zero,
-        primaryXAxis: NumericAxis(
-          isVisible: true,
-          majorGridLines: const MajorGridLines(width: 0),
-          axisLine: const AxisLine(width: 0),
-          labelStyle: TextStyle(color: AppColors.chartAxis, fontSize: 9),
-          desiredIntervals: 5,
-          axisLabelFormatter: (AxisLabelRenderDetails args) {
-            final idx = args.value.toInt().clamp(0, candles.length - 1);
-            return ChartAxisLabel(
-              _formatLabel(candles[idx].ts),
-              TextStyle(color: AppColors.chartAxis, fontSize: 9),
-            );
-          },
-        ),
-        primaryYAxis: NumericAxis(
-          isVisible: true,
-          majorGridLines: MajorGridLines(
-            color: AppColors.chartGrid,
-            dashArray: const <double>[3, 3],
-          ),
-          axisLine: const AxisLine(width: 0),
-          labelStyle: TextStyle(color: AppColors.chartAxis, fontSize: 9),
-          axisLabelFormatter: (AxisLabelRenderDetails args) {
-            return ChartAxisLabel(
-              _formatMoney(args.value.toDouble()),
-              TextStyle(color: AppColors.chartAxis, fontSize: 9),
-            );
-          },
-        ),
+        primaryXAxis: edgeToEdgeIndexAxis(candles.length),
+        primaryYAxis: hiddenValueAxis(minimum: bounds.min, maximum: bounds.max),
         series: <CartesianSeries>[
           CandleSeries<_CandlePoint, num>(
             dataSource: candles,
@@ -162,138 +228,64 @@ class _EquityChartState extends State<EquityChart> {
           ),
         ],
       );
-    } else {
-      final isLine = widget.style == ChartStyle.line;
-      chartWidget = SfCartesianChart(
-        backgroundColor: Colors.transparent,
-        plotAreaBorderWidth: 0,
-        margin: EdgeInsets.zero,
-        primaryXAxis: NumericAxis(
-          isVisible: true,
-          majorGridLines: const MajorGridLines(width: 0),
-          axisLine: const AxisLine(width: 0),
-          labelStyle: TextStyle(color: AppColors.chartAxis, fontSize: 9),
-          desiredIntervals: 5,
-          axisLabelFormatter: (AxisLabelRenderDetails args) {
-            final idx = args.value.toInt().clamp(0, pts.length - 1);
-            return ChartAxisLabel(
-              _formatLabel(pts[idx].ts),
-              TextStyle(color: AppColors.chartAxis, fontSize: 9),
-            );
-          },
-        ),
-        primaryYAxis: NumericAxis(
-          isVisible: true,
-          majorGridLines: MajorGridLines(
-            color: AppColors.chartGrid,
-            dashArray: const <double>[3, 3],
-          ),
-          axisLine: const AxisLine(width: 0),
-          labelStyle: TextStyle(color: AppColors.chartAxis, fontSize: 9),
-          axisLabelFormatter: (AxisLabelRenderDetails args) {
-            return ChartAxisLabel(
-              _formatMoney(args.value.toDouble()),
-              TextStyle(color: AppColors.chartAxis, fontSize: 9),
-            );
-          },
-        ),
-        series: <CartesianSeries>[
-          if (!isLine)
-            AreaSeries<_ChartPoint, num>(
-              dataSource: pts,
-              xValueMapper: (d, _) => d.x,
-              yValueMapper: (d, _) => d.value,
-              color: color.withValues(alpha: 0.28),
-              borderColor: color,
-              borderWidth: 2,
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  color.withValues(alpha: 0.35),
-                  color.withValues(alpha: 0.02),
-                ],
-              ),
-            )
-          else
-            LineSeries<_ChartPoint, num>(
-              dataSource: pts,
-              xValueMapper: (d, _) => d.x,
-              yValueMapper: (d, _) => d.value,
-              color: color,
-              width: 1.75,
-            ),
-        ],
-      );
     }
 
-    // Scrubber overlay
-    return SizedBox(
-      height: widget.height,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onHorizontalDragUpdate: (details) =>
-            _handleScrub(details.localPosition.dx, context),
-        onHorizontalDragEnd: (_) {
-          setState(() => _scrubIndex = null);
-          widget.onScrub?.call(null);
-          widget.onScrubEnd?.call();
-        },
-        onHorizontalDragCancel: () {
-          setState(() => _scrubIndex = null);
-          widget.onScrub?.call(null);
-        },
-        onTapDown: (d) => _handleScrub(d.localPosition.dx, context),
-        child: Stack(
-          children: [
-            chartWidget,
-            if (_scrubIndex != null)
-              Positioned.fill(
-                child: IgnorePointer(
-                  child: CustomPaint(
-                    painter: _ScrubLinePainter(
-                      fraction: _scrubIndex! / (_points.length - 1).clamp(1, 99999),
-                      color: _lineColor,
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        ),
-      ),
+    final isLine = widget.style == ChartStyle.line;
+    return SfCartesianChart(
+      backgroundColor: Colors.transparent,
+      plotAreaBorderWidth: 0,
+      margin: EdgeInsets.zero,
+      primaryXAxis: edgeToEdgeIndexAxis(pts.length),
+      primaryYAxis: hiddenValueAxis(minimum: bounds.min, maximum: bounds.max),
+      series: <CartesianSeries>[
+        if (!isLine)
+          SplineAreaSeries<_ChartPoint, num>(
+            dataSource: pts,
+            splineType: SplineType.monotonic,
+            xValueMapper: (d, _) => d.x,
+            yValueMapper: (d, _) => d.value,
+            color: color.withValues(alpha: 0.28),
+            borderColor: color,
+            borderWidth: 2,
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                color.withValues(alpha: 0.35),
+                color.withValues(alpha: 0.02),
+              ],
+            ),
+          )
+        else
+          SplineSeries<_ChartPoint, num>(
+            dataSource: pts,
+            splineType: SplineType.monotonic,
+            xValueMapper: (d, _) => d.x,
+            yValueMapper: (d, _) => d.value,
+            color: color,
+            width: 1.75,
+          ),
+      ],
     );
   }
 
-  void _handleScrub(double dx, BuildContext context) {
-    final pts = _points;
-    if (pts.isEmpty) return;
-    final w = context.size?.width ?? 300;
-    final frac = (dx / w).clamp(0.0, 1.0);
-    final idx = (frac * (pts.length - 1)).round().clamp(0, pts.length - 1);
-    if (idx != _scrubIndex) {
-      setState(() => _scrubIndex = idx);
-      widget.onScrub?.call(idx);
-    }
-  }
-}
-
-class _ScrubLinePainter extends CustomPainter {
-  _ScrubLinePainter({required this.fraction, required this.color});
-  final double fraction;
-  final Color color;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final x = size.width * fraction;
-    final paint = Paint()
-      ..color = color.withValues(alpha: 0.6)
-      ..strokeWidth = 1.2
-      ..style = PaintingStyle.stroke;
-    canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+  void _handleScrub(double dx, double width, int n) {
+    if (n == 0 || width <= 0) return;
+    final frac = (dx / width).clamp(0.0, 1.0);
+    final idx = fractionToIndex(frac, n);
+    final prev = _scrub.value?.index;
+    // Draw hairline + dot at the data point's own fraction so they land on the
+    // curve and match the value the header reports.
+    _scrub.update(idx, indexToFraction(idx, n));
+    if (idx != prev) widget.onScrub?.call(idx);
   }
 
-  @override
-  bool shouldRepaint(_ScrubLinePainter old) => old.fraction != fraction;
+  void _endScrub() {
+    if (_scrub.value == null) return;
+    _scrub.clear();
+    widget.onScrub?.call(null);
+    widget.onScrubEnd?.call();
+  }
 }
 
 // ── Range stats ───────────────────────────────────────────────────────────────

--- a/mobile/lib/features/live_trading/presentation/live_trading_screen.dart
+++ b/mobile/lib/features/live_trading/presentation/live_trading_screen.dart
@@ -32,7 +32,9 @@ class LiveTradingScreen extends ConsumerStatefulWidget {
 
 class _LiveTradingScreenState extends ConsumerState<LiveTradingScreen> {
   ChartStyle _chartStyle = ChartStyle.area;
-  int? _scrubIndex;
+  // Scrub index lives in a notifier so dragging the chart repaints only the
+  // equity value text below — not the whole screen.
+  final ValueNotifier<int?> _scrubIndex = ValueNotifier(null);
   bool _haltModalOpen = false;
   bool _haltConfirmed = false;
   final _haltReasonCtrl = TextEditingController(text: 'risk breach');
@@ -42,6 +44,7 @@ class _LiveTradingScreenState extends ConsumerState<LiveTradingScreen> {
   @override
   void dispose() {
     _haltReasonCtrl.dispose();
+    _scrubIndex.dispose();
     super.dispose();
   }
 
@@ -358,13 +361,6 @@ class _LiveTradingScreenState extends ConsumerState<LiveTradingScreen> {
     final range = s.currentRange;
     final stats = RangeStats.from(history);
 
-    // Scrub overlay: show the scrubbed value or live equity.
-    double displayEquity = ls.equity;
-    if (_scrubIndex != null && history != null && history.values.isNotEmpty) {
-      final idx = _scrubIndex!.clamp(0, history.values.length - 1);
-      displayEquity = history.values[idx];
-    }
-
     final changeColor = stats.isUp ? AppColors.chartUp : AppColors.chartDown;
 
     return GlassCard(
@@ -389,9 +385,24 @@ class _LiveTradingScreenState extends ConsumerState<LiveTradingScreen> {
                       ),
                     ),
                     const SizedBox(height: 4),
-                    Text(
-                      fmtMoney(displayEquity),
-                      style: AppTextStyles.valueXl,
+                    ValueListenableBuilder<int?>(
+                      valueListenable: _scrubIndex,
+                      builder: (_, scrubIdx, _) {
+                        // Show the scrubbed value or, when not scrubbing, the
+                        // live equity.
+                        var displayEquity = ls.equity;
+                        if (scrubIdx != null &&
+                            history != null &&
+                            history.values.isNotEmpty) {
+                          final idx =
+                              scrubIdx.clamp(0, history.values.length - 1);
+                          displayEquity = history.values[idx];
+                        }
+                        return Text(
+                          fmtMoney(displayEquity),
+                          style: AppTextStyles.valueXl,
+                        );
+                      },
                     ),
                     const SizedBox(height: 6),
                     Row(
@@ -458,8 +469,8 @@ class _LiveTradingScreenState extends ConsumerState<LiveTradingScreen> {
               style: _chartStyle,
               range: range,
               height: 240,
-              onScrub: (idx) => setState(() => _scrubIndex = idx),
-              onScrubEnd: () => setState(() => _scrubIndex = null),
+              onScrub: (idx) => _scrubIndex.value = idx,
+              onScrubEnd: () => _scrubIndex.value = null,
             )
           else
             SizedBox(

--- a/mobile/lib/features/live_trading/presentation/position_card.dart
+++ b/mobile/lib/features/live_trading/presentation/position_card.dart
@@ -263,8 +263,9 @@ class PositionCard extends StatelessWidget {
       ),
       series: <CartesianSeries>[
         if (!isLine)
-          AreaSeries<_SparkPoint, num>(
+          SplineAreaSeries<_SparkPoint, num>(
             dataSource: sparkPts,
+            splineType: SplineType.monotonic,
             xValueMapper: (d, _) => d.x,
             yValueMapper: (d, _) => d.value,
             color: color.withValues(alpha: 0.20),
@@ -280,8 +281,9 @@ class PositionCard extends StatelessWidget {
             ),
           )
         else
-          LineSeries<_SparkPoint, num>(
+          SplineSeries<_SparkPoint, num>(
             dataSource: sparkPts,
+            splineType: SplineType.monotonic,
             xValueMapper: (d, _) => d.x,
             yValueMapper: (d, _) => d.value,
             color: color,

--- a/mobile/lib/features/token_usage/presentation/token_usage_screen.dart
+++ b/mobile/lib/features/token_usage/presentation/token_usage_screen.dart
@@ -466,7 +466,10 @@ class _KpiGrid extends StatelessWidget {
 
     return Column(children: [
       // Row 1: Period cost + Period calls
-      Row(children: [
+      IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
         Expanded(child: GlassCard(padding: const EdgeInsets.all(16), child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -477,10 +480,16 @@ class _KpiGrid extends StatelessWidget {
             Text('${fmtTokens(totalTokens)} tokens · $totalCalls calls',
                 style: AppTextStyles.meta.copyWith(color: AppColors.textMuted)),
             const SizedBox(height: 8),
-            Wrap(spacing: 4, runSpacing: 4, children: topThree.isNotEmpty
-              ? topThree.map((p) => _providerPill(p)).toList()
-              : [Text('No provider spend', style: AppTextStyles.nano.copyWith(color: AppColors.textFaint))],
-            ),
+            // One pill per line (intrinsic-safe — Wrap throws under IntrinsicHeight).
+            if (topThree.isEmpty)
+              Text('No provider spend',
+                  style: AppTextStyles.nano.copyWith(color: AppColors.textFaint))
+            else
+              for (final p in topThree)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: _providerPill(p),
+                ),
           ],
         ))),
         const SizedBox(width: 12),
@@ -497,10 +506,15 @@ class _KpiGrid extends StatelessWidget {
             ]),
           ],
         ))),
-      ]),
+          ],
+        ),
+      ),
       const SizedBox(height: 12),
       // Row 2: Max plan estimate + Telemetry health
-      Row(children: [
+      IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
         Expanded(child: GlassCard(padding: const EdgeInsets.all(16), child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -536,7 +550,9 @@ class _KpiGrid extends StatelessWidget {
             ]),
           ],
         ))),
-      ]),
+          ],
+        ),
+      ),
     ]);
   }
 

--- a/mobile/test/core/charts/chart_geometry_test.dart
+++ b/mobile/test/core/charts/chart_geometry_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intellistock_mobile/core/charts/chart_geometry.dart';
+
+void main() {
+  group('fractionToIndex', () {
+    test('returns 0 for empty / single-point series', () {
+      expect(fractionToIndex(0.5, 0), 0);
+      expect(fractionToIndex(0.5, 1), 0);
+    });
+
+    test('maps fraction 0 -> first, 1 -> last', () {
+      expect(fractionToIndex(0.0, 5), 0);
+      expect(fractionToIndex(1.0, 5), 4);
+    });
+
+    test('rounds to nearest index', () {
+      // 5 points span fractions 0, .25, .5, .75, 1
+      expect(fractionToIndex(0.5, 5), 2);
+      expect(fractionToIndex(0.6, 5), 2); // 0.6*4 = 2.4 -> 2
+      expect(fractionToIndex(0.7, 5), 3); // 0.7*4 = 2.8 -> 3
+    });
+
+    test('clamps out-of-range fractions', () {
+      expect(fractionToIndex(-0.3, 5), 0);
+      expect(fractionToIndex(1.9, 5), 4);
+    });
+  });
+
+  group('indexToFraction', () {
+    test('returns 0 for empty / single-point series', () {
+      expect(indexToFraction(0, 0), 0.0);
+      expect(indexToFraction(3, 1), 0.0);
+    });
+
+    test('maps first -> 0, last -> 1, middle -> 0.5', () {
+      expect(indexToFraction(0, 5), closeTo(0.0, 1e-9));
+      expect(indexToFraction(4, 5), closeTo(1.0, 1e-9));
+      expect(indexToFraction(2, 5), closeTo(0.5, 1e-9));
+    });
+
+    test('round-trips with fractionToIndex', () {
+      for (var i = 0; i < 7; i++) {
+        expect(fractionToIndex(indexToFraction(i, 7), 7), i);
+      }
+    });
+
+    test('clamps out-of-range index', () {
+      expect(indexToFraction(-2, 5), 0.0);
+      expect(indexToFraction(99, 5), 1.0);
+    });
+  });
+
+  group('paddedBounds', () {
+    test('expands min/max by pad fraction of the span', () {
+      final b = paddedBounds([10.0, 20.0], padFraction: 0.1);
+      expect(b.min, closeTo(9.0, 1e-9)); // 10 - 0.1*10
+      expect(b.max, closeTo(21.0, 1e-9)); // 20 + 0.1*10
+    });
+
+    test('handles a flat series without collapsing to zero height', () {
+      final b = paddedBounds([5.0, 5.0, 5.0]);
+      expect(b.max, greaterThan(b.min));
+    });
+
+    test('returns a unit band for an empty series', () {
+      final b = paddedBounds(const []);
+      expect(b.min, 0.0);
+      expect(b.max, 1.0);
+    });
+  });
+
+  group('valueToY', () {
+    test('max value maps to top (y=0), min to bottom (y=height)', () {
+      expect(valueToY(20.0, 10.0, 20.0, 100.0), closeTo(0.0, 1e-9));
+      expect(valueToY(10.0, 10.0, 20.0, 100.0), closeTo(100.0, 1e-9));
+    });
+
+    test('midpoint maps to half height', () {
+      expect(valueToY(15.0, 10.0, 20.0, 100.0), closeTo(50.0, 1e-9));
+    });
+
+    test('clamps values outside the range', () {
+      expect(valueToY(30.0, 10.0, 20.0, 100.0), closeTo(0.0, 1e-9));
+      expect(valueToY(0.0, 10.0, 20.0, 100.0), closeTo(100.0, 1e-9));
+    });
+
+    test('degenerate range maps to mid-height', () {
+      expect(valueToY(5.0, 5.0, 5.0, 100.0), closeTo(50.0, 1e-9));
+    });
+  });
+}

--- a/mobile/test/core/charts/chart_geometry_test.dart
+++ b/mobile/test/core/charts/chart_geometry_test.dart
@@ -69,6 +69,44 @@ void main() {
     });
   });
 
+  group('nearestIndexByTime / timeFractionOf', () {
+    final base = DateTime(2026, 1, 1);
+    // Unevenly spaced: 0h, 1h, 5h (so index fraction != time fraction).
+    final ts = [base, base.add(const Duration(hours: 1)), base.add(const Duration(hours: 5))];
+
+    test('empty / single returns 0', () {
+      expect(nearestIndexByTime(const [], 0.5), 0);
+      expect(nearestIndexByTime([base], 0.9), 0);
+      expect(timeFractionOf(const [], 0), 0.0);
+      expect(timeFractionOf([base], 0), 0.0);
+    });
+
+    test('fraction 0 -> first, 1 -> last', () {
+      expect(nearestIndexByTime(ts, 0.0), 0);
+      expect(nearestIndexByTime(ts, 1.0), 2);
+    });
+
+    test('maps by time, not index', () {
+      // 0.5 of a 5h span = 2.5h -> closest is the 1h point (index 1), since the
+      // next point is at 5h. An index-based mapping would have chosen index 1
+      // too here, so use a clearer case: 0.7*5h = 3.5h -> closer to 5h (index 2).
+      expect(nearestIndexByTime(ts, 0.7), 2);
+      expect(nearestIndexByTime(ts, 0.1), 0); // 0.5h -> closer to 0h
+    });
+
+    test('timeFractionOf returns the point time fraction', () {
+      expect(timeFractionOf(ts, 0), closeTo(0.0, 1e-9));
+      expect(timeFractionOf(ts, 1), closeTo(0.2, 1e-9)); // 1h / 5h
+      expect(timeFractionOf(ts, 2), closeTo(1.0, 1e-9));
+    });
+
+    test('round-trips: nearestIndexByTime(timeFractionOf(i)) == i', () {
+      for (var i = 0; i < ts.length; i++) {
+        expect(nearestIndexByTime(ts, timeFractionOf(ts, i)), i);
+      }
+    });
+  });
+
   group('valueToY', () {
     test('max value maps to top (y=0), min to bottom (y=height)', () {
       expect(valueToY(20.0, 10.0, 20.0, 100.0), closeTo(0.0, 1e-9));

--- a/mobile/test/core/charts/scrub_controller_test.dart
+++ b/mobile/test/core/charts/scrub_controller_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intellistock_mobile/core/charts/scrub_controller.dart';
+
+void main() {
+  group('ScrubController', () {
+    test('starts empty', () {
+      final c = ScrubController(onTick: () {});
+      expect(c.value, isNull);
+    });
+
+    test('fires a haptic tick when the snapped index changes', () {
+      var ticks = 0;
+      final c = ScrubController(onTick: () => ticks++);
+
+      c.update(0, 0.0); // first touch -> tick
+      c.update(0, 0.04); // same index, finger moved -> no tick
+      c.update(1, 0.25); // new index -> tick
+      c.update(2, 0.5); // new index -> tick
+      c.update(2, 0.55); // same index -> no tick
+
+      expect(ticks, 3);
+    });
+
+    test('exposes the latest sample (index + fraction)', () {
+      final c = ScrubController(onTick: () {});
+      c.update(3, 0.72);
+      expect(c.value!.index, 3);
+      expect(c.value!.fraction, closeTo(0.72, 1e-9));
+    });
+
+    test('clear resets to empty and notifies once', () {
+      var notifications = 0;
+      final c = ScrubController(onTick: () {})..addListener(() => notifications++);
+      c.update(1, 0.3);
+      c.clear();
+      expect(c.value, isNull);
+      expect(notifications, 2); // update + clear
+    });
+
+    test('clear on an already-empty controller does not notify', () {
+      var notifications = 0;
+      final c = ScrubController(onTick: () {})..addListener(() => notifications++);
+      c.clear();
+      expect(notifications, 0);
+    });
+
+    test('notifies listeners on every update so the hairline follows the finger', () {
+      var notifications = 0;
+      final c = ScrubController(onTick: () {})..addListener(() => notifications++);
+      c.update(0, 0.0);
+      c.update(0, 0.1); // same index but should still notify (fraction changed)
+      expect(notifications, 2);
+    });
+  });
+}

--- a/mobile/test/features/chatbot/chat_models_test.dart
+++ b/mobile/test/features/chatbot/chat_models_test.dart
@@ -131,6 +131,23 @@ void main() {
       expect(conv.autoConfirmSafeTools, isFalse);
     });
 
+    test('reads auto_confirm_safe_tools nested under settings (backend shape)',
+        () {
+      // The backend stores/returns the flag at settings.auto_confirm_safe_tools,
+      // NOT at the top level — parsing the wrong place made the toggle revert.
+      final on = Conversation.fromJson({
+        'id': 'c',
+        'settings': {'auto_confirm_safe_tools': true},
+      });
+      expect(on.autoConfirmSafeTools, isTrue);
+
+      final off = Conversation.fromJson({
+        'id': 'c',
+        'settings': {'auto_confirm_safe_tools': false},
+      });
+      expect(off.autoConfirmSafeTools, isFalse);
+    });
+
     test('copyWith preserves unchanged fields', () {
       const original = Conversation(id: 'x', title: 'Old', modelId: 'mod');
       final updated = original.copyWith(title: 'New');

--- a/mobile/test/features/live_trading/equity_chart_scrub_test.dart
+++ b/mobile/test/features/live_trading/equity_chart_scrub_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intellistock_mobile/core/models/portfolio_history.dart';
@@ -46,19 +48,22 @@ void main() {
       final y = rect.top + 60;
 
       final gesture = await tester.startGesture(Offset(rect.left + 3, y));
-      await gesture.moveTo(Offset(rect.left + 5, y)); // recognise horizontal drag
+      await gesture.moveTo(Offset(rect.left + 30, y)); // exceed slop -> drag starts
       await tester.pump();
-      await gesture.moveTo(Offset(rect.right - 3, y)); // sweep to the far right
+      await gesture.moveTo(Offset(rect.left + 2, y)); // settle on the far left
+      await tester.pump();
+      await gesture.moveTo(Offset(rect.right - 2, y)); // sweep to the far right
       await tester.pump();
       await gesture.up();
       await tester.pump();
 
       final indices = reported.whereType<int>().toList();
       expect(indices, isNotEmpty, reason: 'reported=$reported rect=$rect');
-      expect(indices.first, lessThanOrEqualTo(1),
-          reason: 'reported=$reported rect=$rect'); // near the first point
-      expect(indices.last, greaterThanOrEqualTo(9),
-          reason: 'reported=$reported rect=$rect'); // near the last point
+      // Far left must report ~first point, far right ~last point.
+      expect(indices.reduce(min), lessThanOrEqualTo(1),
+          reason: 'reported=$reported rect=$rect');
+      expect(indices.reduce(max), greaterThanOrEqualTo(9),
+          reason: 'reported=$reported rect=$rect');
     },
   );
 }

--- a/mobile/test/features/live_trading/equity_chart_scrub_test.dart
+++ b/mobile/test/features/live_trading/equity_chart_scrub_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intellistock_mobile/core/models/portfolio_history.dart';
+import 'package:intellistock_mobile/features/live_trading/presentation/equity_chart.dart';
+
+void main() {
+  // Regression guard for the scrub-misalignment bug: dragging the left edge of
+  // the chart must report the FIRST data point and the right edge the LAST.
+  // The old scrubber mapped the finger across the full widget while the curve
+  // lived inside the y-axis label gutter, so the reported index was shifted.
+  testWidgets(
+    'scrub maps left edge -> first point and right edge -> last point',
+    (tester) async {
+      final history = PortfolioHistory(
+        timestamps: List.generate(
+          11,
+          (i) => DateTime(2026, 1, 1).add(Duration(minutes: i)),
+        ),
+        values: List.generate(11, (i) => i.toDouble()),
+      );
+
+      final reported = <int?>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 220,
+                child: EquityChart(
+                  history: history,
+                  style: ChartStyle.line,
+                  range: '1D',
+                  height: 240,
+                  onScrub: reported.add,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      // Let the series animation finish without relying on pumpAndSettle.
+      await tester.pump(const Duration(seconds: 2));
+
+      final rect = tester.getRect(find.byType(EquityChart));
+      final y = rect.top + 60;
+
+      final gesture = await tester.startGesture(Offset(rect.left + 3, y));
+      await gesture.moveTo(Offset(rect.left + 5, y)); // recognise horizontal drag
+      await tester.pump();
+      await gesture.moveTo(Offset(rect.right - 3, y)); // sweep to the far right
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      final indices = reported.whereType<int>().toList();
+      expect(indices, isNotEmpty, reason: 'reported=$reported rect=$rect');
+      expect(indices.first, lessThanOrEqualTo(1),
+          reason: 'reported=$reported rect=$rect'); // near the first point
+      expect(indices.last, greaterThanOrEqualTo(9),
+          reason: 'reported=$reported rect=$rect'); // near the last point
+    },
+  );
+}


### PR DESCRIPTION
- **docs: chart scrubbing & cleanup design spec**
- **feat(mobile): fix chart scrub alignment + Robinhood-style cleanup**
- **fix(mobile): green the scrub test + make equity chart drag-only**
- **feat(mobile): add chat settings sheet matching the web UI**
- **fix: track mobile backtests feature + apply chart cleanup**
- **fix(mobile): open chat settings sheet + render markdown in chat**
- **fix(mobile): equal-height KPI cards on Token Usage screen**
- **fix(mobile): render chat settings + confirms in-tree (no Navigator)**
- **fix(mobile): wrap chat settings sheet in a Material**
- **fix(mobile): parse auto_confirm_safe_tools from settings (toggle reverting)**
- **feat(mobile): reusable ScrubbableAreaChart with dashboard look & feel**
- **feat(mobile): modernize backtest screens**
