### PR TITLE
fix(openrouter): prompted-JSON profile for all models + non-credentialed catalog fetch

### DIFF
--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -1008,7 +1008,15 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
             default_headers["HTTP-Referer"] = referer
         if title:
             default_headers["X-Title"] = title
-        profile = _prompted_json_profile() if _prefers_prompted_structured_output(p, model) else None
+        # OpenRouter is a gateway to hundreds of open models (nvidia/nemotron,
+        # qwen, llama, mistral, …) whose native structured-output support
+        # (tool-calling / json_schema) is unreliable — exactly like NVIDIA NIM,
+        # which always uses prompted-JSON above. Default to the prompted-JSON
+        # profile for ALL openrouter models (not just the gpt-oss/gpt-5/kimi
+        # "quirky" markers) so single-shot structured calls don't fail on a
+        # model that can't honour a forced schema. Models that DO support
+        # native schema still work fine under prompted mode.
+        profile = _prompted_json_profile()
         if default_headers:
             try:
                 from openai import AsyncOpenAI as _AsyncOpenAI

--- a/backend/tests/test_openrouter_provider.py
+++ b/backend/tests/test_openrouter_provider.py
@@ -64,6 +64,27 @@ def test_build_model_openrouter_base_url():
 
 
 @pytest.mark.skipif(not llm_utils._PYDANTIC_AI_AVAILABLE, reason="pydantic_ai not installed")
+def test_build_model_openrouter_always_prompted_json_profile():
+    # OpenRouter serves many open models (nvidia/nemotron, qwen, llama) whose
+    # native structured-output is unreliable, so — like NVIDIA NIM — every
+    # openrouter model must get the prompted-JSON profile, NOT only the
+    # gpt-oss/gpt-5/kimi "quirky" markers. Regression for a /llm/test failure
+    # ("Exceeded maximum output retries (0)") on nvidia/nemotron-3-ultra.
+    for model_name in ("nvidia/nemotron-3-ultra-550b-a55b", "anthropic/claude-3.5-sonnet"):
+        model = llm_utils._build_pydantic_ai_model(
+            "openrouter", "sk-or-x", model_name,
+            {"openrouter_base_url": "https://openrouter.ai/api/v1"},
+        )
+        assert model is not None
+        profile = getattr(model, "profile", None)
+        assert profile is not None, f"no profile for {model_name}"
+        # Prompted-JSON profile disables forced json-schema output.
+        assert getattr(profile, "supports_json_schema_output", True) is False, (
+            f"{model_name} did not get the prompted-JSON profile"
+        )
+
+
+@pytest.mark.skipif(not llm_utils._PYDANTIC_AI_AVAILABLE, reason="pydantic_ai not installed")
 def test_build_model_openrouter_with_headers():
     model = llm_utils._build_pydantic_ai_model(
         "openrouter", "sk-or-x", "anthropic/claude-3.5-sonnet",

--- a/frontend/src/composables/useOpenRouterModels.js
+++ b/frontend/src/composables/useOpenRouterModels.js
@@ -36,10 +36,14 @@ export async function loadOpenRouterModels({ baseUrl, force = false } = {}) {
     }
   }
   try {
+    // NOTE: deliberately NOT `credentials: 'include'`. Auth is a JWT in the
+    // Authorization header, and the API's CORS is configured
+    // `allow_credentials=False`, so a credentialed request fails the preflight
+    // ("Access-Control-Allow-Credentials must be 'true'"). The main app's
+    // fetches (e.g. ModelsView) are non-credentialed for the same reason.
     const resp = await fetch(`${API_BASE}/openrouter/list-models`, {
       method: 'POST',
       headers: _authHeaders(),
-      credentials: 'include',
       body: JSON.stringify({ base_url: base }),
     })
     if (!resp.ok) {


### PR DESCRIPTION
Follow-up to #59 — two live bugs found testing the merged OpenRouter provider against production.

## 1. Catalog dropdown "Failed to fetch" (CORS)
`useOpenRouterModels` sent `credentials: 'include'`, but the API's CORS is `allow_credentials=False` (it authenticates via a JWT in the `Authorization` header, not cookies). A credentialed request requires the server to return `Access-Control-Allow-Credentials: true`, which it deliberately doesn't — so the browser blocked the preflight. The main app's fetches (e.g. `ModelsView.fetchModels`) are non-credentialed for exactly this reason. **Fix:** drop `credentials: 'include'`.

> Note: `useBedrockModels` / `useOllamaModels` carry the same latent defect but are gated behind entering a key/region/URL first, so they rarely fire. Not changed here (out of scope) — happy to fix in a follow-up.

## 2. `/llm/test` "Exceeded maximum output retries (0)"
On `nvidia/nemotron-3-ultra-550b-a55b` the single-shot structured probe failed. The `nvidia` provider branch in `_build_pydantic_ai_model` **always** applies the prompted-JSON profile (NVIDIA NIM serves open models with unreliable native structured-output); my openrouter branch only applied it for the `gpt-oss`/`gpt-5`/`kimi` "quirky" markers. OpenRouter is a gateway to the same kind of heterogeneous open models. **Fix:** apply the prompted-JSON profile to **all** openrouter models, mirroring nvidia.

## Tests
- New regression: `test_build_model_openrouter_always_prompted_json_profile` (nemotron + claude both get the prompted-JSON profile)
- Full openrouter suite: 30 pass · frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)