### PR TITLE
fix(kalshi): detect all live games — normalize team names + expand ESPN leagues

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4339,13 +4339,14 @@ _ESPN_BOARD_CACHE = {"ts": 0.0, "board": []}
 
 def _espn_live_board():
     """Process-wide ESPN scoreboard cache (~15s) so live-card reads stay fresh
-    without hammering ESPN per request."""
+    without hammering ESPN per request. Uses the full DEFAULT_SCOREBOARD_LEAGUES
+    list so all active competitions are reflected, not just the World Cup."""
     import time as _t
     now = _t.time()
     if now - _ESPN_BOARD_CACHE["ts"] > 15:
         try:
             from kalshi.live import scoreboard as _sb
-            _ESPN_BOARD_CACHE["board"] = _sb.fetch_scoreboard()
+            _ESPN_BOARD_CACHE["board"] = _sb.fetch_scoreboard(_sb.DEFAULT_SCOREBOARD_LEAGUES)
         except Exception:
             pass
         _ESPN_BOARD_CACHE["ts"] = now

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -117,6 +117,10 @@ class EngineConfig:
     devig_method: str = "power"
     odds_refresh_secs: int = 3600
     odds_regions: str = "eu,uk,us"
+    # Kalshi series to scan (empty = use discovery.DEFAULT_SOCCER_SERIES).
+    soccer_series: list = field(default_factory=list)
+    # ESPN league slugs for live-score lookups (empty = use scoreboard.DEFAULT_SCOREBOARD_LEAGUES).
+    scoreboard_leagues: list = field(default_factory=list)
 
 
 def run_once(
@@ -261,8 +265,10 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
     espn_cache: dict = {"ts": 0.0, "board": []}   # ESPN live scores+clock (timing only, ~30s)
     raw_dumped = False           # one-time raw-market field dump (price diagnostics)
     placed_markets: set = set()  # market_tickers already held/ordered — don't re-order
+    _soccer_series = config.soccer_series or discovery.DEFAULT_SOCCER_SERIES
+    _scoreboard_leagues = config.scoreboard_leagues or espn.DEFAULT_SCOREBOARD_LEAGUES
     odds_sport_keys = [k for k in (odds_api.sport_key_for_series(s)
-                                   for s in discovery.DEFAULT_SOCCER_SERIES) if k]
+                                   for s in _soccer_series) if k]
     if not config.odds_api_key:
         log("No odds API key — pricing model-only. Set odds_api_key (or ODDS_API_KEY env) "
             "to anchor fair value to sharp bookmaker odds and trade where Kalshi disagrees.", "yellow")
@@ -291,7 +297,7 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
 
             # 2) Discover open Kalshi soccer markets by series (World Cup = KXWCGAME).
             soccer, total_raw = [], 0
-            for series in discovery.DEFAULT_SOCCER_SERIES:
+            for series in _soccer_series:
                 try:
                     rs = (client.list_markets(status="open", series_ticker=series, limit=500) or {}).get("markets", []) or []
                 except Exception as e:
@@ -318,11 +324,12 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                         p["kickoff_ts"] = match_clock.kickoff_from_market(m)
                         soccer.append(p)
             by_event = discovery.group_by_event(soccer)
-            log(f"tick {tick}: scanned series {discovery.DEFAULT_SOCCER_SERIES} → {total_raw} markets, "
+            log(f"tick {tick}: scanned series {_soccer_series} → {total_raw} markets, "
                 f"{len(soccer)} priceable, {len(by_event)} matches.", "cyan")
             if not by_event:
-                log(f"tick {tick}: no priceable soccer matches in {discovery.DEFAULT_SOCCER_SERIES}. "
-                    f"Add your leagues' series tickers to discovery.DEFAULT_SOCCER_SERIES.", "yellow")
+                log(f"tick {tick}: no priceable soccer matches in {_soccer_series}. "
+                    f"Add your leagues' series tickers to kalshi_config.soccer_series or "
+                    f"discovery.DEFAULT_SOCCER_SERIES.", "yellow")
                 time.sleep(config.poll_seconds)
                 continue
 
@@ -357,7 +364,7 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
             # act, instead of waiting on a price move. Cached ~30s.
             if now_wall - espn_cache["ts"] > 30:
                 try:
-                    espn_cache["board"] = espn.fetch_scoreboard()
+                    espn_cache["board"] = espn.fetch_scoreboard(_scoreboard_leagues)
                 except Exception:
                     espn_cache["board"] = espn_cache.get("board") or []
                 espn_cache["ts"] = now_wall

--- a/backend/kalshi/instance_config.py
+++ b/backend/kalshi/instance_config.py
@@ -62,6 +62,10 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
                          in ("power", "shin", "proportional") else "power"),
         "odds_refresh_secs": max(300, int(raw.get("odds_refresh_secs", 3600))),
         "odds_regions": str(raw.get("odds_regions") or "eu,uk,us").strip() or "eu,uk,us",
+        # Kalshi series tickers to scan ([] = engine uses DEFAULT_SOCCER_SERIES).
+        "soccer_series": [str(s).strip() for s in (raw.get("soccer_series") or []) if str(s).strip()],
+        # ESPN league slugs for live-score detection ([] = engine uses DEFAULT_SCOREBOARD_LEAGUES).
+        "scoreboard_leagues": [str(s).strip() for s in (raw.get("scoreboard_leagues") or []) if str(s).strip()],
     }
 
 

--- a/backend/kalshi/live/scoreboard.py
+++ b/backend/kalshi/live/scoreboard.py
@@ -9,8 +9,22 @@ import re
 
 from kalshi.normalize import normalize_team
 
-# ESPN soccer league slugs to poll for live scores. World Cup = fifa.world.
-DEFAULT_SCOREBOARD_LEAGUES = ("fifa.world",)
+# ESPN soccer league slugs to poll for live scores. Add slugs here to cover
+# any competition that may have active Kalshi markets. The fetch is a single
+# HTTP call per slug; adding more only costs a few extra ms per scoreboard refresh.
+DEFAULT_SCOREBOARD_LEAGUES = (
+    "fifa.world",       # FIFA World Cup (main tournament)
+    "fifa.cwc",         # FIFA Club World Cup
+    "concacaf.gold",    # CONCACAF Gold Cup
+    "conmebol.copa",    # Copa America
+    "uefa.euro",        # UEFA European Championship
+    "concacaf.nations.league",  # CONCACAF Nations League
+    "uefa.nations",     # UEFA Nations League
+    "afc.asian.cup",    # AFC Asian Cup
+    "caf.africa_cup_of_nations",  # Africa Cup of Nations
+    "conmebol.world.qualifier",   # CONMEBOL World Cup Qualifiers
+    "fifa.friendly",    # International Friendlies
+)
 
 
 def _int(v):

--- a/backend/kalshi/normalize.py
+++ b/backend/kalshi/normalize.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # Canonical-name replacements, keyed by a normalized lookup form
 # (lowercase, collapsed whitespace, punctuation stripped).
 _REPLACEMENTS: dict[str, str] = {
+    # Club teams
     "man utd": "Manchester United",
     "man united": "Manchester United",
     "manchester utd": "Manchester United",
@@ -24,6 +25,32 @@ _REPLACEMENTS: dict[str, str] = {
     "psg": "Paris Saint-Germain",
     "inter": "Internazionale",
     "atletico": "Atletico Madrid",
+    # National teams — "&" vs "and" and other common variants that break
+    # substring matching between ESPN and Kalshi/FIFA spellings.
+    "bosnia herzegovina": "Bosnia and Herzegovina",
+    "bosnia and herzegovina": "Bosnia and Herzegovina",
+    "bosnia herzeg": "Bosnia and Herzegovina",
+    "czech republic": "Czech Republic",
+    "czechia": "Czech Republic",
+    "republic of ireland": "Republic of Ireland",
+    "north macedonia": "North Macedonia",
+    "north macedonia republic": "North Macedonia",
+    "ivory coast": "Ivory Coast",
+    "cote divoire": "Ivory Coast",
+    "cotedivoire": "Ivory Coast",
+    "united states": "United States",
+    "usa": "United States",
+    "us": "United States",
+    "korea republic": "South Korea",
+    "south korea": "South Korea",
+    "republic of korea": "South Korea",
+    "democratic republic of congo": "DR Congo",
+    "dr congo": "DR Congo",
+    "cape verde": "Cape Verde",
+    "trinidad tobago": "Trinidad and Tobago",
+    "trinidad and tobago": "Trinidad and Tobago",
+    "antigua barbuda": "Antigua and Barbuda",
+    "saint kitts nevis": "St. Kitts and Nevis",
 }
 
 

--- a/backend/kalshi/runner.py
+++ b/backend/kalshi/runner.py
@@ -118,6 +118,8 @@ def main(argv: list[str] | None = None) -> int:
             devig_method=str(cfg.get("devig_method", "power")),
             odds_refresh_secs=int(cfg.get("odds_refresh_secs", 3600)),
             odds_regions=str(cfg.get("odds_regions", "eu,uk,us")),
+            soccer_series=list(cfg.get("soccer_series") or []),
+            scoreboard_leagues=list(cfg.get("scoreboard_leagues") or []),
         )
     )
     return 0

--- a/backend/tests/test_kalshi_normalize.py
+++ b/backend/tests/test_kalshi_normalize.py
@@ -23,3 +23,20 @@ def test_crosswalk_extra_overrides():
     cw = TeamCrosswalk(extra={"the gunners": "Arsenal"})
     assert cw.normalize("The Gunners") == "Arsenal"
     assert cw.normalize("Man City") == "Manchester City"
+
+
+def test_national_team_ampersand_vs_and():
+    # ESPN uses "Bosnia & Herzegovina"; Kalshi/FIFA uses "Bosnia and Herzegovina".
+    # Both must normalize to the same canonical name so match_score can join them.
+    assert normalize_team("Bosnia & Herzegovina") == "Bosnia and Herzegovina"
+    assert normalize_team("Bosnia and Herzegovina") == "Bosnia and Herzegovina"
+
+
+def test_national_team_aliases():
+    assert normalize_team("USA") == "United States"
+    assert normalize_team("Korea Republic") == "South Korea"
+    assert normalize_team("Czechia") == "Czech Republic"
+    assert normalize_team("Czech Republic") == "Czech Republic"
+    assert normalize_team("Ivory Coast") == "Ivory Coast"
+    assert normalize_team("Cote d'Ivoire") == "Ivory Coast"
+    assert normalize_team("Trinidad and Tobago") == "Trinidad and Tobago"

--- a/backend/tests/test_kalshi_scoreboard.py
+++ b/backend/tests/test_kalshi_scoreboard.py
@@ -1,4 +1,6 @@
-from kalshi.live.scoreboard import clock_minutes, live_status, match_score, parse_scoreboard
+from kalshi.live.scoreboard import (
+    DEFAULT_SCOREBOARD_LEAGUES, clock_minutes, live_status, match_score, parse_scoreboard,
+)
 
 
 def test_clock_minutes():
@@ -63,3 +65,26 @@ def test_match_score_by_name_and_flipped_orientation():
     f = match_score(board, "Austria", "Argentina")
     assert f["home"] == "Austria" and f["home_score"] == 1 and f["away_score"] == 2
     assert match_score(board, "Brazil", "France") is None
+
+
+def test_match_score_bosnia_ampersand_vs_and():
+    # ESPN returns "Bosnia & Herzegovina"; Kalshi titles say "Bosnia and Herzegovina".
+    # After normalize_team both must resolve to the same canonical name.
+    espn_payload = {"events": [{"competitions": [{
+        "status": {"type": {"state": "in", "shortDetail": "59'"}},
+        "competitors": [
+            {"homeAway": "home", "score": "2", "team": {"displayName": "Bosnia & Herzegovina"}},
+            {"homeAway": "away", "score": "1", "team": {"displayName": "Qatar"}},
+        ],
+    }]}]}
+    board = parse_scoreboard(espn_payload)
+    # Kalshi title-extracted name uses "and"; must still match the ESPN "&" entry.
+    result = match_score(board, "Bosnia and Herzegovina", "Qatar")
+    assert result is not None, "Bosnia and Herzegovina should match ESPN's 'Bosnia & Herzegovina'"
+    assert result["home_score"] == 2 and result["away_score"] == 1
+
+
+def test_default_scoreboard_leagues_covers_multiple_competitions():
+    assert "fifa.world" in DEFAULT_SCOREBOARD_LEAGUES
+    assert "fifa.cwc" in DEFAULT_SCOREBOARD_LEAGUES
+    assert len(DEFAULT_SCOREBOARD_LEAGUES) > 1


### PR DESCRIPTION
## Summary
- Fix team name mismatch between ESPN (`Bosnia & Herzegovina`) and Kalshi/FIFA (`Bosnia and Herzegovina`) that kept games stuck in PREGAME — added national team aliases to `normalize.py`
- Expand `DEFAULT_SCOREBOARD_LEAGUES` from just `fifa.world` to 11 competitions (Club World Cup, CONCACAF, Copa America, UEFA, etc.)
- Add `soccer_series` + `scoreboard_leagues` per-instance config fields so instances can target specific competitions
- Fix `_espn_live_board()` in API read path to also use the expanded league list

## Test plan
- [ ] All 27 unit tests pass (`test_kalshi_normalize.py`, `test_kalshi_scoreboard.py`, `test_kalshi_instance_config.py`, `test_kalshi_engine.py`)
- [ ] Multiple simultaneous live games (e.g. Bosnia vs Qatar + Switzerland vs Canada) both appear under LIVE NOW in the mobile app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpZe3XnGcMXejtgRXgWuWU