### PR TITLE
feat: add OpenRouter as a model provider (web + mobile, live catalog, pricing auto-fill)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -438,12 +438,21 @@ def _build_llm_test_provider_config(body: "LlmConfigTestBody") -> dict[str, Any]
         reasoning = str(body.bedrock_reasoning or "").strip().lower()
         if reasoning:
             config["bedrock_reasoning"] = reasoning
+    if provider == "openrouter":
+        base = str(body.openrouter_base_url or "").strip()
+        config["openrouter_base_url"] = base or "https://openrouter.ai/api/v1"
+        referer = str(body.openrouter_referer or "").strip()
+        if referer:
+            config["openrouter_referer"] = referer
+        title = str(body.openrouter_title or "").strip()
+        if title:
+            config["openrouter_title"] = title
     reasoning_effort = normalize_reasoning_effort(body.reasoning_effort)
     # claude-cli accepts ``--effort`` (low/medium/high/xhigh/max) too —
     # its session manager folds it into the spawn argv. Drop the value
     # only for providers where the LLM dispatcher doesn't actually
     # forward it (gemini/deepseek/anthropic-direct as of today).
-    if provider in {"openai", "azure", "nvidia", "claude-cli", "codex-cli"} and reasoning_effort:
+    if provider in {"openai", "azure", "nvidia", "openrouter", "claude-cli", "codex-cli"} and reasoning_effort:
         config["reasoning_effort"] = reasoning_effort
     return config
 
@@ -531,6 +540,12 @@ class LlmConfigTestBody(BaseModel):
     # bedrock_reasoning is "off"/"low"/"medium"/"high" (Claude 3.7+ only).
     bedrock_region: Optional[str] = Field(default=None, max_length=32)
     bedrock_reasoning: Optional[str] = Field(default=None, max_length=16)
+    # OpenRouter provider config — base_url defaults to the public API when
+    # omitted; referer/title are optional leaderboard-attribution headers
+    # (HTTP-Referer / X-Title).
+    openrouter_base_url: Optional[str] = Field(default=None, max_length=512)
+    openrouter_referer: Optional[str] = Field(default=None, max_length=512)
+    openrouter_title: Optional[str] = Field(default=None, max_length=128)
 
 
 class LlmConfigTestOutput(BaseModel):
@@ -571,6 +586,11 @@ class CreateModelBody(BaseModel):
     # equivalent of ollama_think ("off"/"low"/"medium"/"high", Claude 3.7+).
     bedrock_region: Optional[str] = Field(default=None, max_length=32)
     bedrock_reasoning: Optional[str] = Field(default=None, max_length=16)
+    # OpenRouter provider config — base_url defaults to the public API;
+    # referer/title are optional leaderboard-attribution headers.
+    openrouter_base_url: Optional[str] = Field(default=None, max_length=512)
+    openrouter_referer: Optional[str] = Field(default=None, max_length=512)
+    openrouter_title: Optional[str] = Field(default=None, max_length=128)
     # Optional cache-grouping tag: rows sharing this value share LLM cache (same
     # underlying model across providers/names). See canonical_model_cache_key.
     model_cache_family: Optional[str] = Field(default=None, max_length=64)
@@ -600,6 +620,9 @@ class EditModelBody(BaseModel):
     ollama_think: Optional[str] = Field(default=None, max_length=16)
     bedrock_region: Optional[str] = Field(default=None, max_length=32)
     bedrock_reasoning: Optional[str] = Field(default=None, max_length=16)
+    openrouter_base_url: Optional[str] = Field(default=None, max_length=512)
+    openrouter_referer: Optional[str] = Field(default=None, max_length=512)
+    openrouter_title: Optional[str] = Field(default=None, max_length=128)
     model_cache_family: Optional[str] = Field(default=None, max_length=64)
     input_cost_per_1m: Optional[float] = Field(default=None, ge=0)
     output_cost_per_1m: Optional[float] = Field(default=None, ge=0)
