### PR TITLE
fix(openrouter): chatbot dock dispatch + reachable pricing auto-fill

### DIFF
--- a/backend/chatbot/llm.py
+++ b/backend/chatbot/llm.py
@@ -122,6 +122,9 @@ def _openai_compat_url(provider: str, base_url: Optional[str], azure_endpoint: O
         if not base.endswith("/v1"):
             base = base + "/v1"
         return f"{base}/chat/completions", {"Content-Type": "application/json"}
+    if p == "openrouter":
+        base = (base_url or "https://openrouter.ai/api/v1").strip().rstrip("/")
+        return f"{base}/chat/completions", {"Content-Type": "application/json"}
     raise ValueError(f"unsupported provider for openai-compat: {provider!r}")
 
 
@@ -151,7 +154,7 @@ def _call_openai_compat(
     # OpenAI deployments. DeepSeek (auto-reasons) and NVIDIA NIM use other
     # control surfaces, so passing it through there can 400.
     eff = ""
-    if p in ("openai", "azure") and reasoning_effort:
+    if p in ("openai", "azure", "openrouter") and reasoning_effort:
         eff_candidate = str(reasoning_effort).strip().lower()
         if eff_candidate in ("low", "medium", "high"):
             eff = eff_candidate
@@ -332,7 +335,7 @@ def call_chat_with_tools(
     if not model:
         raise ValueError("model required")
     try:
-        if p in ("openai", "azure", "deepseek", "nvidia"):
+        if p in ("openai", "azure", "deepseek", "nvidia", "openrouter"):
             return _call_openai_compat(
                 provider=p,
                 api_key=api_key,

--- a/backend/chatbot/orchestration.py
+++ b/backend/chatbot/orchestration.py
@@ -130,7 +130,7 @@ def _resolve_model(conn, model_id: Optional[str]) -> Dict[str, Any]:
         "model": doc.get("model") or "",
         "model_name": doc.get("name") or "",
         "api_key": api_key,
-        "base_url": doc.get("openai_base_url") or doc.get("nvidia_base_url"),
+        "base_url": doc.get("openai_base_url") or doc.get("nvidia_base_url") or doc.get("openrouter_base_url"),
         "azure_endpoint": doc.get("azure_openai_endpoint"),
         "azure_api_version": doc.get("azure_openai_api_version"),
         "reasoning_effort": doc.get("reasoning_effort"),

--- a/backend/tests/test_chatbot_openrouter.py
+++ b/backend/tests/test_chatbot_openrouter.py
@@ -1,0 +1,42 @@
+"""Chatbot (dock) LLM dispatch must route the `openrouter` provider through the
+OpenAI-compatible path, not fall through to Gemini. Regression for: an
+OpenRouter model in the dock called the Gemini API ("API key not valid")."""
+from chatbot import llm as chatbot_llm
+
+
+def test_openai_compat_url_openrouter_default():
+    url, headers = chatbot_llm._openai_compat_url("openrouter", None, None, None, "nvidia/nemotron-3-ultra-550b-a55b")
+    assert url == "https://openrouter.ai/api/v1/chat/completions"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_openai_compat_url_openrouter_custom_base():
+    url, _ = chatbot_llm._openai_compat_url("openrouter", "https://proxy.example/api/v1", None, None, "x/y")
+    assert url == "https://proxy.example/api/v1/chat/completions"
+
+
+def test_call_chat_with_tools_routes_openrouter_to_openai_compat(monkeypatch):
+    captured = {}
+
+    def _fake_compat(**kwargs):
+        captured.update(kwargs)
+        return {"content": "ok", "tool_calls": [], "finish_reason": "stop", "raw": {}}
+
+    def _fake_gemini(**kwargs):
+        captured["WENT_TO_GEMINI"] = True
+        return {"content": "", "tool_calls": [], "finish_reason": "", "raw": {}}
+
+    monkeypatch.setattr(chatbot_llm, "_call_openai_compat", _fake_compat)
+    monkeypatch.setattr(chatbot_llm, "_call_gemini", _fake_gemini)
+
+    out = chatbot_llm.call_chat_with_tools(
+        provider="openrouter",
+        api_key="sk-or-x",
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+        messages=[{"role": "user", "content": "hi"}],
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert out["content"] == "ok"
+    assert "WENT_TO_GEMINI" not in captured
+    assert captured["provider"] == "openrouter"
+    assert captured["base_url"] == "https://openrouter.ai/api/v1"

--- a/frontend/src/components/LlmConfigForm.vue
+++ b/frontend/src/components/LlmConfigForm.vue
@@ -228,6 +228,24 @@ function onOpenRouterModelSelect(id) {
   emit('update:draft', next)
 }
 
+// The catalog row matching the CURRENT model (whether it was typed, hydrated
+// from a saved row, or already the selected dropdown option). Drives the
+// explicit "fill pricing" button below — re-selecting an already-selected
+// dropdown option doesn't fire @change, so editing an existing row needs a
+// non-change path to (re)apply pricing.
+const openrouterCurrentCatalogRow = computed(() =>
+  openrouterModels.value.find((m) => m.id === (props.draft.model || '')) || null
+)
+
+function fillOpenRouterPricingFromCatalog() {
+  const row = openrouterCurrentCatalogRow.value
+  if (!row) return
+  const costs = openRouterPricingToPer1m(row.pricing)
+  if (!Object.keys(costs).length) return
+  openrouterPricingAutofilled.value = true
+  emit('update:draft', { ...props.draft, ...costs })
+}
+
 function clearOpenRouterCosts() {
   openrouterPricingAutofilled.value = false
   emit('update:draft', {
@@ -802,6 +820,16 @@ onUnmounted(() => {
         <p class="mt-1.5 text-[11px] leading-relaxed text-slate-500">
           The Model field above is the source of truth — picking from the catalog fills it in and auto-fills the per-model pricing below. Free-text entry works too.
         </p>
+        <!-- Explicit fill button for an already-selected/typed model: re-picking
+             the same dropdown option doesn't fire @change, so editing a saved
+             row (or a typed id) needs this to (re)apply catalog pricing. -->
+        <button
+          v-if="openrouterCurrentCatalogRow && !openrouterPricingAutofilled"
+          type="button"
+          @click="fillOpenRouterPricingFromCatalog"
+          :disabled="disabled || readOnly"
+          class="mt-2 text-[11px] text-primary hover:underline disabled:opacity-50"
+        >Fill pricing from catalog for <span class="font-mono">{{ draft.model }}</span></button>
         <div v-if="openrouterPricingAutofilled" class="mt-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-[11px] leading-relaxed text-emerald-300/90 flex items-center justify-between gap-2">
           <span>Pricing auto-filled from OpenRouter — editable below. Per-request / image surcharges aren't tracked.</span>
           <button


### PR DESCRIPTION
Two more issues found testing the merged OpenRouter provider live.

## 1. Chatbot dock routed OpenRouter → Gemini
With an OpenRouter model selected, the dock failed: `gemini API 400: API key not valid`. The chatbot has its **own** LLM dispatch (`chatbot/llm.py`), separate from `llm_utils`. `call_chat_with_tools` only treated `openai/azure/deepseek/nvidia` as OpenAI-compatible; everything else fell through to `_call_gemini`, so the `sk-or-` key was sent to Google.

**Fix:**
- Add `openrouter` to the OpenAI-compatible set in `call_chat_with_tools`
- Add an `openrouter` branch to `_openai_compat_url` (defaults to `https://openrouter.ai/api/v1`)
- Pass `reasoning_effort` through for openrouter
- Map `openrouter_base_url → base_url` in `orchestration._model_config`

## 2. Pricing auto-fill unreachable when editing a saved row
Auto-fill only fired on a dropdown `@change`. When editing an existing row, the model is already the selected option, so re-picking it fires nothing and the per-row cost fields never filled. **Fix:** add a "Fill pricing from catalog" button shown whenever the current model id matches a loaded catalog row (works for saved rows and typed ids). Selecting a *new* model from the dropdown still auto-fills as before.

## Tests
- `test_chatbot_openrouter.py` (3): URL builder + dispatch routes to OpenAI-compat, not Gemini
- Frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)