@@ -2147,6 +2170,9 @@ def api_create_model(body: CreateModelBody, conn=Depends(conn_dependency), curre
             ollama_think=body.ollama_think,
             bedrock_region=body.bedrock_region,
             bedrock_reasoning=body.bedrock_reasoning,
+            openrouter_base_url=body.openrouter_base_url,
+            openrouter_referer=body.openrouter_referer,
+            openrouter_title=body.openrouter_title,
             model_cache_family=body.model_cache_family,
             input_cost_per_1m=body.input_cost_per_1m,
             output_cost_per_1m=body.output_cost_per_1m,

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2302,6 +2302,35 @@ def api_bedrock_list_models(
         )
 
 
+class OpenRouterListModelsBody(BaseModel):
+    base_url: Optional[str] = Field(default=None, max_length=512)
+
+
+# Imported lazily (like ollama_client / bedrock_client) so a missing dep at boot
+# never takes down the API; the endpoint surfaces errors as an empty list.
+import openrouter_client  # noqa: E402
+
+
+@app.post("/openrouter/list-models", response_class=JSONResponse)
+def api_openrouter_list_models(
+    body: OpenRouterListModelsBody,
+    current_user: dict = Depends(get_current_user),
+):
+    """Discovery endpoint: list the OpenRouter model catalog.
+
+    Body: ``{"base_url": str | null}`` (defaults to the public OpenRouter API).
+    No API key required — the catalog is public.
+
+    Returns: ``{"models": [{"id", "name", "context_length", "pricing"}, …],
+    "error": str | null}``. ``pricing`` is the raw OpenRouter object (USD per
+    token, string values) so the UI can auto-fill the per-row cost overrides.
+    On any failure ``models`` is ``[]`` and the UI falls back to manual entry.
+    """
+    base_url = str((body.base_url or openrouter_client.DEFAULT_BASE_URL)).strip()
+    models = openrouter_client.list_models(base_url)
+    return {"models": models, "error": None if models else "No models returned (discovery unavailable)"}
+
+
 @app.post("/models/{model_id}/test-cli", response_class=JSONResponse)
 async def api_test_claude_cli(
     model_id: str,

--- a/backend/interactive_utils.py
+++ b/backend/interactive_utils.py
@@ -8465,6 +8465,8 @@ def action_create_model(conn, name, provider, model, api_key=None,
                         ollama_base_url=None, ollama_keep_alive=None,
                         ollama_think=None,
                         bedrock_region=None, bedrock_reasoning=None,
+                        openrouter_base_url=None, openrouter_referer=None,
+                        openrouter_title=None,
                         model_cache_family=None,
                         input_cost_per_1m=None, output_cost_per_1m=None,
                         cache_creation_cost_per_1m=None,
@@ -8500,6 +8502,13 @@ def action_create_model(conn, name, provider, model, api_key=None,
         # time; reasoning is "off"/"low"/"medium"/"high".
         "bedrock_region": (bedrock_region or "").strip(),
         "bedrock_reasoning": (bedrock_reasoning or "").strip().lower(),
+        # OpenRouter-specific (empty for non-openrouter rows; the dispatcher
+        # only reads them when provider == "openrouter"). base_url defaults to
+        # the public API; referer/title are optional leaderboard-attribution
+        # headers (HTTP-Referer / X-Title).
+        "openrouter_base_url": (openrouter_base_url or "").strip(),
+        "openrouter_referer": (openrouter_referer or "").strip(),
+        "openrouter_title": (openrouter_title or "").strip(),
         # Cache-grouping tag (canonical_model_cache_key override).
         "model_cache_family": (model_cache_family or "").strip().lower(),
         # Optional per-model pricing override ($/1M tokens). None means
@@ -8574,7 +8583,9 @@ def action_edit_model(conn, model_id, **kwargs):
                   "azure_openai_api_version", "reasoning_effort",
                   "cli_path", "extra_args",
                   "ollama_base_url", "ollama_keep_alive", "ollama_think",
-                  "bedrock_region", "bedrock_reasoning", "model_cache_family",
+                  "bedrock_region", "bedrock_reasoning",
+                  "openrouter_base_url", "openrouter_referer", "openrouter_title",
+                  "model_cache_family",
                   "input_cost_per_1m", "output_cost_per_1m",
                   "cache_creation_cost_per_1m", "cache_read_cost_per_1m"):
         if field not in kwargs:

--- a/backend/llm_pricing.yaml
+++ b/backend/llm_pricing.yaml
@@ -1,5 +1,10 @@
 # USD per 1M tokens. Per-model entries in the Models table override these.
 # Update when providers change pricing.
+#
+# OpenRouter models are NOT listed here: selecting a model in the Models UI
+# auto-fills its pricing into that row's per-model cost overrides (USD/token
+# from the catalog × 1e6 → USD/1M), which take precedence over this file.
+# See docs/openrouter-setup.md.
 
 claude-sonnet-4-6:
   provider: anthropic

--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -169,6 +169,7 @@ def _is_non_retryable_filter_response(
 GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta"
 _STRUCTURED_LLM_PROVIDER_LOCKS: dict[str, threading.Lock] = {
     "gemini": threading.Lock(),
+    "openrouter": threading.Lock(),
 }
 _LAST_STRUCTURED_LLM_CALL = threading.local()
 _LAST_PLAIN_LLM_CALL_ERROR = threading.local()  # stores last error from _call_openai/_call_azure_openai
@@ -234,6 +235,8 @@ def resolve_api_key_for_provider(provider: str, explicit_api_key: str | None = N
         return str(os.environ.get("OLLAMA_API_KEY") or "").strip()
     if p == "bedrock":
         return str(os.environ.get("BEDROCK_API_KEY") or "").strip()
+    if p == "openrouter":
+        return str(os.environ.get("OPENROUTER_API_KEY") or "").strip()
     return str(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY") or "").strip()
 
 
@@ -735,6 +738,36 @@ def _resolve_provider_config(provider: str, provider_config: dict[str, Any] | No
             resolved["reasoning_effort"] = reasoning_effort
         else:
             resolved.pop("reasoning_effort", None)
+    elif p == "openrouter":
+        base_url = str(
+            resolved.get("openrouter_base_url")
+            or os.environ.get("OPENROUTER_BASE_URL")
+            or "https://openrouter.ai/api/v1"
+        ).strip().rstrip("/")
+        resolved["openrouter_base_url"] = base_url
+        referer = str(
+            resolved.get("openrouter_referer")
+            or os.environ.get("OPENROUTER_HTTP_REFERER")
+            or ""
+        ).strip()
+        if referer:
+            resolved["openrouter_referer"] = referer
+        else:
+            resolved.pop("openrouter_referer", None)
+        title = str(
+            resolved.get("openrouter_title")
+            or os.environ.get("OPENROUTER_X_TITLE")
+            or ""
+        ).strip()
+        if title:
+            resolved["openrouter_title"] = title
+        else:
+            resolved.pop("openrouter_title", None)
+        reasoning_effort = normalize_reasoning_effort(resolved.get("reasoning_effort"))
+        if reasoning_effort:
+            resolved["reasoning_effort"] = reasoning_effort
+        else:
+            resolved.pop("reasoning_effort", None)
     elif p == "ollama":
         base = str(
             resolved.get("ollama_base_url")
@@ -813,6 +846,12 @@ def _safe_provider_meta(provider: str, provider_config: dict[str, Any] | None = 
         if reasoning and reasoning != "off":
             meta["bedrock_reasoning"] = reasoning
         return meta
+    if p == "openrouter":
+        meta = {"base_url": str(config.get("openrouter_base_url") or "https://openrouter.ai/api/v1")}
+        reasoning_effort = normalize_reasoning_effort(config.get("reasoning_effort"))
+        if reasoning_effort:
+            meta["reasoning_effort"] = reasoning_effort
+        return meta
     return {}
 
 
@@ -835,7 +874,7 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         # without triggering the broken schema constraint.
         lowered_model = str(model_name or "").strip().lower()
         return (
-            provider_name in {"azure", "openai", "nvidia"}
+            provider_name in {"azure", "openai", "nvidia", "openrouter"}
             and _model_skips_json_object_format(lowered_model)
         )
 
@@ -960,6 +999,28 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
                 api_key=effective_key,
             ),
         )
+    if p == "openrouter":
+        base_url = str(resolved.get("openrouter_base_url") or "https://openrouter.ai/api/v1").strip().rstrip("/")
+        referer = str(resolved.get("openrouter_referer") or "").strip()
+        title = str(resolved.get("openrouter_title") or "").strip()
+        default_headers: dict[str, str] = {}
+        if referer:
+            default_headers["HTTP-Referer"] = referer
+        if title:
+            default_headers["X-Title"] = title
+        profile = _prompted_json_profile() if _prefers_prompted_structured_output(p, model) else None
+        if default_headers:
+            try:
+                from openai import AsyncOpenAI as _AsyncOpenAI
+                _client = _AsyncOpenAI(base_url=base_url, api_key=api_key, default_headers=default_headers)
+                return OpenAIChatModel(model, provider=OpenAIProvider(openai_client=_client), profile=profile)
+            except Exception:
+                pass  # fall through to header-less provider on any client-construction issue
+        return OpenAIChatModel(
+            model,
+            provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+            profile=profile,
+        )
     return GoogleModel(
         model,
         provider=GoogleProvider(api_key=api_key),
@@ -1025,11 +1086,12 @@ def _is_terminal_provider_not_found(provider: str, exc: Exception) -> bool:
             or ("404" in lowered and "is not supported for generatecontent" in lowered)
             or "models/" in lowered and "is not found" in lowered
         )
-    if p in ("openai", "nvidia"):
+    if p in ("openai", "nvidia", "openrouter"):
         return (
             "model_not_found" in lowered
             or ("404" in lowered and "does not exist" in lowered)
             or ("404" in lowered and "the model" in lowered)
+            or ("404" in lowered and "no endpoints found" in lowered)
         )
     if p in ("anthropic", "claude"):
         return (
@@ -1095,6 +1157,11 @@ def _terminal_provider_not_found_hint(provider: str, model: str, provider_config
         cross_provider_hint = (
             f" The model name {name!r} doesn't belong to Anthropic — change "
             "provider to match (openai or gemini)."
+        )
+    elif p == "openrouter" and name and "/" not in name:
+        cross_provider_hint = (
+            f" OpenRouter model ids are 'vendor/model' (e.g. 'anthropic/claude-3.5-sonnet'); "
+            f"{name!r} has no '/' and is probably wrong."
         )
     if cross_provider_hint:
         return cross_provider_hint.strip()
@@ -4443,6 +4510,153 @@ def _call_nvidia(
         return ""
 
 
+def _call_openrouter(
+    api_key: str,
+    model: str,
+    prompt: str,
+    max_output_tokens: int = 256,
+    timeout_sec: int | None = None,
+    retries: int = 0,
+    base_url: str = "",
+    response_mime_type: str | None = None,
+    reasoning_effort: str = "",
+    referer: str = "",
+    title: str = "",
+) -> str:
+    """Call OpenRouter (OpenAI-compatible /chat/completions). Structural clone of
+    _call_nvidia without NVIDIA's RPM limiter, plus optional attribution headers
+    (HTTP-Referer / X-Title) and reasoning-effort passthrough."""
+    if not api_key:
+        return ""
+    try:
+        import requests as _requests
+        url = (base_url or "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions"
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+        if referer:
+            headers["HTTP-Referer"] = referer
+        if title:
+            headers["X-Title"] = title
+        body: dict = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "top_p": 0.95,
+        }
+        if not _omit_temperature(model):
+            body["temperature"] = 0.2
+        if max_output_tokens and max_output_tokens > 0:
+            body["max_tokens"] = max_output_tokens
+        effort = normalize_reasoning_effort(reasoning_effort)
+        if effort:
+            # OpenRouter accepts the OpenAI-style `reasoning_effort` alias AND its
+            # native `reasoning.effort` object — send both for max compatibility.
+            body["reasoning_effort"] = effort
+            body["reasoning"] = {"effort": effort}
+        if (
+            str(response_mime_type or "").strip().lower() == "application/json"
+            and not _model_skips_json_object_format(model)
+        ):
+            body["response_format"] = {"type": "json_object"}
+        timeout = _coerce_timeout_sec(timeout_sec)
+        max_retries = max(0, int(retries or 0))
+        retriable_status = {429, 500, 502, 503, 504}
+
+        for attempt in range(max_retries + 1):
+            attempt_timeout = timeout if attempt == 0 else timeout * 2
+            connect_timeout = min(15, attempt_timeout)
+            try:
+                r = _requests.post(url, headers=headers, json=body, timeout=(connect_timeout, attempt_timeout))
+            except _requests.exceptions.Timeout as _to_e:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt))
+                    continue
+                try:
+                    _stash_last_http(status=None, body=f"timeout after {attempt_timeout}s", exc=_to_e)
+                except Exception:
+                    pass
+                return ""
+            except _requests.exceptions.RequestException as _req_e:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt))
+                    continue
+                try:
+                    _resp = getattr(_req_e, "response", None)
+                    _stash_last_http(
+                        status=getattr(_resp, "status_code", None),
+                        body=(getattr(_resp, "text", "") if _resp is not None else str(_req_e))[:1000],
+                        exc=_req_e,
+                    )
+                except Exception:
+                    pass
+                return ""
+
+            if r.status_code in retriable_status and attempt < max_retries:
+                _nr_filter, _nr_tag = _is_non_retryable_filter_response(
+                    status=r.status_code, body=getattr(r, "text", "") or "",
+                )
+                if _nr_filter:
+                    import sys
+                    print(
+                        f"[llm_utils] OpenRouter {model!r}: non-retryable response ({_nr_tag}) at status {r.status_code}; skipping further retries.",
+                        file=sys.stderr, flush=True,
+                    )
+                else:
+                    wait = _retry_after_seconds(getattr(r, "headers", None)) or _http_retry_backoff_seconds(f"status_code: {r.status_code}", attempt)
+                    time.sleep(wait)
+                    continue
+
+            if r.status_code >= 400:
+                try:
+                    _err_body = r.json()
+                except Exception:
+                    _err_body = r.text[:500]
+                try:
+                    _stash_last_http(
+                        status=r.status_code,
+                        body=(r.text or "")[:1000] if hasattr(r, "text") else str(_err_body)[:1000],
+                        exc=None,
+                    )
+                except Exception:
+                    pass
+                raise RuntimeError(f"HTTP {r.status_code}: {_err_body}")
+            data = r.json()
+            _log_token_usage("openrouter", model, data)
+            choices = data.get("choices") or []
+            if not choices:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt))
+                    continue
+                return ""
+            message = choices[0].get("message") or {}
+            text = _extract_chat_message_text(message)
+            if text:
+                try:
+                    _stash_last_http(status=200, body=None, exc=None)
+                except Exception:
+                    pass
+                return text
+            if attempt < max_retries:
+                time.sleep(_backoff_sleep_seconds(attempt))
+                continue
+            return ""
+        return ""
+    except Exception as _exc:
+        _LAST_PLAIN_LLM_CALL_ERROR.error = str(_exc)
+        try:
+            tid = threading.get_ident()
+            with _LAST_HTTP_LOCK:
+                _already = tid in _LAST_HTTP_PER_THREAD
+            if not _already:
+                _resp = getattr(_exc, "response", None)
+                _stash_last_http(
+                    status=getattr(_resp, "status_code", None),
+                    body=(getattr(_resp, "text", "") if _resp is not None else str(_exc))[:1000],
+                    exc=_exc,
+                )
+        except Exception:
+            pass
+        return ""
+
+
 def _call_azure_openai(
     api_key: str,
     deployment_name: str,
@@ -5532,6 +5746,20 @@ def call_llm_by_provider(
             base_url=str(resolved.get("base_url") or ""),
             response_mime_type=response_mime_type,
             reasoning_effort=str(resolved.get("reasoning_effort") or ""),
+        )
+    elif p == "openrouter":
+        _result = _call_openrouter(
+            api_key,
+            model,
+            prompt,
+            max_output_tokens=max_output_tokens,
+            timeout_sec=timeout_sec,
+            retries=retries,
+            base_url=str(resolved.get("openrouter_base_url") or ""),
+            response_mime_type=response_mime_type,
+            reasoning_effort=str(resolved.get("reasoning_effort") or ""),
+            referer=str(resolved.get("openrouter_referer") or ""),
+            title=str(resolved.get("openrouter_title") or ""),
         )
     elif p == "deepseek":
         _result = _call_deepseek(api_key, model, prompt, max_output_tokens, timeout_sec=timeout_sec, retries=retries)

--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -2699,7 +2699,7 @@ def call_structured_llm_by_provider(
                 if http_attempt == 0:
                     _LAST_STRUCTURED_LLM_CALL.data["attempted_models"].append(structured_model)
                 _model_forces_raw = (
-                    (provider or "").strip().lower() in {"azure", "openai", "nvidia"}
+                    (provider or "").strip().lower() in {"azure", "openai", "nvidia", "openrouter"}
                     and _model_skips_json_object_format(structured_model)
                 )
                 force_raw_json = prefer_raw_json or _model_forces_raw

--- a/backend/model_resolver.py
+++ b/backend/model_resolver.py
@@ -163,6 +163,13 @@ def resolve_model_refs_in_config(conn, config: dict, *, force_refresh: bool = Fa
             # non-bedrock row never injects empty bedrock keys.
             "bedrock_region": f"{prefix}bedrock_region",
             "bedrock_reasoning": f"{prefix}bedrock_reasoning",
+            # OpenRouter-specific propagation: base_url + optional attribution
+            # headers (HTTP-Referer / X-Title). Not in always_overwrite — only
+            # set when the row has them, so a non-openrouter row never injects
+            # empty openrouter keys.
+            "openrouter_base_url": f"{prefix}openrouter_base_url",
+            "openrouter_referer": f"{prefix}openrouter_referer",
+            "openrouter_title": f"{prefix}openrouter_title",
             # Cache-grouping override (canonical_model_cache_key).
             "model_cache_family": f"{prefix}model_cache_family",
         }

--- a/backend/openrouter_client.py
+++ b/backend/openrouter_client.py
@@ -1,0 +1,50 @@
+"""OpenRouter model-discovery client.
+
+Backs the ``POST /openrouter/list-models`` endpoint and the web LLM-config
+dropdown. OpenRouter's catalog is a public ``GET {base_url}/models`` — no auth
+required. Never raises: returns ``[]`` on any failure so the caller falls back
+to manual model-id entry (same contract as the Bedrock/Ollama discovery paths).
+
+Each returned row preserves the raw ``pricing`` object (USD **per token**,
+string values) so the frontend can auto-fill the per-row cost-override fields
+(``× 1e6`` → USD per 1M tokens).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def list_models(base_url: str = DEFAULT_BASE_URL, *, timeout_sec: float = 15.0) -> list[dict[str, Any]]:
+    """Return the OpenRouter model catalog as a list of
+    ``{id, name, context_length, pricing}`` rows, sorted by id.
+
+    Never raises — returns ``[]`` on network/parse error.
+    """
+    base = str(base_url or DEFAULT_BASE_URL).strip().rstrip("/")
+    if not base:
+        base = DEFAULT_BASE_URL
+    try:
+        import requests
+        r = requests.get(f"{base}/models", timeout=timeout_sec)
+        r.raise_for_status()
+        data = r.json() or {}
+    except Exception:
+        return []
+    rows: list[dict[str, Any]] = []
+    for m in (data.get("data") or []):
+        if not isinstance(m, dict):
+            continue
+        mid = str(m.get("id") or "").strip()
+        if not mid:
+            continue
+        pricing = m.get("pricing")
+        rows.append({
+            "id": mid,
+            "name": str(m.get("name") or mid),
+            "context_length": m.get("context_length"),
+            "pricing": pricing if isinstance(pricing, dict) else {},
+        })
+    rows.sort(key=lambda x: x["id"])
+    return rows

--- a/backend/tests/test_models_api_openrouter.py
+++ b/backend/tests/test_models_api_openrouter.py
@@ -1,0 +1,144 @@
+"""Tests for OpenRouter-specific Models CRUD + discovery in backend/api/main.py
+and backend/interactive_utils.py. Mirrors test_models_api_bedrock.py."""
+import importlib
+
+import pytest
+
+
+def _import_body(name: str):
+    mod = importlib.import_module("api.main")
+    return getattr(mod, name)
+
+
+# ─────────────────── body classes accept openrouter fields ──────────────────
+def test_create_model_body_accepts_openrouter_fields():
+    CreateModelBody = _import_body("CreateModelBody")
+    b = CreateModelBody(
+        name="OR Claude", provider="openrouter",
+        model="anthropic/claude-3.5-sonnet", api_key="sk-or-k",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+        openrouter_referer="https://intellistock.app",
+        openrouter_title="IntelliStock")
+    assert b.openrouter_base_url == "https://openrouter.ai/api/v1"
+    assert b.openrouter_referer == "https://intellistock.app"
+    assert b.openrouter_title == "IntelliStock"
+
+
+def test_edit_model_body_accepts_openrouter_fields():
+    EditModelBody = _import_body("EditModelBody")
+    b = EditModelBody(openrouter_base_url="https://proxy/api/v1", openrouter_title="X")
+    assert b.openrouter_base_url == "https://proxy/api/v1"
+    assert b.openrouter_title == "X"
+
+
+def test_llm_config_test_body_accepts_openrouter_fields():
+    LlmConfigTestBody = _import_body("LlmConfigTestBody")
+    b = LlmConfigTestBody(provider="openrouter", model="anthropic/claude-3.5-sonnet",
+                          api_key="k", openrouter_referer="https://x")
+    assert b.openrouter_referer == "https://x"
+
+
+# ─────────────── _build_llm_test_provider_config branch ────────────────────
+def test_build_llm_test_provider_config_openrouter():
+    from api.main import _build_llm_test_provider_config
+    LlmConfigTestBody = _import_body("LlmConfigTestBody")
+    body = LlmConfigTestBody(provider="openrouter", model="anthropic/claude-3.5-sonnet",
+                             api_key="k", openrouter_referer="https://intellistock.app",
+                             openrouter_title="IntelliStock", reasoning_effort="High")
+    cfg = _build_llm_test_provider_config(body)
+    assert cfg["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert cfg["openrouter_referer"] == "https://intellistock.app"
+    assert cfg["openrouter_title"] == "IntelliStock"
+    assert cfg["reasoning_effort"] == "high"
+
+
+def test_build_llm_test_provider_config_openrouter_defaults_base():
+    from api.main import _build_llm_test_provider_config
+    LlmConfigTestBody = _import_body("LlmConfigTestBody")
+    body = LlmConfigTestBody(provider="openrouter", model="openai/gpt-4o-mini", api_key="k")
+    cfg = _build_llm_test_provider_config(body)
+    assert cfg["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert "openrouter_referer" not in cfg
+    assert "openrouter_title" not in cfg
+
+
+# ─────────────── POST /openrouter/list-models endpoint ─────────────────────
+@pytest.fixture
+def app_client():
+    from fastapi.testclient import TestClient
+    from api import main as api_main
+    app = api_main.app
+    app.dependency_overrides[api_main.get_current_user] = lambda: {
+        "id": "test-user", "username": "test", "role": "user"}
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_openrouter_list_models_happy_path(app_client):
+    from unittest.mock import patch, Mock
+    fake = [{"id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet",
+             "context_length": 200000, "pricing": {"prompt": "0.000003", "completion": "0.000015"}}]
+    with patch("api.main.openrouter_client.list_models", new=Mock(return_value=fake)):
+        resp = app_client.post("/openrouter/list-models", json={})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["models"] == fake
+    assert resp.json()["error"] is None
+
+
+def test_openrouter_list_models_empty_sets_error(app_client):
+    from unittest.mock import patch, Mock
+    with patch("api.main.openrouter_client.list_models", new=Mock(return_value=[])):
+        resp = app_client.post("/openrouter/list-models", json={})
+    assert resp.status_code == 200
+    assert resp.json()["models"] == []
+    assert resp.json()["error"]
+
+
+def test_openrouter_list_models_passes_base_url(app_client):
+    from unittest.mock import patch
+    captured = {}
+
+    def _fake(base_url, **kw):
+        captured["base_url"] = base_url
+        return [{"id": "x/y", "name": "Y", "context_length": None, "pricing": {}}]
+
+    with patch("api.main.openrouter_client.list_models", new=_fake):
+        resp = app_client.post("/openrouter/list-models", json={"base_url": "https://proxy/api/v1"})
+    assert resp.status_code == 200
+    assert captured["base_url"] == "https://proxy/api/v1"
+
+
+# ─────────────── interactive_utils action round-trips ──────────────────────
+def test_action_create_model_persists_openrouter_fields(monkeypatch):
+    import interactive_utils as iu
+    from unittest.mock import MagicMock
+    fake_r = MagicMock()
+    fake_r.db.return_value.table.return_value.insert.return_value.run.return_value = {"generated_keys": ["new-id"]}
+    monkeypatch.setattr(iu, "r", fake_r)
+    monkeypatch.setattr(iu, "_ensure_models_table", lambda conn: None)
+    iu.action_create_model(
+        None, "or", "openrouter", "anthropic/claude-3.5-sonnet",
+        api_key="key", openrouter_base_url="https://openrouter.ai/api/v1",
+        openrouter_referer="https://intellistock.app", openrouter_title="IntelliStock")
+    doc = fake_r.db.return_value.table.return_value.insert.call_args.args[0]
+    assert doc["provider"] == "openrouter"
+    assert doc["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert doc["openrouter_referer"] == "https://intellistock.app"
+    assert doc["openrouter_title"] == "IntelliStock"
+
+
+def test_action_edit_model_updates_openrouter_fields(monkeypatch):
+    import interactive_utils as iu
+    from unittest.mock import MagicMock
+    existing = {"id": "m1", "provider": "openrouter",
+                "model": "anthropic/claude-3.5-sonnet",
+                "openrouter_base_url": "https://openrouter.ai/api/v1"}
+    fake_r = MagicMock()
+    fake_r.db.return_value.table.return_value.get.return_value.run.return_value = existing
+    monkeypatch.setattr(iu, "r", fake_r)
+    monkeypatch.setattr(iu, "_ensure_models_table", lambda conn: None)
+    iu.action_edit_model(None, "m1", openrouter_referer="https://new.app",
+                         openrouter_title="New")
+    update = fake_r.db.return_value.table.return_value.get.return_value.update.call_args.args[0]
+    assert update["openrouter_referer"] == "https://new.app"
+    assert update["openrouter_title"] == "New"

--- a/backend/tests/test_openrouter_client.py
+++ b/backend/tests/test_openrouter_client.py
@@ -1,0 +1,81 @@
+import openrouter_client
+
+
+def test_list_models_normalizes(monkeypatch):
+    payload = {"data": [
+        {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini", "context_length": 128000,
+         "pricing": {"prompt": "0.00000015", "completion": "0.0000006"}},
+        {"id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet",
+         "context_length": 200000,
+         "pricing": {"prompt": "0.000003", "completion": "0.000015",
+                     "input_cache_read": "0.0000003", "input_cache_write": "0.00000375"}},
+    ]}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    import requests
+    monkeypatch.setattr(requests, "get", lambda url, timeout=None: _Resp())
+    rows = openrouter_client.list_models()
+    # Sorted by id → anthropic first.
+    assert rows[0]["id"] == "anthropic/claude-3.5-sonnet"
+    assert rows[0]["pricing"]["prompt"] == "0.000003"
+    assert rows[0]["context_length"] == 200000
+    assert rows[1]["id"] == "openai/gpt-4o-mini"
+
+
+def test_list_models_skips_malformed(monkeypatch):
+    payload = {"data": [
+        {"name": "no id here"},
+        "not a dict",
+        {"id": "x/y", "name": "Y"},
+    ]}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    import requests
+    monkeypatch.setattr(requests, "get", lambda url, timeout=None: _Resp())
+    rows = openrouter_client.list_models()
+    assert [r["id"] for r in rows] == ["x/y"]
+    assert rows[0]["pricing"] == {}
+
+
+def test_list_models_error_returns_empty(monkeypatch):
+    import requests
+
+    def _boom(url, timeout=None):
+        raise requests.RequestException("down")
+
+    monkeypatch.setattr(requests, "get", _boom)
+    assert openrouter_client.list_models() == []
+
+
+def test_list_models_custom_base_url(monkeypatch):
+    seen = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": []}
+
+    def _get(url, timeout=None):
+        seen["url"] = url
+        return _Resp()
+
+    import requests
+    monkeypatch.setattr(requests, "get", _get)
+    openrouter_client.list_models("https://proxy.example/api/v1/")
+    assert seen["url"] == "https://proxy.example/api/v1/models"

--- a/backend/tests/test_openrouter_provider.py
+++ b/backend/tests/test_openrouter_provider.py
@@ -1,0 +1,147 @@
+import pytest
+
+import llm_utils
+
+
+# ── Task 1: api key + config + meta ─────────────────────────────────────────
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-xyz")
+    assert llm_utils.resolve_api_key_for_provider("openrouter") == "sk-or-xyz"
+
+
+def test_api_key_explicit_wins(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "envkey")
+    assert llm_utils.resolve_api_key_for_provider("openrouter", "explicit") == "explicit"
+
+
+def test_resolve_config_defaults(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    cfg = llm_utils._resolve_provider_config("openrouter", {})
+    assert cfg["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+
+
+def test_resolve_config_headers_and_reasoning():
+    cfg = llm_utils._resolve_provider_config("openrouter", {
+        "openrouter_referer": "https://intellistock.app",
+        "openrouter_title": "IntelliStock",
+        "reasoning_effort": "HIGH",
+    })
+    assert cfg["openrouter_referer"] == "https://intellistock.app"
+    assert cfg["openrouter_title"] == "IntelliStock"
+    assert cfg["reasoning_effort"] == "high"
+
+
+def test_resolve_config_base_url_env(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://proxy.example/api/v1/")
+    cfg = llm_utils._resolve_provider_config("openrouter", {})
+    assert cfg["openrouter_base_url"] == "https://proxy.example/api/v1"
+
+
+def test_safe_meta_no_secrets():
+    meta = llm_utils._safe_provider_meta("openrouter", {
+        "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://x", "reasoning_effort": "low",
+    })
+    assert meta["base_url"] == "https://openrouter.ai/api/v1"
+    assert "openrouter_referer" not in meta
+    assert meta["reasoning_effort"] == "low"
+
+
+# ── Task 2: structured model build + lock + 404 ─────────────────────────────
+@pytest.mark.skipif(not llm_utils._PYDANTIC_AI_AVAILABLE, reason="pydantic_ai not installed")
+def test_build_model_openrouter_base_url():
+    model = llm_utils._build_pydantic_ai_model(
+        "openrouter", "sk-or-x", "anthropic/claude-3.5-sonnet",
+        {"openrouter_base_url": "https://openrouter.ai/api/v1"},
+    )
+    assert model is not None
+    blob = " ".join(str(x) for x in (
+        getattr(model, "base_url", ""),
+        getattr(getattr(model, "client", None), "base_url", ""),
+        getattr(getattr(model, "_provider", None), "base_url", ""),
+    ))
+    assert "openrouter.ai" in blob
+
+
+@pytest.mark.skipif(not llm_utils._PYDANTIC_AI_AVAILABLE, reason="pydantic_ai not installed")
+def test_build_model_openrouter_with_headers():
+    model = llm_utils._build_pydantic_ai_model(
+        "openrouter", "sk-or-x", "anthropic/claude-3.5-sonnet",
+        {"openrouter_base_url": "https://openrouter.ai/api/v1",
+         "openrouter_referer": "https://intellistock.app",
+         "openrouter_title": "IntelliStock"},
+    )
+    assert model is not None
+
+
+def test_lock_registered():
+    assert "openrouter" in llm_utils._STRUCTURED_LLM_PROVIDER_LOCKS
+
+
+def test_terminal_not_found_openrouter():
+    exc = RuntimeError("HTTP 404: model_not_found")
+    assert llm_utils._is_terminal_provider_not_found("openrouter", exc) is True
+
+
+# ── Task 3: plain path + dispatch ───────────────────────────────────────────
+def test_call_openrouter_posts_chat_completions(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        headers = {}
+        text = ""
+
+        def json(self):
+            return {"choices": [{"message": {"content": "hello"}}]}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = json
+        return _Resp()
+
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+    out = llm_utils._call_openrouter(
+        "sk-or-x", "anthropic/claude-3.5-sonnet", "hi",
+        referer="https://intellistock.app", title="IntelliStock",
+        reasoning_effort="high",
+    )
+    assert out == "hello"
+    assert captured["url"].endswith("/chat/completions")
+    assert captured["url"].startswith("https://openrouter.ai/api/v1")
+    assert captured["headers"]["Authorization"] == "Bearer sk-or-x"
+    assert captured["headers"]["HTTP-Referer"] == "https://intellistock.app"
+    assert captured["headers"]["X-Title"] == "IntelliStock"
+    assert captured["body"]["reasoning_effort"] == "high"
+    assert captured["body"]["reasoning"] == {"effort": "high"}
+
+
+def test_call_openrouter_no_headers_when_unset(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        headers = {}
+        text = ""
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        captured["body"] = json
+        return _Resp()
+
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+    out = llm_utils._call_openrouter("sk-or-x", "openai/gpt-4o-mini", "hi")
+    assert out == "ok"
+    assert "HTTP-Referer" not in captured["headers"]
+    assert "X-Title" not in captured["headers"]
+    assert "reasoning_effort" not in captured["body"]
+
+
+def test_call_openrouter_empty_key_returns_empty():
+    assert llm_utils._call_openrouter("", "openai/gpt-4o-mini", "hi") == ""

--- a/backend/tests/test_openrouter_resolver.py
+++ b/backend/tests/test_openrouter_resolver.py
@@ -1,0 +1,34 @@
+import model_resolver
+
+
+class _FakeConn:
+    pass
+
+
+def test_openrouter_fields_injected(monkeypatch):
+    doc = {
+        "id": "m1", "provider": "openrouter", "model": "anthropic/claude-3.5-sonnet",
+        "api_key": "sk-or-x", "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://intellistock.app", "openrouter_title": "IntelliStock",
+    }
+    monkeypatch.setattr(model_resolver, "_get_model_from_cache_or_db", lambda c, mid: doc)
+    out = model_resolver.resolve_model_refs_in_config(_FakeConn(), {"llm_model_id": "m1"})
+    assert out["llm_provider"] == "openrouter"
+    assert out["llm_model"] == "anthropic/claude-3.5-sonnet"
+    assert out["llm_api_key"] == "sk-or-x"
+    assert out["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert out["openrouter_referer"] == "https://intellistock.app"
+    assert out["openrouter_title"] == "IntelliStock"
+
+
+def test_openrouter_optional_fields_absent(monkeypatch):
+    doc = {
+        "id": "m2", "provider": "openrouter", "model": "openai/gpt-4o-mini",
+        "api_key": "sk-or-y",
+    }
+    monkeypatch.setattr(model_resolver, "_get_model_from_cache_or_db", lambda c, mid: doc)
+    out = model_resolver.resolve_model_refs_in_config(_FakeConn(), {"llm_model_id": "m2"})
+    assert out["llm_provider"] == "openrouter"
+    # Optional header fields not present on the row → not injected.
+    assert "openrouter_referer" not in out
+    assert "openrouter_title" not in out

--- a/docs/openrouter-setup.md
+++ b/docs/openrouter-setup.md
@@ -1,0 +1,72 @@
+# OpenRouter Provider Setup
+
+IntelliStock supports [OpenRouter](https://openrouter.ai) as an LLM provider.
+OpenRouter is an OpenAI-compatible gateway to hundreds of models (Anthropic,
+OpenAI, Google, Meta, Mistral, DeepSeek, and more) behind a single API key.
+
+## 1. Get an API key
+
+Create a key at <https://openrouter.ai/keys>. It looks like `sk-or-v1-…`.
+
+## 2. Add a Model in IntelliStock
+
+In the web app go to **Models → New Model** (or the **Models** tab on mobile):
+
+| Field | Value |
+|-------|-------|
+| Provider | **OpenRouter** |
+| Model | A `vendor/model` id, e.g. `anthropic/claude-3.5-sonnet`, `openai/gpt-4o-mini`, `google/gemini-2.5-pro`. Pick from the live catalog dropdown, or type it. |
+| API Key | your `sk-or-…` key |
+| Base URL | leave as `https://openrouter.ai/api/v1` (only change for a self-hosted proxy) |
+| Reasoning Effort | optional — `Low` / `Medium` / `High` for thinking models |
+| HTTP-Referer / X-Title | optional — see *Attribution* below |
+
+The web **Model** dropdown is populated from OpenRouter's public catalog
+(`GET /api/v1/models`). Selecting a model also **auto-fills its pricing** into
+the per-model cost-override fields.
+
+## 3. Pricing auto-fill
+
+When you pick a model from the catalog dropdown, IntelliStock reads that model's
+catalog pricing (USD per token) and fills the per-row cost overrides, converting
+to USD per **1M tokens**:
+
+| OpenRouter catalog field | IntelliStock cost field |
+|--------------------------|-------------------------|
+| `prompt`                 | Input $/1M |
+| `completion`             | Output $/1M |
+| `input_cache_read`       | Cache-read $/1M |
+| `input_cache_write`      | Cache-create $/1M |
+
+These are a **prefill, not a lock** — edit or clear them before saving. They
+take precedence over `backend/llm_pricing.yaml` in telemetry cost accounting.
+
+**Limitation:** per-request, per-image, and web-search surcharges aren't
+representable in the per-1M-token cost model, so they aren't tracked (same as
+every other provider). Token costs are accurate.
+
+## 4. Attribution (optional)
+
+OpenRouter can attribute usage to your app on its public leaderboard. Set:
+
+- **HTTP-Referer** — your site URL (required for an app page to be created)
+- **X-Title** — your app's display name
+
+Both are optional; calls work fine without them. They're sent as request
+headers only when set.
+
+## Environment-variable fallback (optional)
+
+Instead of (or in addition to) per-row values, the backend reads:
+
+- `OPENROUTER_API_KEY` — used when a Model row leaves the key blank
+- `OPENROUTER_BASE_URL` — overrides the default base URL
+- `OPENROUTER_HTTP_REFERER`, `OPENROUTER_X_TITLE` — default attribution headers
+
+## Notes
+
+- Model ids are namespaced `vendor/model`. A bare name (no `/`) is almost
+  always wrong and will 404 — the form warns about this.
+- Reasoning uses the standard `reasoning_effort` knob (OpenRouter accepts it as
+  an alias for its native `reasoning.effort`), so cache identity and history
+  labels behave the same as the OpenAI/NVIDIA providers.

--- a/docs/superpowers/plans/2026-06-29-openrouter-provider.md
+++ b/docs/superpowers/plans/2026-06-29-openrouter-provider.md
@@ -1,0 +1,685 @@
+# OpenRouter Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `openrouter` as a first-class LLM provider (backend + web + mobile) with a live model dropdown, configurable attribution headers, reasoning-effort support, and pricing auto-fill into the existing per-row cost-override fields.
+
+**Architecture:** OpenRouter is OpenAI Chat-Completions compatible, so it mirrors the existing `nvidia` provider end-to-end — `OpenAIChatModel`+`OpenAIProvider(base_url, api_key)` on the structured path and a `_call_nvidia` clone on the plain path. Two additions beyond nvidia: optional `HTTP-Referer`/`X-Title` headers, and a public `GET /api/v1/models` discovery endpoint that also feeds pricing auto-fill.
+
+**Tech Stack:** Python (backend, pydantic_ai, requests, FastAPI, RethinkDB), Vue 3 (web), Flutter/Dart (mobile), pytest, flutter test.
+
+## Global Constraints
+
+- Provider key string is exactly `openrouter` (lowercase) everywhere.
+- Default base URL: `https://openrouter.ai/api/v1` (env override `OPENROUTER_BASE_URL`).
+- API key env var: `OPENROUTER_API_KEY`. Attribution env fallbacks: `OPENROUTER_HTTP_REFERER`, `OPENROUTER_X_TITLE`.
+- Model ids are `vendor/model` slash form.
+- Reasoning reuses the **standard** `reasoning_effort` field (low/medium/high) — do NOT add an openrouter-specific reasoning field; OpenRouter accepts `reasoning_effort` as an alias.
+- Pricing values from `/models` are USD **per token** (strings) → multiply by `1_000_000` for IntelliStock's USD-per-1M fields.
+- Per-row cost-override fields already exist: `input_cost_per_1m`, `output_cost_per_1m`, `cache_creation_cost_per_1m`, `cache_read_cost_per_1m`. Do NOT add new pricing schema.
+- Before editing each backend symbol, run `gitnexus_impact({target, direction:"upstream"})`; run `gitnexus_detect_changes()` before each commit (per CLAUDE.md).
+- Backend tests run with `python3 -m pytest` from `backend/`; mobile with `flutter test` from `mobile/`.
+
+---
+
+### Task 1: Backend — API-key + config resolution + provider meta
+
+**Files:**
+- Modify: `backend/llm_utils.py` — `resolve_api_key_for_provider` (~217-237), `_resolve_provider_config` (~689-779), `_safe_provider_meta` (~782-816)
+- Test: `backend/tests/test_openrouter_provider.py` (new)
+
+**Interfaces:**
+- Produces: `resolve_api_key_for_provider("openrouter")` → `OPENROUTER_API_KEY`; `_resolve_provider_config("openrouter", cfg)` returns dict with `openrouter_base_url`, `openrouter_referer`, `openrouter_title`, normalized `reasoning_effort`; `_safe_provider_meta("openrouter", cfg)` → `{base_url, reasoning_effort?}`.
+
+- [ ] **Step 1: Write failing tests** in `backend/tests/test_openrouter_provider.py`:
+
+```python
+import os
+import importlib
+import llm_utils
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-xyz")
+    assert llm_utils.resolve_api_key_for_provider("openrouter") == "sk-or-xyz"
+
+
+def test_api_key_explicit_wins(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "envkey")
+    assert llm_utils.resolve_api_key_for_provider("openrouter", "explicit") == "explicit"
+
+
+def test_resolve_config_defaults(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    cfg = llm_utils._resolve_provider_config("openrouter", {})
+    assert cfg["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+
+
+def test_resolve_config_headers_and_reasoning():
+    cfg = llm_utils._resolve_provider_config("openrouter", {
+        "openrouter_referer": "https://intellistock.app",
+        "openrouter_title": "IntelliStock",
+        "reasoning_effort": "HIGH",
+    })
+    assert cfg["openrouter_referer"] == "https://intellistock.app"
+    assert cfg["openrouter_title"] == "IntelliStock"
+    assert cfg["reasoning_effort"] == "high"
+
+
+def test_safe_meta_no_secrets():
+    meta = llm_utils._safe_provider_meta("openrouter", {
+        "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://x", "reasoning_effort": "low",
+    })
+    assert meta["base_url"] == "https://openrouter.ai/api/v1"
+    assert "openrouter_referer" not in meta
+    assert meta["reasoning_effort"] == "low"
+```
+
+- [ ] **Step 2: Run, verify fail**: `cd backend && python3 -m pytest tests/test_openrouter_provider.py -v` → FAIL (provider not handled / returns gemini key).
+
+- [ ] **Step 3: Implement.** In `resolve_api_key_for_provider`, add before the final `return`:
+
+```python
+    if p == "openrouter":
+        return str(os.environ.get("OPENROUTER_API_KEY") or "").strip()
+```
+
+In `_resolve_provider_config`, add a branch after the `nvidia` branch:
+
+```python
+    elif p == "openrouter":
+        base_url = str(
+            resolved.get("openrouter_base_url")
+            or os.environ.get("OPENROUTER_BASE_URL")
+            or "https://openrouter.ai/api/v1"
+        ).strip().rstrip("/")
+        resolved["openrouter_base_url"] = base_url
+        referer = str(
+            resolved.get("openrouter_referer")
+            or os.environ.get("OPENROUTER_HTTP_REFERER")
+            or ""
+        ).strip()
+        if referer:
+            resolved["openrouter_referer"] = referer
+        else:
+            resolved.pop("openrouter_referer", None)
+        title = str(
+            resolved.get("openrouter_title")
+            or os.environ.get("OPENROUTER_X_TITLE")
+            or ""
+        ).strip()
+        if title:
+            resolved["openrouter_title"] = title
+        else:
+            resolved.pop("openrouter_title", None)
+        reasoning_effort = normalize_reasoning_effort(resolved.get("reasoning_effort"))
+        if reasoning_effort:
+            resolved["reasoning_effort"] = reasoning_effort
+        else:
+            resolved.pop("reasoning_effort", None)
+```
+
+In `_safe_provider_meta`, add after the `nvidia` block:
+
+```python
+    if p == "openrouter":
+        meta = {"base_url": str(config.get("openrouter_base_url") or "https://openrouter.ai/api/v1")}
+        reasoning_effort = normalize_reasoning_effort(config.get("reasoning_effort"))
+        if reasoning_effort:
+            meta["reasoning_effort"] = reasoning_effort
+        return meta
+```
+
+- [ ] **Step 4: Run, verify pass**: `python3 -m pytest tests/test_openrouter_provider.py -v` → PASS.
+- [ ] **Step 5: Commit**: `git add backend/llm_utils.py backend/tests/test_openrouter_provider.py && git commit -m "feat(llm): openrouter api-key + config + meta resolution"`
+
+---
+
+### Task 2: Backend — structured model build, locks, terminal-404
+
+**Files:**
+- Modify: `backend/llm_utils.py` — `_build_pydantic_ai_model` (~819-966), `_STRUCTURED_LLM_PROVIDER_LOCKS` (~170-172), `_is_terminal_provider_not_found` (~997-1056), `_terminal_provider_not_found_hint` (~1059-1101), and the `{azure, openai, nvidia}` membership sets (~838, ~2635).
+- Test: `backend/tests/test_openrouter_provider.py`
+
+**Interfaces:**
+- Consumes: `_resolve_provider_config` (Task 1).
+- Produces: `_build_pydantic_ai_model("openrouter", key, model, cfg)` returns an `OpenAIChatModel` whose provider base_url is the openrouter URL; injects `HTTP-Referer`/`X-Title` via the OpenAI client `default_headers` when set.
+
+- [ ] **Step 1: Write failing tests** (append):
+
+```python
+import pytest
+
+
+@pytest.mark.skipif(not llm_utils._PYDANTIC_AI_AVAILABLE, reason="pydantic_ai not installed")
+def test_build_model_openrouter_base_url():
+    model = llm_utils._build_pydantic_ai_model(
+        "openrouter", "sk-or-x", "anthropic/claude-3.5-sonnet",
+        {"openrouter_base_url": "https://openrouter.ai/api/v1"},
+    )
+    assert model is not None
+    # OpenAIChatModel exposes the provider's base_url on its client.
+    assert "openrouter.ai" in str(getattr(model, "base_url", "") or
+                                  getattr(getattr(model, "client", None), "base_url", ""))
+
+
+def test_lock_registered():
+    assert "openrouter" in llm_utils._STRUCTURED_LLM_PROVIDER_LOCKS
+
+
+def test_terminal_not_found_openrouter():
+    exc = RuntimeError("HTTP 404: model_not_found")
+    assert llm_utils._is_terminal_provider_not_found("openrouter", exc) is True
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement.** Add lock: in `_STRUCTURED_LLM_PROVIDER_LOCKS` dict add `"openrouter": threading.Lock(),`.
+
+In `_build_pydantic_ai_model`, add a branch before the final `return GoogleModel(...)`:
+
+```python
+    if p == "openrouter":
+        base_url = str(resolved.get("openrouter_base_url") or "https://openrouter.ai/api/v1").strip().rstrip("/")
+        referer = str(resolved.get("openrouter_referer") or "").strip()
+        title = str(resolved.get("openrouter_title") or "").strip()
+        default_headers = {}
+        if referer:
+            default_headers["HTTP-Referer"] = referer
+        if title:
+            default_headers["X-Title"] = title
+        profile = _prompted_json_profile() if _prefers_prompted_structured_output(p, model) else None
+        if default_headers:
+            try:
+                from openai import AsyncOpenAI as _AsyncOpenAI
+                _client = _AsyncOpenAI(base_url=base_url, api_key=api_key, default_headers=default_headers)
+                return OpenAIChatModel(model, provider=OpenAIProvider(openai_client=_client), profile=profile)
+            except Exception:
+                pass  # fall through to header-less provider
+        return OpenAIChatModel(
+            model,
+            provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+            profile=profile,
+        )
+```
+
+In `_is_terminal_provider_not_found`, extend the OpenAI-compatible group:
+
+```python
+    if p in ("openai", "nvidia", "openrouter"):
+```
+
+In `_terminal_provider_not_found_hint`, extend the same `("openai", "nvidia")` cross-provider checks to include `"openrouter"`, and add a slash hint:
+
+```python
+    elif p == "openrouter" and "/" not in (model or ""):
+        cross_provider_hint = (
+            f" OpenRouter model ids are 'vendor/model' (e.g. 'anthropic/claude-3.5-sonnet'); "
+            f"{name!r} has no '/' and is probably wrong."
+        )
+```
+
+Add `"openrouter"` to the `_prefers_prompted_structured_output` provider set (`{"azure", "openai", "nvidia"}` → add `"openrouter"`) and to the membership set near line ~2635 (`{"azure", "openai", "nvidia"}`).
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit**: `git commit -am "feat(llm): openrouter structured model build + lock + 404 handling"`
+
+---
+
+### Task 3: Backend — plain-text `_call_openrouter` + dispatch
+
+**Files:**
+- Modify: `backend/llm_utils.py` — add `_call_openrouter` near `_call_nvidia` (~4277-4444); add dispatch branch in `call_llm_by_provider` (~5524 nvidia branch).
+- Test: `backend/tests/test_openrouter_provider.py`
+
+**Interfaces:**
+- Produces: `_call_openrouter(api_key, model, prompt, max_output_tokens=256, timeout_sec=None, retries=0, base_url="", response_mime_type=None, reasoning_effort="", referer="", title="") -> str`. `call_llm_by_provider(provider="openrouter", ...)` routes to it.
+
+- [ ] **Step 1: Write failing test** (uses `requests_mock`-style monkeypatch on `requests.post`):
+
+```python
+def test_call_openrouter_posts_chat_completions(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        headers = {}
+        text = ""
+        def json(self):
+            return {"choices": [{"message": {"content": "hello"}}]}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = json
+        return _Resp()
+
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+    out = llm_utils._call_openrouter(
+        "sk-or-x", "anthropic/claude-3.5-sonnet", "hi",
+        referer="https://intellistock.app", title="IntelliStock",
+        reasoning_effort="high",
+    )
+    assert out == "hello"
+    assert captured["url"].endswith("/chat/completions")
+    assert captured["headers"]["Authorization"] == "Bearer sk-or-x"
+    assert captured["headers"]["HTTP-Referer"] == "https://intellistock.app"
+    assert captured["headers"]["X-Title"] == "IntelliStock"
+    assert captured["body"]["reasoning_effort"] == "high"
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** `_call_openrouter` as a clone of `_call_nvidia` with these differences: default base_url `https://openrouter.ai/api/v1`; build headers dict including `HTTP-Referer`/`X-Title` when passed; add `reasoning_effort` as a top-level body field when non-empty (also set `body["reasoning"] = {"effort": reasoning_effort}` for native support); NO `_get_model_request_rate_limiter` block (openrouter has no NVIDIA-style cap); `_log_token_usage("openrouter", model, data)`:
+
+```python
+def _call_openrouter(
+    api_key: str,
+    model: str,
+    prompt: str,
+    max_output_tokens: int = 256,
+    timeout_sec: int | None = None,
+    retries: int = 0,
+    base_url: str = "",
+    response_mime_type: str | None = None,
+    reasoning_effort: str = "",
+    referer: str = "",
+    title: str = "",
+) -> str:
+    """Call OpenRouter (OpenAI-compatible /chat/completions). Clone of _call_nvidia
+    without NVIDIA's RPM limiter, plus optional attribution headers + reasoning."""
+    if not api_key:
+        return ""
+    try:
+        import requests as _requests
+        url = (base_url or "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions"
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+        if referer:
+            headers["HTTP-Referer"] = referer
+        if title:
+            headers["X-Title"] = title
+        body: dict = {"model": model, "messages": [{"role": "user", "content": prompt}], "top_p": 0.95}
+        if not _omit_temperature(model):
+            body["temperature"] = 0.2
+        if max_output_tokens and max_output_tokens > 0:
+            body["max_tokens"] = max_output_tokens
+        effort = normalize_reasoning_effort(reasoning_effort)
+        if effort:
+            body["reasoning_effort"] = effort
+            body["reasoning"] = {"effort": effort}
+        if (
+            str(response_mime_type or "").strip().lower() == "application/json"
+            and not _model_skips_json_object_format(model)
+        ):
+            body["response_format"] = {"type": "json_object"}
+        timeout = _coerce_timeout_sec(timeout_sec)
+        max_retries = max(0, int(retries or 0))
+        retriable_status = {429, 500, 502, 503, 504}
+        for attempt in range(max_retries + 1):
+            attempt_timeout = timeout if attempt == 0 else timeout * 2
+            connect_timeout = min(15, attempt_timeout)
+            try:
+                r = _requests.post(url, headers=headers, json=body, timeout=(connect_timeout, attempt_timeout))
+            except _requests.exceptions.Timeout as _to_e:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt)); continue
+                try: _stash_last_http(status=None, body=f"timeout after {attempt_timeout}s", exc=_to_e)
+                except Exception: pass
+                return ""
+            except _requests.exceptions.RequestException as _req_e:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt)); continue
+                try:
+                    _resp = getattr(_req_e, "response", None)
+                    _stash_last_http(status=getattr(_resp, "status_code", None),
+                                     body=(getattr(_resp, "text", "") if _resp is not None else str(_req_e))[:1000], exc=_req_e)
+                except Exception: pass
+                return ""
+            if r.status_code in retriable_status and attempt < max_retries:
+                _nr_filter, _nr_tag = _is_non_retryable_filter_response(status=r.status_code, body=getattr(r, "text", "") or "")
+                if not _nr_filter:
+                    wait = _retry_after_seconds(getattr(r, "headers", None)) or _http_retry_backoff_seconds(f"status_code: {r.status_code}", attempt)
+                    time.sleep(wait); continue
+            if r.status_code >= 400:
+                try: _err_body = r.json()
+                except Exception: _err_body = r.text[:500]
+                try: _stash_last_http(status=r.status_code, body=(r.text or "")[:1000] if hasattr(r, "text") else str(_err_body)[:1000], exc=None)
+                except Exception: pass
+                raise RuntimeError(f"HTTP {r.status_code}: {_err_body}")
+            data = r.json()
+            _log_token_usage("openrouter", model, data)
+            choices = data.get("choices") or []
+            if not choices:
+                if attempt < max_retries:
+                    time.sleep(_backoff_sleep_seconds(attempt)); continue
+                return ""
+            message = choices[0].get("message") or {}
+            text = _extract_chat_message_text(message)
+            if text:
+                try: _stash_last_http(status=200, body=None, exc=None)
+                except Exception: pass
+                return text
+            if attempt < max_retries:
+                time.sleep(_backoff_sleep_seconds(attempt)); continue
+            return ""
+        return ""
+    except Exception as _exc:
+        _LAST_PLAIN_LLM_CALL_ERROR.error = str(_exc)
+        try:
+            tid = threading.get_ident()
+            with _LAST_HTTP_LOCK:
+                _already = tid in _LAST_HTTP_PER_THREAD
+            if not _already:
+                _resp = getattr(_exc, "response", None)
+                _stash_last_http(status=getattr(_resp, "status_code", None),
+                                 body=(getattr(_resp, "text", "") if _resp is not None else str(_exc))[:1000], exc=_exc)
+        except Exception: pass
+        return ""
+```
+
+In `call_llm_by_provider`, add after the `nvidia` branch (read the nvidia branch first to match how it pulls config + reasoning_effort; mirror exactly):
+
+```python
+    elif p == "openrouter":
+        _cfg = _resolve_provider_config(provider, provider_config)
+        _result = _call_openrouter(
+            api_key, model, prompt,
+            max_output_tokens=max_output_tokens, timeout_sec=timeout_sec, retries=retries,
+            base_url=str(_cfg.get("openrouter_base_url") or ""),
+            response_mime_type=response_mime_type,
+            reasoning_effort=str(_cfg.get("reasoning_effort") or ""),
+            referer=str(_cfg.get("openrouter_referer") or ""),
+            title=str(_cfg.get("openrouter_title") or ""),
+        )
+```
+
+(Match the exact surrounding variable names — `_result`, return/telemetry handling — by reading the nvidia branch first.)
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit**: `git commit -am "feat(llm): _call_openrouter plain path + dispatch"`
+
+---
+
+### Task 4: Backend — model_resolver field map
+
+**Files:**
+- Modify: `backend/model_resolver.py` — `field_map` (~143-168)
+- Test: `backend/tests/test_openrouter_resolver.py` (new)
+
+- [ ] **Step 1: Failing test:**
+
+```python
+import model_resolver
+
+
+class _FakeConn: pass
+
+
+def test_openrouter_fields_injected(monkeypatch):
+    doc = {
+        "id": "m1", "provider": "openrouter", "model": "anthropic/claude-3.5-sonnet",
+        "api_key": "sk-or-x", "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://intellistock.app", "openrouter_title": "IntelliStock",
+    }
+    monkeypatch.setattr(model_resolver, "_get_model_from_cache_or_db", lambda c, mid: doc)
+    out = model_resolver.resolve_model_refs_in_config(_FakeConn(), {"llm_model_id": "m1"})
+    assert out["llm_provider"] == "openrouter"
+    assert out["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert out["openrouter_referer"] == "https://intellistock.app"
+    assert out["openrouter_title"] == "IntelliStock"
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** — add to `field_map`:
+
+```python
+            "openrouter_base_url": f"{prefix}openrouter_base_url",
+            "openrouter_referer": f"{prefix}openrouter_referer",
+            "openrouter_title": f"{prefix}openrouter_title",
+```
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit**: `git commit -am "feat(resolver): inject openrouter_* config fields"`
+
+---
+
+### Task 5: Backend — `openrouter_client.list_models` + `POST /openrouter/list-models`
+
+**Files:**
+- Create: `backend/openrouter_client.py`
+- Modify: `backend/api/main.py` — add endpoint (mirror `POST /ollama/list-models` ~2213) + a `ListModelsBody`-style request model if needed.
+- Test: `backend/tests/test_openrouter_client.py` (new)
+
+**Interfaces:**
+- Produces: `openrouter_client.list_models(base_url="https://openrouter.ai/api/v1", timeout_sec=15.0) -> list[dict]` where each row is `{id, name, context_length, pricing}` and `pricing` is the raw OpenRouter dict (USD/token strings). Never raises; returns `[]` on error.
+
+- [ ] **Step 1: Failing test:**
+
+```python
+import openrouter_client
+
+
+def test_list_models_normalizes(monkeypatch):
+    payload = {"data": [
+        {"id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet",
+         "context_length": 200000,
+         "pricing": {"prompt": "0.000003", "completion": "0.000015",
+                     "input_cache_read": "0.0000003", "input_cache_write": "0.00000375"}},
+        {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini", "context_length": 128000,
+         "pricing": {"prompt": "0.00000015", "completion": "0.0000006"}},
+    ]}
+
+    class _Resp:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return payload
+
+    import requests
+    monkeypatch.setattr(requests, "get", lambda url, timeout=None: _Resp())
+    rows = openrouter_client.list_models()
+    assert rows[0]["id"] == "anthropic/claude-3.5-sonnet"
+    assert rows[0]["pricing"]["prompt"] == "0.000003"
+    assert rows[0]["context_length"] == 200000
+
+
+def test_list_models_error_returns_empty(monkeypatch):
+    import requests
+    def _boom(url, timeout=None): raise requests.RequestException("down")
+    monkeypatch.setattr(requests, "get", _boom)
+    assert openrouter_client.list_models() == []
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** `backend/openrouter_client.py`:
+
+```python
+"""OpenRouter model-discovery client. Backs POST /openrouter/list-models and
+the web LLM-config dropdown. Public GET {base_url}/models — no auth. Never
+raises; returns [] on any failure (caller falls back to manual entry)."""
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def list_models(base_url: str = DEFAULT_BASE_URL, *, timeout_sec: float = 15.0) -> list[dict[str, Any]]:
+    base = str(base_url or DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        import requests
+        r = requests.get(f"{base}/models", timeout=timeout_sec)
+        r.raise_for_status()
+        data = r.json() or {}
+    except Exception:
+        return []
+    rows: list[dict[str, Any]] = []
+    for m in (data.get("data") or []):
+        if not isinstance(m, dict):
+            continue
+        mid = str(m.get("id") or "").strip()
+        if not mid:
+            continue
+        rows.append({
+            "id": mid,
+            "name": str(m.get("name") or mid),
+            "context_length": m.get("context_length"),
+            "pricing": m.get("pricing") if isinstance(m.get("pricing"), dict) else {},
+        })
+    rows.sort(key=lambda x: x["id"])
+    return rows
+```
+
+In `backend/api/main.py`, mirror the ollama endpoint. Read `POST /ollama/list-models` first; add:
+
+```python
+@app.post("/openrouter/list-models", response_class=JSONResponse)
+def api_openrouter_list_models(body: dict = Body(default={}), current_user: dict = Depends(get_current_user)):
+    import openrouter_client
+    base_url = str((body or {}).get("base_url") or openrouter_client.DEFAULT_BASE_URL).strip()
+    models = openrouter_client.list_models(base_url)
+    return {"models": models, "error": None if models else "No models returned"}
+```
+
+(Adjust `Body`/`Depends` imports + auth dependency to match the file's existing conventions — read the ollama endpoint to copy them exactly.)
+
+- [ ] **Step 4: Run, verify pass**: `python3 -m pytest tests/test_openrouter_client.py -v`.
+- [ ] **Step 5: Commit**: `git commit -am "feat(api): openrouter model-discovery client + endpoint"`
+
+---
+
+### Task 6: Backend — Models CRUD, compat validation, API bodies, /llm/test
+
+**Files:**
+- Modify: `backend/interactive_utils.py` — `action_create_model` (~8460), `action_edit_model` field list (~8519-8580), `_validate_provider_model_compat` (~8407-8451)
+- Modify: `backend/api/main.py` — `CreateModelBody` (~575), `UpdateModelBody` (~600), `LlmConfigTestBody` (~508), `_build_llm_test_provider_config` (~408), and the create/edit call sites passing fields through (~2151, ~2175).
+- Test: `backend/tests/test_openrouter_models_api.py` (new) — or extend existing models-api test if pattern matches.
+
+**Interfaces:**
+- Consumes: resolver field names from Task 4.
+- Produces: create/edit a model with `openrouter_base_url`, `openrouter_referer`, `openrouter_title`; `/llm/test` builds an openrouter provider_config.
+
+- [ ] **Step 1: Failing test** — assert `action_create_model` stores the three fields and `_validate_provider_model_compat("openrouter", "anthropic/claude-3.5-sonnet")` is OK while `"claude-3.5-sonnet"` (no slash) warns. (Read the existing bedrock models-api test to match harness/fixtures; mirror it.)
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** — add `openrouter_base_url=None, openrouter_referer=None, openrouter_title=None` params to `action_create_model` and persist them in the doc; add the three keys to the `action_edit_model` updatable-field list; add an `openrouter` clause to `_validate_provider_model_compat` (accept slash ids; warn otherwise). In `main.py` add the three `Optional[str]` fields to `CreateModelBody`/`UpdateModelBody`/`LlmConfigTestBody` (camelCase `openrouterBaseUrl`, `openrouterReferer`, `openrouterTitle` for the test body to match its peers; snake for create/update to match theirs — verify each model's existing convention), pass them through at the call sites, and add an `openrouter` branch to `_build_llm_test_provider_config`:
+
+```python
+    if provider == "openrouter":
+        return {
+            "openrouter_base_url": (body.openrouterBaseUrl or "https://openrouter.ai/api/v1"),
+            "openrouter_referer": (body.openrouterReferer or ""),
+            "openrouter_title": (body.openrouterTitle or ""),
+            "reasoning_effort": (body.reasoningEffort or ""),
+        }
+```
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit**: `git commit -am "feat(models): openrouter CRUD + compat + /llm/test config"`
+
+---
+
+### Task 7: Web — provider option, reasoning, test payload
+
+**Files:**
+- Modify: `frontend/src/utils/strategyConfig.js` — `LLM_PROVIDER_OPTIONS` (~303-313), reasoning options (~315-361), `buildStrategyLlmTestPayload` (~408+)
+
+- [ ] **Step 1:** Add `{ value: 'openrouter', label: 'OpenRouter' }` to `LLM_PROVIDER_OPTIONS`.
+- [ ] **Step 2:** Reuse the generic low/medium/high reasoning options for `openrouter` (map provider→options so `openrouter` returns the standard effort list, same as `openai`).
+- [ ] **Step 3:** In `buildStrategyLlmTestPayload`, include `openrouterBaseUrl`, `openrouterReferer`, `openrouterTitle` when provider is `openrouter`.
+- [ ] **Step 4:** If a frontend unit test harness exists for `strategyConfig.js`, add an assertion that `openrouter` is in the options; otherwise verify by `npm run build` later in Task 10.
+- [ ] **Step 5: Commit**: `git commit -am "feat(web): openrouter provider option + test payload"`
+
+---
+
+### Task 8: Web — `useOpenRouterModels` composable
+
+**Files:**
+- Create: `frontend/src/composables/useOpenRouterModels.js` (mirror `useBedrockModels.js`)
+
+- [ ] **Step 1:** Create the composable: `loadOpenRouterModels({ baseUrl, force })` → POSTs `{ base_url }` to `${API_BASE}/openrouter/list-models`, returns `{ models, error }`. **Preserve the full `pricing` object and `context_length`** on each row (needed for auto-fill). 30s cache keyed by baseUrl. `clearOpenRouterModelsCache()`.
+- [ ] **Step 2: Commit**: `git commit -am "feat(web): useOpenRouterModels discovery composable"`
+
+---
+
+### Task 9: Web — `LlmConfigForm.vue` openrouter block + pricing auto-fill
+
+**Files:**
+- Modify: `frontend/src/components/LlmConfigForm.vue`
+
+**Interfaces:**
+- Consumes: `useOpenRouterModels` (Task 8); existing draft cost fields `inputCostPer1m`/`outputCostPer1m`/`cacheCreationCostPer1m`/`cacheReadCostPer1m`.
+
+- [ ] **Step 1:** Add an `openrouter` provider-specific template block (shown when `provider === 'openrouter'`): base-url input (default prefilled), HTTP-Referer input, X-Title input, and a searchable model dropdown backed by `useOpenRouterModels` with a Refresh button and free-text fallback. Wire the reasoning-effort dropdown for `openrouter`.
+- [ ] **Step 2:** Add a `onOpenRouterModelSelected(model)` handler. Helper:
+
+```js
+function _perMillion(v) {
+  const n = Number(v)
+  return Number.isFinite(n) ? +(n * 1_000_000).toFixed(6) : null
+}
+function applyOpenRouterPricing(row) {
+  const p = (row && row.pricing) || {}
+  const inp = _perMillion(p.prompt)
+  const out = _perMillion(p.completion)
+  const cr = _perMillion(p.input_cache_read)
+  const cw = _perMillion(p.input_cache_write)
+  if (inp != null) formDraft.inputCostPer1m = inp
+  if (out != null) formDraft.outputCostPer1m = out
+  if (cr != null) formDraft.cacheReadCostPer1m = cr
+  if (cw != null) formDraft.cacheCreationCostPer1m = cw
+}
+```
+
+On dropdown select: set `formDraft.model` and call `applyOpenRouterPricing(row)`. Values are editable (not locked). Show an "auto-filled from OpenRouter — editable" hint and a "Clear cost fields" button that nulls the four fields.
+- [ ] **Step 3:** Verify `npm run build` (or `npm run lint`) from `frontend/` succeeds.
+- [ ] **Step 4: Commit**: `git commit -am "feat(web): openrouter config block + pricing auto-fill"`
+
+---
+
+### Task 10: Web — `ModelsView.vue` draft fields
+
+**Files:**
+- Modify: `frontend/src/views/ModelsView.vue` — form-draft initial state (~69-96), reset (~155), load mapping (~193-196 area), save payload (~354 area)
+
+- [ ] **Step 1:** Add `openrouterBaseUrl: 'https://openrouter.ai/api/v1'`, `openrouterReferer: ''`, `openrouterTitle: ''` to the initial draft + reset.
+- [ ] **Step 2:** Map them on load (`m.openrouter_base_url ?? 'https://openrouter.ai/api/v1'`, etc.) and into the save payload (snake_case) alongside the nvidia fields.
+- [ ] **Step 3:** `npm run build` from `frontend/` → succeeds.
+- [ ] **Step 4: Commit**: `git commit -am "feat(web): ModelsView openrouter draft fields"`
+
+---
+
+### Task 11: Mobile — provider option, model fields, form, labels
+
+**Files:**
+- Modify: `mobile/lib/features/strategies/strategy_config.dart` (provider option ~420-429; reasoning options ~438-468)
+- Modify: `mobile/lib/features/models/data/model_repository.dart` (`LlmModel` fields + JSON ~17-95)
+- Modify: `mobile/lib/features/models/presentation/llm_config_form.dart` (`LlmConfigDraft` + form UI)
+- Modify: `mobile/lib/features/models/presentation/models_screen.dart` (provider label + draft init)
+- Test: `mobile/test/features/models/llm_config_draft_test.dart`
+
+- [ ] **Step 1: Failing test** — assert an `LlmConfigDraft`/`LlmModel` round-trips `openrouterBaseUrl`/`openrouterReferer`/`openrouterTitle` through JSON. (Mirror the existing bedrock assertions in the file.)
+- [ ] **Step 2: Run, verify fail**: `cd mobile && flutter test test/features/models/llm_config_draft_test.dart`.
+- [ ] **Step 3: Implement** — add `SelectOption(value: 'openrouter', label: 'OpenRouter')`; reuse generic reasoning-effort options for openrouter; add the three string fields to `LlmModel` (+ `fromJson`/`toJson` snake_case keys) and `LlmConfigDraft` (+ constructor/copy); add form inputs (base-url default, referer, title, model free-text — dropdown deferred per spec §4.5); add the provider label + draft init in `models_screen.dart`.
+- [ ] **Step 4: Run, verify pass**; also `flutter analyze` clean for touched files.
+- [ ] **Step 5: Commit**: `git commit -am "feat(mobile): openrouter provider + config fields"`
+
+---
+
+### Task 12: Docs
+
+**Files:**
+- Modify/create: `docs/claude-code-provider-setup.md` (or a new `docs/openrouter-setup.md`)
+- Modify: `backend/llm_pricing.yaml` (comment only — note openrouter rows use per-row overrides via auto-fill)
+
+- [ ] **Step 1:** Document: get an `OPENROUTER_API_KEY`, set provider=openrouter, base URL default, optional HTTP-Referer/X-Title for leaderboard attribution, `vendor/model` ids, reasoning low/medium/high, pricing auto-fills from the dropdown into per-row cost fields (editable), per-request/image surcharges not tracked.
+- [ ] **Step 2:** Add a comment block to `llm_pricing.yaml` noting openrouter relies on per-row overrides (auto-filled), not global YAML entries.
+- [ ] **Step 3: Commit**: `git commit -am "docs: openrouter provider setup"`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §3 config → T1/T4/T6; §4.1 dispatch → T1/T2/T3; §4.2 discovery → T5; §4.3 CRUD → T6; §4.4 web → T7/T8/T9/T10; §4.5 mobile → T11; §4.6 tests → folded into each task; §4.7 docs → T12; §7a pricing auto-fill → T8 (preserve pricing) + T9 (apply). All covered.
+- **Type consistency:** `_call_openrouter` signature in T3 matches its dispatch call in T3; `applyOpenRouterPricing` reads `pricing.{prompt,completion,input_cache_read,input_cache_write}` matching OpenRouter's keys and writes the four existing draft cost fields; `list_models` row shape (`{id,name,context_length,pricing}`) in T5 matches what T8 preserves and T9 reads.
+- **Placeholder scan:** new/non-obvious code (resolution, `_call_openrouter`, `openrouter_client`, pricing conversion) shown in full; mechanical mirrors point to the exact analog file+lines and list the exact fields to add.
+- **Note:** several tasks instruct "read the nvidia/ollama/bedrock analog first to copy exact conventions" — this is deliberate for the mechanical-mirror steps where matching surrounding variable names matters.

--- a/docs/superpowers/specs/2026-06-29-openrouter-provider-design.md
+++ b/docs/superpowers/specs/2026-06-29-openrouter-provider-design.md
@@ -1,0 +1,154 @@
+# OpenRouter Model-Provider Integration — Design
+
+**Date:** 2026-06-29
+**Status:** Approved design, pending implementation plan
+**Scope decisions (confirmed with operator):** full parity (backend + web + mobile); live searchable model dropdown; configurable app-attribution headers; reasoning-effort low/medium/high.
+
+## 1. Goal
+
+Add `openrouter` as a first-class LLM provider, selectable anywhere the existing providers (`gemini`, `openai`, `azure`, `nvidia`, `deepseek`, `ollama`, `bedrock`, `claude-cli`, `codex-cli`) are. An operator should be able to create a Models-table row with `provider = openrouter`, pick a model from a live dropdown, optionally set attribution headers and reasoning effort, save it, and have every strategy/instance that references that model route LLM calls through OpenRouter — on web and mobile, plain-text and structured-output paths alike.
+
+## 2. Verified facts from OpenRouter official docs
+
+| Property | Value |
+|---|---|
+| Base URL | `https://openrouter.ai/api/v1` |
+| Chat endpoint | `POST /chat/completions` (OpenAI Chat Completions compatible — drop-in) |
+| Auth | `Authorization: Bearer <OPENROUTER_API_KEY>` |
+| Model id format | `vendor/model`, e.g. `anthropic/claude-3.5-sonnet` |
+| List models | `GET /api/v1/models` (public, no auth) → `{ data: [{ id, name, context_length, pricing, ... }] }` |
+| Reasoning | request body `reasoning: { effort: "low" \| "medium" \| "high" }`; the OpenAI-style top-level `reasoning_effort` is accepted as an alias |
+| Attribution headers (optional) | `HTTP-Referer: <site url>` and `X-Title: <app name>`. Only affect leaderboard ranking; calls work without them. |
+
+**Architectural consequence:** OpenRouter is structurally identical to the existing `nvidia` provider — an OpenAI-compatible endpoint reached through pydantic_ai's `OpenAIChatModel` + `OpenAIProvider(base_url=…, api_key=…)` (structured path) and a raw-HTTP `requests.post(.../chat/completions)` clone of `_call_nvidia` (plain path). The only two things beyond `nvidia` are (a) optional attribution headers and (b) the model-id is a slash-namespaced string. This keeps the integration almost entirely mechanical pattern-replication of the recent `nvidia`/`bedrock`/`ollama` additions.
+
+## 3. Configuration model
+
+A new Models-table row with `provider = "openrouter"` carries these fields (mirroring `nvidia_base_url` / `bedrock_region` conventions):
+
+| Models-row field | Strategy-config key (after resolution) | Default / env fallback | Notes |
+|---|---|---|---|
+| `model` | `llm_model` / `model_name` | — | `vendor/model` id |
+| `api_key` | `llm_api_key` | env `OPENROUTER_API_KEY` | Bearer token |
+| `openrouter_base_url` | `openrouter_base_url` | `https://openrouter.ai/api/v1` (env `OPENROUTER_BASE_URL`) | rarely changed |
+| `openrouter_referer` | `openrouter_referer` | env `OPENROUTER_HTTP_REFERER` (default empty) | sent as `HTTP-Referer` |
+| `openrouter_title` | `openrouter_title` | env `OPENROUTER_X_TITLE` (default empty) | sent as `X-Title` |
+| `reasoning_effort` | `llm_reasoning_effort` | empty | reuses the existing low/medium/high knob |
+
+`reasoning_effort` deliberately reuses the **existing** field (not an OpenRouter-specific one) because OpenRouter accepts the standard `reasoning_effort` alias. This means it flows automatically through `_unified_reasoning_effort`, `_cache_effort_key`, and `canonical_model_cache_key` with **zero** changes to the cache-identity layer.
+
+## 4. Components & touch points
+
+Grouped by layer. Each item names the existing analog being mirrored.
+
+### 4.1 Backend — dispatch & call paths (`backend/llm_utils.py`)
+1. **`resolve_api_key_for_provider`** — add `if p == "openrouter": return OPENROUTER_API_KEY`. (mirror `nvidia`)
+2. **`_resolve_provider_config`** — add `openrouter` branch resolving `openrouter_base_url` (default + env), `openrouter_referer`, `openrouter_title`, and normalized `reasoning_effort`. (mirror `nvidia` + `ollama` extra fields)
+3. **`_safe_provider_meta`** — add `openrouter` branch returning `{ base_url, reasoning_effort }` (no secrets/headers). (mirror `nvidia`)
+4. **`_build_pydantic_ai_model`** — add `openrouter` branch building `OpenAIChatModel(model, provider=OpenAIProvider(base_url, api_key, openai_client=AsyncOpenAI(base_url, api_key, default_headers={HTTP-Referer, X-Title})))`. Attribution headers are injected via the client's `default_headers`; when both are empty, fall back to the plain `OpenAIProvider(base_url, api_key)` form. (mirror `nvidia`, extended for headers)
+5. **`_call_openrouter`** (new) — clone of `_call_nvidia`: OpenAI-compatible `POST /chat/completions`, Bearer auth, retry/backoff, token-usage logging tagged `"openrouter"`, attribution headers added to the header dict, reasoning passed as top-level `reasoning_effort` (with `extra_body={"reasoning": {"effort": …}}` as the native equivalent). No special model rate-limiter (the kimi RPM caps are NVIDIA-only).
+6. **`call_llm_by_provider`** — add `elif p == "openrouter": _call_openrouter(...)` branch. (mirror `nvidia` branch at ~line 5524)
+7. **`_STRUCTURED_LLM_PROVIDER_LOCKS`** — add `"openrouter": threading.Lock()`.
+8. **`_is_terminal_provider_not_found` / `_terminal_provider_not_found_hint`** — add `openrouter` to the OpenAI-compatible 404 group and add a cross-provider hint (a bare model id with no `/` is probably the wrong provider).
+9. **Structured path** (`call_structured_llm_by_provider`, `_structured_model_name`, `_structured_model_candidates`) — provider-agnostic via `_build_pydantic_ai_model`; add `openrouter` only where the code explicitly enumerates the OpenAI-compatible set (e.g. the `{azure, openai, nvidia}` membership checks) so prompted-JSON handling and base-url logic apply.
+
+### 4.2 Backend — model discovery (new, mirrors `bedrock_client` / `ollama_client`)
+10. **`backend/openrouter_client.py`** (new) — `list_models(base_url) -> list[dict]` doing `GET {base_url}/models`, normalizing to `{ id, name, context_length, modalities }`. Public endpoint, so no key required; never raises (returns `[]` + error on failure).
+11. **`backend/api/main.py`** — `POST /openrouter/list-models` endpoint (mirror `POST /ollama/list-models` at ~line 2213) returning `{ models, error }`.
+
+### 4.3 Backend — Models CRUD & resolution
+12. **`model_resolver.py` `field_map`** — add `openrouter_base_url`, `openrouter_referer`, `openrouter_title` mappings (mirror `nvidia_base_url`).
+13. **`interactive_utils.py` `action_create_model` / `action_edit_model`** — add the three `openrouter_*` params to the signature + persisted-field list.
+14. **`interactive_utils.py` `_validate_provider_model_compat`** — accept `openrouter` with a `vendor/model` slash id; warn if no slash.
+15. **`backend/api/main.py` Pydantic bodies** — `CreateModelBody`, `UpdateModelBody`, `LlmConfigTestBody` gain `openrouterBaseUrl`, `openrouterReferer`, `openrouterTitle`; `_build_llm_test_provider_config` gains an `openrouter` branch.
+
+### 4.4 Frontend (web)
+16. **`frontend/src/utils/strategyConfig.js`** — add `{ value: 'openrouter', label: 'OpenRouter' }` to `LLM_PROVIDER_OPTIONS`; reuse the generic low/medium/high reasoning options for it; include the `openrouter_*` fields in `buildStrategyLlmTestPayload`.
+17. **`frontend/src/composables/useOpenRouterModels.js`** (new) — cached loader hitting `POST /openrouter/list-models` (mirror `useBedrockModels.js`), with manual-entry fallback on error.
+18. **`frontend/src/components/LlmConfigForm.vue`** — add an `openrouter` config block: base-url input (prefilled default), HTTP-Referer + X-Title inputs, and a searchable model dropdown backed by `useOpenRouterModels` with a Refresh button and free-text fallback; wire the reasoning-effort dropdown for `openrouter`.
+19. **`frontend/src/views/ModelsView.vue`** — add `openrouterBaseUrl` (default `https://openrouter.ai/api/v1`), `openrouterReferer`, `openrouterTitle` to the form-draft initial state and save/load mapping.
+
+### 4.5 Mobile (Flutter)
+20. **`mobile/lib/features/strategies/strategy_config.dart`** — add the `openrouter` provider option (+ reuse generic reasoning-effort options).
+21. **`mobile/lib/features/models/data/model_repository.dart`** — add `openrouterBaseUrl`, `openrouterReferer`, `openrouterTitle` to `LlmModel` + JSON (de)serialization.
+22. **`mobile/lib/features/models/presentation/llm_config_form.dart`** — add the three fields to `LlmConfigDraft` + the form UI (base-url, referer, title, model field; dropdown if the mobile app exposes a discovery call, else free-text to match current mobile patterns).
+23. **`mobile/lib/features/models/presentation/models_screen.dart`** — add the `openrouter` provider label + form-draft initialization.
+
+### 4.6 Tests
+24. **Backend** (mirror `test_model_resolver_*`, `test_models_api_*`, `test_llm_utils_*`): api-key resolution, config resolution (defaults + headers + reasoning), `_build_pydantic_ai_model` returns an OpenAI-compatible model with base_url + default_headers, `model_resolver` field-map injection, `openrouter_client.list_models` parsing/error handling, dispatch routes to `_call_openrouter`.
+25. **Mobile** (mirror `llm_config_draft_test.dart`): draft round-trips the three new fields.
+
+### 4.7 Docs
+26. **`docs/claude-code-provider-setup.md`** (or a sibling) — OpenRouter setup: key signup, base URL, optional attribution headers, model-id format, reasoning note.
+27. **`backend/llm_pricing.yaml`** — optional: operators may add per-model entries with `provider: openrouter` for cost tracking; not required for function.
+
+## 5. Data flow (runtime)
+
+```
+Strategy config { llm_model_id: <row id> }
+  → model_resolver.resolve_model_refs_in_config
+      injects provider=openrouter, llm_model, llm_api_key,
+              openrouter_base_url, openrouter_referer, openrouter_title,
+              llm_reasoning_effort
+  → call_llm_by_provider(provider="openrouter", ...)            [plain path]
+      → _call_openrouter → POST {base_url}/chat/completions
+         headers: Authorization, HTTP-Referer?, X-Title?
+         body: model, messages, reasoning_effort?
+  OR call_structured_llm_by_provider(...)                       [structured path]
+      → _build_pydantic_ai_model → OpenAIChatModel(OpenAIProvider(base_url, key, default_headers))
+```
+
+## 6. Error handling
+
+- **Missing API key:** `resolve_api_key_for_provider` returns empty → existing "no api key" short-circuit logs and skips (same as openai/nvidia today).
+- **Wrong-provider model id** (no `/`): surfaced via `_validate_provider_model_compat` warning at save time and `_terminal_provider_not_found_hint` at call time.
+- **`GET /models` failure:** `openrouter_client.list_models` returns `[]` + error; the form shows the error and falls back to free-text model entry (exactly the Bedrock behavior).
+- **429 / 5xx:** reuse `_call_nvidia`'s retry/backoff and critical-guard HTTP stashing. No OpenRouter-specific rate limiter is added (OpenRouter does its own upstream balancing; the kimi RPM caps stay NVIDIA-scoped).
+- **Content-filter / abuse patterns:** the existing `_is_non_retryable_filter_response` guard applies unchanged in the cloned call path.
+
+## 7. Cache identity (no changes needed)
+
+Because OpenRouter reuses the standard `reasoning_effort` field, `canonical_model_cache_key` and `_cache_effort_key` already handle it. One nuance: `_auto_normalize_model` strips **dot**-namespaced vendor prefixes (`anthropic.`), not the **slash** form (`anthropic/`), so `anthropic/claude-3.5-sonnet` keeps its full id as the cache base. This is internally consistent (OpenRouter rows cache against each other). Operators who want an OpenRouter model to *share* cache with the same model on another provider can set `model_cache_family` — the existing override. No code change; documented as a note.
+
+## 7a. Pricing auto-fill (operator-requested)
+
+When the operator picks a model from the live dropdown, the form auto-fills the Models-row per-model cost overrides from OpenRouter's catalog pricing. **Feasibility verified — reliable for all models, no new backend schema.**
+
+**Why no schema change:** the Models row already has `input_cost_per_1m`, `output_cost_per_1m`, `cache_creation_cost_per_1m`, `cache_read_cost_per_1m` fields, fully wired through `ModelsView.vue` (`inputCostPer1m` etc.), the `CreateModelBody`/`UpdateModelBody` API bodies, CRUD, and — critically — `llm_telemetry.compute_cost`, where a Models-row override takes precedence over `llm_pricing.yaml`. Auto-fill simply prefills these existing fields.
+
+**Data source:** `GET /api/v1/models` already returns a `pricing` object per model (the same call that backs the dropdown — no extra request). Pricing values are **strings in USD per token**. Conversion to IntelliStock's USD-per-1M units is `value × 1_000_000`:
+
+| OpenRouter `pricing.*` (USD/token, string) | Models-row field (USD/1M) |
+|---|---|
+| `prompt` | `input_cost_per_1m = prompt × 1e6` |
+| `completion` | `output_cost_per_1m = completion × 1e6` |
+| `input_cache_read` | `cache_read_cost_per_1m = input_cache_read × 1e6` |
+| `input_cache_write` | `cache_creation_cost_per_1m = input_cache_write × 1e6` |
+
+Example — Claude Opus 4.8 via OpenRouter (`prompt: "0.000005"`, `completion: "0.000025"`) → `input_cost_per_1m = 5.00`, `output_cost_per_1m = 25.00`.
+
+**Reliability across all models:**
+- `prompt` and `completion` are present for **every** model in the catalog (they are the billing basis) → input/output per-1M auto-fill is reliable for all models. Free models report `"0"` → 0.00.
+- `input_cache_read` / `input_cache_write` are present only for caching-capable models → mapped when present, left null otherwise (telemetry then falls through to YAML/zero for those components — correct).
+- **Not representable** in IntelliStock's per-1M-token cost model and therefore NOT auto-filled (documented limitation): `request` (per-request flat fee), `image`, `audio`, `web_search`, `internal_reasoning`. Token costs remain correct; these surcharges go untracked, same as every other provider today.
+
+**Implementation:**
+- `useOpenRouterModels` (§4.4 #17) must preserve the full `pricing` object (and `context_length`) per model in its normalized rows, not just `id`/`name`.
+- `LlmConfigForm.vue` (§4.4 #18): on model-select, parse the four pricing strings (guarding non-numeric/empty), multiply by 1e6, and write into the existing `inputCostPer1m` / `outputCostPer1m` / `cacheCreationCostPer1m` / `cacheReadCostPer1m` draft fields. Values are **prefilled, not locked** — the operator can edit or clear any of them before saving. Re-selecting a model re-fills.
+- A small "auto-filled from OpenRouter" hint + a button to clear the cost fields, so an operator who wants to fall through to YAML can opt out.
+- Mobile parity (§4.5): same prefill if the mobile form gains the dropdown; if mobile keeps free-text model entry, pricing auto-fill is deferred there (mobile already exposes the cost-override fields for manual entry).
+- Tests: a unit test for the string→per-1M conversion (incl. missing-cache-field and non-numeric guards).
+
+## 8. Out of scope (YAGNI)
+
+- No per-model OpenRouter rate limiter (add later only if 429s appear in practice).
+- No OpenRouter "provider routing" / fallback-model preferences in the request body — single model id only for v1.
+- No automatic price import into the global `llm_pricing.yaml` — pricing auto-fill targets the **per-row** cost-override fields only (see §7a). The YAML stays hand-maintained.
+- No per-request/image/web-search surcharge tracking (not representable in the per-1M-token cost model; see §7a).
+- No OAuth PKCE flow — API-key auth only.
+
+## 9. Testing & verification strategy
+
+- Unit tests per §4.6 run in `backend/tests` (python3) and `mobile/test` (flutter test).
+- Manual: create an `openrouter` Models row with a real key, use the `/llm/test` endpoint (web form "Test" button) to confirm a live round-trip on both a non-reasoning and a reasoning model; confirm the live dropdown populates; confirm a referenced strategy resolves and calls through.
+- `gitnexus_impact` on `call_llm_by_provider`, `_build_pydantic_ai_model`, `resolve_api_key_for_provider`, and `resolve_model_refs_in_config` before editing each (per CLAUDE.md), and `gitnexus_detect_changes` before committing.

--- a/frontend/src/components/LlmConfigForm.vue
+++ b/frontend/src/components/LlmConfigForm.vue
@@ -285,6 +285,15 @@ function onProviderChange(value) {
     next.openrouterBaseUrl = ''
     next.openrouterReferer = ''
     next.openrouterTitle = ''
+    // If the cost fields were auto-filled from OpenRouter's catalog, clear them
+    // when leaving the provider — otherwise OpenRouter's per-1M pricing would
+    // be saved as the cost override for the newly-selected provider's model.
+    if (openrouterPricingAutofilled.value) {
+      next.inputCostPer1m = null
+      next.outputCostPer1m = null
+      next.cacheCreationCostPer1m = null
+      next.cacheReadCostPer1m = null
+    }
     openrouterPricingAutofilled.value = false
   }
   emit('update:draft', next)

--- a/frontend/src/components/LlmConfigForm.vue
+++ b/frontend/src/components/LlmConfigForm.vue
@@ -11,6 +11,7 @@ import {
 } from '../utils/strategyConfig.js'
 import { loadOllamaModels } from '../composables/useOllamaModels.js'
 import { loadBedrockModels } from '../composables/useBedrockModels.js'
+import { loadOpenRouterModels, openRouterPricingToPer1m } from '../composables/useOpenRouterModels.js'
 import { getToken } from '../utils/auth.js'
 import CodexCliSetupPanel from './CodexCliSetupPanel.vue'
 import ClaudeCliSetupPanel from './ClaudeCliSetupPanel.vue'
@@ -171,6 +172,73 @@ watch(
   { immediate: true },
 )
 
+// ── OpenRouter-specific state ────────────────────────────────────────────────
+const openrouterModels = ref([])
+const openrouterListLoading = ref(false)
+const openrouterListError = ref('')
+// True after a model-select auto-filled the per-row cost overrides — drives the
+// "auto-filled from OpenRouter" hint + the Clear button.
+const openrouterPricingAutofilled = ref(false)
+
+async function fetchOpenRouterModels({ force = false } = {}) {
+  const baseUrl = String(props.draft?.openrouterBaseUrl || '').trim()
+  openrouterListLoading.value = true
+  openrouterListError.value = ''
+  const { models, error } = await loadOpenRouterModels({ baseUrl, force })
+  openrouterModels.value = models || []
+  openrouterListError.value = error || ''
+  openrouterListLoading.value = false
+}
+
+function refreshOpenRouterModels() {
+  if (_openrouterDebounceHandle) { clearTimeout(_openrouterDebounceHandle); _openrouterDebounceHandle = null }
+  fetchOpenRouterModels({ force: true })
+}
+
+let _openrouterDebounceHandle = null
+
+watch(
+  () => [props.draft?.provider, props.draft?.openrouterBaseUrl],
+  ([provider]) => {
+    if (_openrouterDebounceHandle) clearTimeout(_openrouterDebounceHandle)
+    if (provider !== 'openrouter') {
+      openrouterModels.value = []
+      openrouterListError.value = ''
+      return
+    }
+    _openrouterDebounceHandle = setTimeout(() => {
+      _openrouterDebounceHandle = null
+      fetchOpenRouterModels()
+    }, FETCH_DEBOUNCE_MS)
+  },
+  { immediate: true },
+)
+
+// Selecting a model fills the Model field AND auto-fills the per-row cost
+// overrides from OpenRouter's catalog pricing (USD/token × 1e6 → USD/1M). The
+// values are editable afterwards — this is a prefill, not a lock.
+function onOpenRouterModelSelect(id) {
+  const row = openrouterModels.value.find((m) => m.id === id)
+  const next = { ...props.draft, model: id }
+  if (row) {
+    const costs = openRouterPricingToPer1m(row.pricing)
+    Object.assign(next, costs)
+    openrouterPricingAutofilled.value = Object.keys(costs).length > 0
+  }
+  emit('update:draft', next)
+}
+
+function clearOpenRouterCosts() {
+  openrouterPricingAutofilled.value = false
+  emit('update:draft', {
+    ...props.draft,
+    inputCostPer1m: null,
+    outputCostPer1m: null,
+    cacheCreationCostPer1m: null,
+    cacheReadCostPer1m: null,
+  })
+}
+
 function onProviderChange(value) {
   const next = { ...props.draft, provider: value }
   if (value === 'claude-cli' || value === 'codex-cli') {
@@ -209,6 +277,15 @@ function onProviderChange(value) {
   } else {
     next.bedrockRegion = ''
     next.bedrockReasoning = ''
+  }
+  if (value === 'openrouter') {
+    // Default the base URL so the public catalog dropdown can fire immediately.
+    if (!next.openrouterBaseUrl) next.openrouterBaseUrl = 'https://openrouter.ai/api/v1'
+  } else {
+    next.openrouterBaseUrl = ''
+    next.openrouterReferer = ''
+    next.openrouterTitle = ''
+    openrouterPricingAutofilled.value = false
   }
   emit('update:draft', next)
 }
@@ -667,7 +744,102 @@ onUnmounted(() => {
       </div>
     </template>
 
-    <div v-if="['azure', 'openai', 'nvidia', 'claude-cli', 'codex-cli'].includes(draft.provider)">
+    <!-- OpenRouter-specific configuration -->
+    <template v-if="draft.provider === 'openrouter'">
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">OpenRouter Base URL</label>
+        <input
+          :value="draft.openrouterBaseUrl"
+          @input="update('openrouterBaseUrl', $event.target.value)"
+          type="text"
+          :disabled="disabled || readOnly"
+          placeholder="https://openrouter.ai/api/v1"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-primary transition-colors font-mono disabled:opacity-50"
+        />
+        <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          Defaults to the public OpenRouter API. Only change this for a self-hosted proxy.
+        </p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5 flex items-center justify-between">
+          <span>Pick from the OpenRouter catalog</span>
+          <button
+            type="button"
+            @click="refreshOpenRouterModels"
+            :disabled="disabled || readOnly || openrouterListLoading"
+            class="text-[11px] text-primary hover:underline disabled:opacity-50"
+          >{{ openrouterListLoading ? 'Loading…' : 'Refresh' }}</button>
+        </label>
+        <div v-if="openrouterListError" class="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-300 mb-2 space-y-1">
+          <div>Couldn't load the OpenRouter model catalog.</div>
+          <div class="text-amber-200/70 font-mono whitespace-pre-wrap break-words">{{ openrouterListError }}</div>
+          <div class="text-amber-200/70">
+            Enter the model id manually in the Model field above — OpenRouter ids are <span class="font-mono">vendor/model</span> (e.g. <span class="font-mono">anthropic/claude-3.5-sonnet</span>).
+          </div>
+        </div>
+        <select
+          v-else
+          :value="draft.model"
+          @change="onOpenRouterModelSelect($event.target.value)"
+          :disabled="disabled || readOnly || !openrouterModels.length"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary transition-colors disabled:opacity-50"
+        >
+          <option value="" disabled>{{ openrouterModels.length ? 'Select a model' : 'No models — enter the model id manually above' }}</option>
+          <option v-for="m in openrouterModels" :key="m.id" :value="m.id">
+            {{ m.id }}<template v-if="m.context_length"> · ctx {{ m.context_length }}</template>
+          </option>
+        </select>
+        <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          The Model field above is the source of truth — picking from the catalog fills it in and auto-fills the per-model pricing below. Free-text entry works too.
+        </p>
+        <div v-if="openrouterPricingAutofilled" class="mt-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-[11px] leading-relaxed text-emerald-300/90 flex items-center justify-between gap-2">
+          <span>Pricing auto-filled from OpenRouter — editable below. Per-request / image surcharges aren't tracked.</span>
+          <button
+            type="button"
+            @click="clearOpenRouterCosts"
+            :disabled="disabled || readOnly"
+            class="shrink-0 text-[11px] text-emerald-300 hover:underline disabled:opacity-50"
+          >Clear cost fields</button>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          HTTP-Referer <span class="text-slate-600">(optional)</span>
+        </label>
+        <input
+          :value="draft.openrouterReferer"
+          @input="update('openrouterReferer', $event.target.value)"
+          type="text"
+          :disabled="disabled || readOnly"
+          placeholder="https://your-site.example"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-primary transition-colors font-mono disabled:opacity-50"
+        />
+        <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          Sent as the <span class="font-mono">HTTP-Referer</span> header for OpenRouter leaderboard attribution. Optional — calls work without it.
+        </p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">
+          X-Title <span class="text-slate-600">(optional)</span>
+        </label>
+        <input
+          :value="draft.openrouterTitle"
+          @input="update('openrouterTitle', $event.target.value)"
+          type="text"
+          :disabled="disabled || readOnly"
+          placeholder="IntelliStock"
+          class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-primary transition-colors font-mono disabled:opacity-50"
+        />
+        <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+          Sent as the <span class="font-mono">X-Title</span> header — your app name on the OpenRouter leaderboard.
+        </p>
+      </div>
+    </template>
+
+    <div v-if="['azure', 'openai', 'nvidia', 'openrouter', 'claude-cli', 'codex-cli'].includes(draft.provider)">
       <label class="block text-xs font-medium text-slate-400 mb-1.5">Reasoning Effort</label>
       <select
         :value="draft.reasoningEffort"

--- a/frontend/src/composables/useOpenRouterModels.js
+++ b/frontend/src/composables/useOpenRouterModels.js
@@ -1,0 +1,83 @@
+// Cached loader for the OpenRouter model catalog (GET /api/v1/models, proxied
+// through our backend's POST /openrouter/list-models). 30-second in-memory
+// cache; pass force=true to bypass (the form's Refresh button).
+//
+// Returns ``{ models, error }`` where models is an array of
+//   { id, name, context_length, pricing }.
+// ``pricing`` is OpenRouter's raw object (USD **per token**, string values) so
+// the caller can auto-fill the per-row cost overrides (× 1e6 → USD per 1M).
+//
+// The catalog is public — no API key is required. On any error the caller
+// falls back to manual model-id entry (same contract as useBedrockModels).
+
+import { getToken } from '../utils/auth.js'
+
+const API_BASE = import.meta.env.DEV
+  ? '/api'
+  : (import.meta.env.VITE_API_URL || '/api')
+
+const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1'
+const CACHE = new Map()          // key: baseUrl → {ts, models}
+const TTL_MS = 30_000
+
+function _authHeaders() {
+  const token = getToken()
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+export async function loadOpenRouterModels({ baseUrl, force = false } = {}) {
+  const base = String(baseUrl || DEFAULT_BASE_URL).trim() || DEFAULT_BASE_URL
+  if (!force) {
+    const hit = CACHE.get(base)
+    if (hit && (Date.now() - hit.ts) < TTL_MS) {
+      return { models: hit.models, error: null }
+    }
+  }
+  try {
+    const resp = await fetch(`${API_BASE}/openrouter/list-models`, {
+      method: 'POST',
+      headers: _authHeaders(),
+      credentials: 'include',
+      body: JSON.stringify({ base_url: base }),
+    })
+    if (!resp.ok) {
+      let body = {}
+      try { body = await resp.json() } catch (_) {}
+      const msg = body.error || body.detail || `HTTP ${resp.status}`
+      return { models: [], error: String(msg) }
+    }
+    const data = await resp.json()
+    const models = Array.isArray(data?.models) ? data.models : []
+    if (models.length) CACHE.set(base, { ts: Date.now(), models })
+    return { models, error: data?.error || (models.length ? null : 'No models returned') }
+  } catch (err) {
+    return { models: [], error: String(err?.message || err) }
+  }
+}
+
+export function clearOpenRouterModelsCache() {
+  CACHE.clear()
+}
+
+// Convert an OpenRouter pricing object (USD per token, string values) into the
+// per-row cost-override fields IntelliStock stores (USD per 1M tokens). Returns
+// only the keys that were present + numeric; callers spread into the draft.
+export function openRouterPricingToPer1m(pricing) {
+  const p = pricing || {}
+  const per1m = (v) => {
+    const n = Number(v)
+    return Number.isFinite(n) ? +(n * 1_000_000).toFixed(6) : null
+  }
+  const out = {}
+  const inp = per1m(p.prompt)
+  const out_ = per1m(p.completion)
+  const cr = per1m(p.input_cache_read)
+  const cw = per1m(p.input_cache_write)
+  if (inp != null) out.inputCostPer1m = inp
+  if (out_ != null) out.outputCostPer1m = out_
+  if (cr != null) out.cacheReadCostPer1m = cr
+  if (cw != null) out.cacheCreationCostPer1m = cw
+  return out
+}

--- a/frontend/src/utils/strategyConfig.js
+++ b/frontend/src/utils/strategyConfig.js
@@ -308,6 +308,7 @@ export const LLM_PROVIDER_OPTIONS = [
   { value: 'nvidia', label: 'NVIDIA NIM' },
   { value: 'ollama', label: 'Ollama (local / cloud)' },
   { value: 'bedrock', label: 'AWS Bedrock' },
+  { value: 'openrouter', label: 'OpenRouter' },
   { value: 'claude-cli', label: 'Claude Code CLI (subscription)' },
   { value: 'codex-cli', label: 'OpenAI Codex CLI (subscription)' },
 ]
@@ -435,6 +436,9 @@ function buildLlmGroup(prefix, keySet) {
     azureEndpointKey: `${prefix}azure_openai_endpoint`,
     azureApiVersionKey: `${prefix}azure_openai_api_version`,
     reasoningEffortKey: `${prefix}llm_reasoning_effort`,
+    openrouterBaseUrlKey: `${prefix}openrouter_base_url`,
+    openrouterRefererKey: `${prefix}openrouter_referer`,
+    openrouterTitleKey: `${prefix}openrouter_title`,
   }
 }
 
@@ -449,6 +453,9 @@ function allGroupKeys(group) {
     group.azureEndpointKey,
     group.azureApiVersionKey,
     group.reasoningEffortKey,
+    group.openrouterBaseUrlKey,
+    group.openrouterRefererKey,
+    group.openrouterTitleKey,
   ]
 }
 
@@ -622,6 +629,25 @@ export function buildStrategyLlmDraft(config, group) {
         prefix ? source.llm_reasoning_effort : '',
       )
     ).trim().toLowerCase(),
+    openrouterBaseUrl: String(
+      _pickFirstNonEmpty(
+        source[group.openrouterBaseUrlKey],
+        prefix ? source.openrouter_base_url : '',
+        'https://openrouter.ai/api/v1',
+      )
+    ).trim(),
+    openrouterReferer: String(
+      _pickFirstNonEmpty(
+        source[group.openrouterRefererKey],
+        prefix ? source.openrouter_referer : '',
+      )
+    ).trim(),
+    openrouterTitle: String(
+      _pickFirstNonEmpty(
+        source[group.openrouterTitleKey],
+        prefix ? source.openrouter_title : '',
+      )
+    ).trim(),
   }
 }
 
@@ -671,7 +697,15 @@ export function applyStrategyLlmDraft(config, group, draft) {
     const nvidiaBaseUrl = String(draft?.nvidiaBaseUrl || '').trim()
     if (nvidiaBaseUrl) next[`${String(group.prefix || '')}nvidia_base_url`] = nvidiaBaseUrl
   }
-  if (provider === 'openai' || provider === 'azure' || provider === 'nvidia') {
+  if (provider === 'openrouter') {
+    const openrouterBaseUrl = String(draft?.openrouterBaseUrl || '').trim()
+    if (openrouterBaseUrl) next[group.openrouterBaseUrlKey] = openrouterBaseUrl
+    const openrouterReferer = String(draft?.openrouterReferer || '').trim()
+    if (openrouterReferer) next[group.openrouterRefererKey] = openrouterReferer
+    const openrouterTitle = String(draft?.openrouterTitle || '').trim()
+    if (openrouterTitle) next[group.openrouterTitleKey] = openrouterTitle
+  }
+  if (provider === 'openai' || provider === 'azure' || provider === 'nvidia' || provider === 'openrouter') {
     const reasoningEffort = String(draft?.reasoningEffort || '').trim().toLowerCase()
     if (reasoningEffort) next[group.reasoningEffortKey] = reasoningEffort
   }
@@ -710,7 +744,14 @@ export function buildStrategyLlmTestPayload(draft) {
     if (reasoning) payload.bedrock_reasoning = reasoning
     // api_key is the Bedrock bearer token, populated above.
   }
-  if (provider === 'openai' || provider === 'azure' || provider === 'nvidia' || provider === 'codex-cli') {
+  if (provider === 'openrouter') {
+    payload.openrouter_base_url = String(draft?.openrouterBaseUrl || 'https://openrouter.ai/api/v1').trim()
+    const referer = String(draft?.openrouterReferer || '').trim()
+    if (referer) payload.openrouter_referer = referer
+    const title = String(draft?.openrouterTitle || '').trim()
+    if (title) payload.openrouter_title = title
+  }
+  if (provider === 'openai' || provider === 'azure' || provider === 'nvidia' || provider === 'openrouter' || provider === 'codex-cli') {
     const reasoningEffort = String(draft?.reasoningEffort || '').trim().toLowerCase()
     if (reasoningEffort) payload.reasoning_effort = reasoningEffort
   }

--- a/frontend/src/views/ModelsView.vue
+++ b/frontend/src/views/ModelsView.vue
@@ -85,6 +85,10 @@ const formDraft = ref({
   // Bedrock provider config — only used when provider === 'bedrock'.
   bedrockRegion: 'us-east-1',
   bedrockReasoning: 'off',
+  // OpenRouter provider config — only used when provider === 'openrouter'.
+  openrouterBaseUrl: 'https://openrouter.ai/api/v1',
+  openrouterReferer: '',
+  openrouterTitle: '',
   // Cache-grouping tag — share LLM cache across same-model-different-name rows.
   modelCacheFamily: '',
   // Optional per-model pricing override ($/1M tokens). null = use
@@ -188,6 +192,10 @@ function openEditModal(m) {
     // Bedrock: hydrate region + reasoning; default region when blank.
     bedrockRegion: m.bedrock_region || 'us-east-1',
     bedrockReasoning: m.bedrock_reasoning || 'off',
+    // OpenRouter: hydrate base_url + attribution headers; default base when blank.
+    openrouterBaseUrl: m.openrouter_base_url || 'https://openrouter.ai/api/v1',
+    openrouterReferer: m.openrouter_referer || '',
+    openrouterTitle: m.openrouter_title || '',
     modelCacheFamily: m.model_cache_family || '',
     // Pricing override: row stores snake_case; null/undefined → blank input.
     inputCostPer1m: (m.input_cost_per_1m ?? null),
@@ -343,6 +351,13 @@ async function submitModel() {
     if (d.provider === 'bedrock') {
       payload.bedrock_region = (d.bedrockRegion || '').trim() || undefined
       payload.bedrock_reasoning = (d.bedrockReasoning || '').trim().toLowerCase() || undefined
+    }
+    // OpenRouter fields — base_url always sent (defaults to public API);
+    // referer/title are optional attribution headers.
+    if (d.provider === 'openrouter') {
+      payload.openrouter_base_url = (d.openrouterBaseUrl || '').trim() || 'https://openrouter.ai/api/v1'
+      payload.openrouter_referer = (d.openrouterReferer || '').trim() || undefined
+      payload.openrouter_title = (d.openrouterTitle || '').trim() || undefined
     }
     // Cache-grouping tag applies to every provider.
     payload.model_cache_family = (d.modelCacheFamily || '').trim().toLowerCase() || undefined

--- a/mobile/lib/features/models/data/model_repository.dart
+++ b/mobile/lib/features/models/data/model_repository.dart
@@ -33,6 +33,9 @@ class LlmModel {
     this.ollamaThink,
     this.bedrockRegion,
     this.bedrockReasoning,
+    this.openrouterBaseUrl,
+    this.openrouterReferer,
+    this.openrouterTitle,
     this.modelCacheFamily,
     this.inputCostPer1m,
     this.outputCostPer1m,
@@ -58,6 +61,9 @@ class LlmModel {
   final String? ollamaThink;
   final String? bedrockRegion;
   final String? bedrockReasoning;
+  final String? openrouterBaseUrl;
+  final String? openrouterReferer;
+  final String? openrouterTitle;
   final String? modelCacheFamily;
   final double? inputCostPer1m;
   final double? outputCostPer1m;
@@ -84,6 +90,9 @@ class LlmModel {
       ollamaThink: _asStr(j['ollama_think']),
       bedrockRegion: _asStr(j['bedrock_region']),
       bedrockReasoning: _asStr(j['bedrock_reasoning']),
+      openrouterBaseUrl: _asStr(j['openrouter_base_url']),
+      openrouterReferer: _asStr(j['openrouter_referer']),
+      openrouterTitle: _asStr(j['openrouter_title']),
       modelCacheFamily: _asStr(j['model_cache_family']),
       inputCostPer1m: (j['input_cost_per_1m'] as num?)?.toDouble(),
       outputCostPer1m: (j['output_cost_per_1m'] as num?)?.toDouble(),

--- a/mobile/lib/features/models/presentation/llm_config_form.dart
+++ b/mobile/lib/features/models/presentation/llm_config_form.dart
@@ -26,6 +26,9 @@ class LlmConfigDraft {
     this.ollamaThink = '',
     this.bedrockRegion = 'us-east-1',
     this.bedrockReasoning = 'off',
+    this.openrouterBaseUrl = 'https://openrouter.ai/api/v1',
+    this.openrouterReferer = '',
+    this.openrouterTitle = '',
     this.modelCacheFamily = '',
   });
 
@@ -44,6 +47,9 @@ class LlmConfigDraft {
   String ollamaThink;
   String bedrockRegion;
   String bedrockReasoning;
+  String openrouterBaseUrl;
+  String openrouterReferer;
+  String openrouterTitle;
   String modelCacheFamily;
 
   LlmConfigDraft copyWith({
@@ -62,6 +68,9 @@ class LlmConfigDraft {
     String? ollamaThink,
     String? bedrockRegion,
     String? bedrockReasoning,
+    String? openrouterBaseUrl,
+    String? openrouterReferer,
+    String? openrouterTitle,
     String? modelCacheFamily,
   }) {
     return LlmConfigDraft(
@@ -80,6 +89,9 @@ class LlmConfigDraft {
       ollamaThink: ollamaThink ?? this.ollamaThink,
       bedrockRegion: bedrockRegion ?? this.bedrockRegion,
       bedrockReasoning: bedrockReasoning ?? this.bedrockReasoning,
+      openrouterBaseUrl: openrouterBaseUrl ?? this.openrouterBaseUrl,
+      openrouterReferer: openrouterReferer ?? this.openrouterReferer,
+      openrouterTitle: openrouterTitle ?? this.openrouterTitle,
       modelCacheFamily: modelCacheFamily ?? this.modelCacheFamily,
     );
   }
@@ -112,6 +124,13 @@ class LlmConfigDraft {
       if (bedrockRegion.isNotEmpty) m['bedrock_region'] = bedrockRegion.trim();
       if (bedrockReasoning.isNotEmpty) m['bedrock_reasoning'] = bedrockReasoning.trim().toLowerCase();
     }
+    if (provider == 'openrouter') {
+      m['openrouter_base_url'] = openrouterBaseUrl.isNotEmpty
+          ? openrouterBaseUrl.trim()
+          : 'https://openrouter.ai/api/v1';
+      if (openrouterReferer.isNotEmpty) m['openrouter_referer'] = openrouterReferer.trim();
+      if (openrouterTitle.isNotEmpty) m['openrouter_title'] = openrouterTitle.trim();
+    }
     return m;
   }
 
@@ -133,6 +152,7 @@ const _kProviders = [
   ('nvidia', 'NVIDIA NIM'),
   ('ollama', 'Ollama (local/cloud)'),
   ('bedrock', 'AWS Bedrock'),
+  ('openrouter', 'OpenRouter'),
   ('claude-cli', 'Claude Code CLI'),
   ('codex-cli', 'OpenAI Codex CLI'),
 ];
@@ -353,6 +373,13 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
     } else {
       next = next.copyWith(bedrockRegion: '', bedrockReasoning: '');
     }
+    if (value == 'openrouter') {
+      if (next.openrouterBaseUrl.isEmpty) {
+        next = next.copyWith(openrouterBaseUrl: 'https://openrouter.ai/api/v1');
+      }
+    } else {
+      next = next.copyWith(openrouterBaseUrl: '', openrouterReferer: '', openrouterTitle: '');
+    }
     _update(next);
   }
 
@@ -361,7 +388,7 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
     final d = widget.draft;
     final disabled = widget.disabled;
     final isCliProvider = d.provider == 'claude-cli' || d.provider == 'codex-cli';
-    final showReasoningEffort = ['azure', 'openai', 'nvidia', 'claude-cli', 'codex-cli'].contains(d.provider);
+    final showReasoningEffort = ['azure', 'openai', 'nvidia', 'openrouter', 'claude-cli', 'codex-cli'].contains(d.provider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -594,6 +621,39 @@ class _LlmConfigFormState extends ConsumerState<LlmConfigForm> {
             mono: true,
             disabled: disabled,
             onChanged: (v) => _update(d.copyWith(nvidiaBaseUrl: v)),
+          ),
+        ],
+
+        // OpenRouter
+        if (d.provider == 'openrouter') ...[
+          const SizedBox(height: 4),
+          _label('OpenRouter Base URL'),
+          _textField(
+            value: d.openrouterBaseUrl,
+            placeholder: 'https://openrouter.ai/api/v1',
+            mono: true,
+            disabled: disabled,
+            onChanged: (v) => _update(d.copyWith(openrouterBaseUrl: v)),
+          ),
+          const SizedBox(height: 8),
+          _infoBox('Model ids are vendor/model, e.g. anthropic/claude-3.5-sonnet.', AppColors.info),
+          const SizedBox(height: 12),
+          _label('HTTP-Referer (optional)'),
+          _textField(
+            value: d.openrouterReferer,
+            placeholder: 'https://your-site.example',
+            mono: true,
+            disabled: disabled,
+            onChanged: (v) => _update(d.copyWith(openrouterReferer: v)),
+          ),
+          const SizedBox(height: 12),
+          _label('X-Title (optional)'),
+          _textField(
+            value: d.openrouterTitle,
+            placeholder: 'IntelliStock',
+            mono: true,
+            disabled: disabled,
+            onChanged: (v) => _update(d.copyWith(openrouterTitle: v)),
           ),
         ],
 

--- a/mobile/lib/features/models/presentation/models_screen.dart
+++ b/mobile/lib/features/models/presentation/models_screen.dart
@@ -25,6 +25,7 @@ String _providerLabel(String p) {
     'nvidia': 'NVIDIA NIM',
     'ollama': 'Ollama (local/cloud)',
     'bedrock': 'AWS Bedrock',
+    'openrouter': 'OpenRouter',
     'claude-cli': 'Claude Code CLI',
     'codex-cli': 'OpenAI Codex CLI',
   };
@@ -508,6 +509,11 @@ class _AddEditSheetState extends ConsumerState<_AddEditSheet> {
         ollamaThink: e.ollamaThink ?? '',
         bedrockRegion: e.bedrockRegion?.isNotEmpty == true ? e.bedrockRegion! : 'us-east-1',
         bedrockReasoning: e.bedrockReasoning ?? 'off',
+        openrouterBaseUrl: e.openrouterBaseUrl?.isNotEmpty == true
+            ? e.openrouterBaseUrl!
+            : 'https://openrouter.ai/api/v1',
+        openrouterReferer: e.openrouterReferer ?? '',
+        openrouterTitle: e.openrouterTitle ?? '',
         modelCacheFamily: e.modelCacheFamily ?? '',
       );
       if (e.inputCostPer1m != null) _inputCostCtrl.text = e.inputCostPer1m!.toString();

--- a/mobile/lib/features/strategies/strategy_config.dart
+++ b/mobile/lib/features/strategies/strategy_config.dart
@@ -424,6 +424,7 @@ const llmProviderOptions = [
   SelectOption(value: 'nvidia', label: 'NVIDIA NIM'),
   SelectOption(value: 'ollama', label: 'Ollama (local / cloud)'),
   SelectOption(value: 'bedrock', label: 'AWS Bedrock'),
+  SelectOption(value: 'openrouter', label: 'OpenRouter'),
   SelectOption(value: 'claude-cli', label: 'Claude Code CLI (subscription)'),
   SelectOption(value: 'codex-cli', label: 'OpenAI Codex CLI (subscription)'),
 ];

--- a/mobile/test/features/models/llm_config_draft_test.dart
+++ b/mobile/test/features/models/llm_config_draft_test.dart
@@ -86,6 +86,45 @@ void main() {
       expect(p['api_key'], 'bearer-token');
     });
 
+    test('openrouter sends base_url and attribution headers', () {
+      final d = LlmConfigDraft(
+        provider: 'openrouter',
+        model: 'anthropic/claude-3.5-sonnet',
+        openrouterBaseUrl: 'https://openrouter.ai/api/v1',
+        openrouterReferer: 'https://intellistock.app',
+        openrouterTitle: 'IntelliStock',
+        apiKey: 'sk-or-key',
+        reasoningEffort: 'high',
+      );
+      final p = d.toPayload();
+      expect(p['provider'], 'openrouter');
+      expect(p['openrouter_base_url'], 'https://openrouter.ai/api/v1');
+      expect(p['openrouter_referer'], 'https://intellistock.app');
+      expect(p['openrouter_title'], 'IntelliStock');
+      expect(p['api_key'], 'sk-or-key');
+      expect(p['reasoning_effort'], 'high');
+    });
+
+    test('openrouter falls back to default base URL and omits empty headers', () {
+      final d = LlmConfigDraft(
+        provider: 'openrouter',
+        model: 'openai/gpt-4o-mini',
+        openrouterBaseUrl: '',
+      );
+      final p = d.toPayload();
+      expect(p['openrouter_base_url'], 'https://openrouter.ai/api/v1');
+      expect(p.containsKey('openrouter_referer'), isFalse);
+      expect(p.containsKey('openrouter_title'), isFalse);
+    });
+
+    test('openrouter copyWith round-trips the new fields', () {
+      final d = LlmConfigDraft(provider: 'openrouter', model: 'x/y');
+      final d2 = d.copyWith(openrouterReferer: 'https://a', openrouterTitle: 'T');
+      expect(d2.openrouterReferer, 'https://a');
+      expect(d2.openrouterTitle, 'T');
+      expect(d2.openrouterBaseUrl, 'https://openrouter.ai/api/v1');
+    });
+
     test('azure sends endpoint and api_version', () {
       final d = LlmConfigDraft(
         provider: 'azure',


### PR DESCRIPTION
## Summary

Adds **OpenRouter** as a first-class LLM provider across backend, web, and mobile — mirroring the existing `nvidia`/`bedrock` provider pattern. OpenRouter is OpenAI Chat-Completions compatible, so the integration reuses the existing `OpenAIChatModel` + `OpenAIProvider` plumbing.

Design: `docs/superpowers/specs/2026-06-29-openrouter-provider-design.md` · Plan: `docs/superpowers/plans/2026-06-29-openrouter-provider.md` · Setup: `docs/openrouter-setup.md`

## What's included

**Backend**
- `openrouter` branches in `resolve_api_key_for_provider`, `_resolve_provider_config`, `_safe_provider_meta`, `_build_pydantic_ai_model` (attribution headers via `default_headers`), `call_llm_by_provider`, structured lock, 404 hints, and the structured-output raw-JSON guard
- New `_call_openrouter` plain-text path (clone of `_call_nvidia`)
- New `openrouter_client.list_models` + `POST /openrouter/list-models` discovery endpoint
- `model_resolver` field-map + Models CRUD + `/llm/test` config + Pydantic bodies for `openrouter_base_url` / `openrouter_referer` / `openrouter_title`

**Web**
- Provider option, config block (base URL, HTTP-Referer, X-Title), reasoning-effort dropdown
- Live searchable catalog dropdown via `useOpenRouterModels` (`GET /api/v1/models`)
- **Pricing auto-fill**: selecting a model fills the existing per-row cost-override fields (USD/token × 1e6 → USD/1M)

**Mobile (Flutter)**
- Provider option, `LlmModel` + `LlmConfigDraft` fields, config UI, JSON round-trip

## Reasoning & pricing
- Reasoning reuses the standard `reasoning_effort` field (OpenRouter accepts it as an alias) → no cache-identity changes
- Pricing auto-fill reuses existing per-row cost fields → no new schema; reliable for all models (per-request/image/web-search surcharges aren't representable, documented)

## Configuration
- Per-row fields, or env fallbacks: `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL`, `OPENROUTER_HTTP_REFERER`, `OPENROUTER_X_TITLE`

## Testing
- New backend tests: `test_openrouter_provider.py`, `test_openrouter_resolver.py`, `test_openrouter_client.py`, `test_models_api_openrouter.py` (29 pass)
- Regression: 269 provider/model tests pass
- Mobile: `llm_config_draft_test.dart` extended (all pass); `flutter analyze` clean
- Frontend builds clean
- Adversarial bug-sweep (backend/web/mobile) run; 2 real findings fixed in the final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)