### PR TITLE
feat(nexus): preserve-history popup on LLM model switch

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -84,6 +84,7 @@ from interactive_utils import (
     action_get_strategy,
     action_create_strategy,
     action_edit_strategy,
+    action_preview_strategy_config_change,
     action_delete_strategy,
     action_link_strategy,
     action_unlink_strategy,
@@ -500,6 +501,15 @@ class CreateStrategyBody(BaseModel):
 class EditStrategyBody(BaseModel):
     name: Optional[str] = None
     strategies: Optional[List[dict]] = None
+    # When true, re-stamp existing Nexus saved-state to the new model identities
+    # so the next boot reuses it (no destructive lookback + cleanup). The web /
+    # mobile editors set this after the operator confirms the preserve-history
+    # popup that fires on a hash-changing edit.
+    preserve_history: bool = False
+
+
+class ConfigChangePreviewBody(BaseModel):
+    strategies: List[dict] = Field(default_factory=list)
 
 
 class DeleteStrategyBody(BaseModel):
@@ -2092,7 +2102,17 @@ def api_create_strategy(body: CreateStrategyBody, conn=Depends(conn_dependency),
 
 @app.put("/strategies/{strategy_id}", response_class=JSONResponse)
 def api_edit_strategy(strategy_id: int, body: EditStrategyBody, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
-    return _run(action_edit_strategy, conn, strategy_id, name=body.name, strategies=body.strategies)
+    return _run(action_edit_strategy, conn, strategy_id, name=body.name, strategies=body.strategies, preserve_history=body.preserve_history)
+
+
+@app.post("/strategies/{strategy_id}/config-change-preview", response_class=JSONResponse)
+def api_preview_strategy_config_change(strategy_id: int, body: ConfigChangePreviewBody, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    """Read-only dry-run: would saving these strategies trigger a Nexus rebuild?
+
+    Drives the save-time "preserve history" popup. Returns ``needs_prompt`` and a
+    per-linked-instance ``would_rebuild`` / ``snapshot_exists`` breakdown.
+    """
+    return _run(action_preview_strategy_config_change, conn, strategy_id, body.strategies)
 
 
 @app.delete("/strategies/{strategy_id}", response_class=JSONResponse)

--- a/backend/broker.py
+++ b/backend/broker.py
@@ -2847,84 +2847,15 @@ def _merged_strategy_settings(spec):
     return merged
 
 
-def _nexus_history_scope_doc(settings):
-    settings = settings if isinstance(settings, dict) else {}
-
-    def _role_provider(prefix):
-        return str(
-            settings.get(f"{prefix}llm_provider")
-            or settings.get("llm_provider")
-            or ""
-        ).strip().lower()
-
-    def _role_reasoning(prefix):
-        return normalize_reasoning_effort(
-            settings.get(f"{prefix}llm_reasoning_effort")
-            or settings.get("llm_reasoning_effort")
-            or ""
-        )
-
-    def _role_model(prefix):
-        model = str(
-            settings.get(f"{prefix}llm_model")
-            or settings.get("llm_model")
-            or ""
-        ).strip()
-        return llm_model_reference(model, _role_reasoning(prefix))
-
-    def _role_prompt(prefix):
-        if prefix:
-            return str(
-                settings.get(f"{prefix}llm_prompt_version")
-                or settings.get("llm_prompt_version")
-                or ""
-            ).strip()
-        return str(settings.get("llm_prompt_version") or "").strip()
-
-    return {
-        "scope_version": "nexus_history_model_scope_v3",
-        "root_provider": _role_provider(""),
-        "root_model": _role_model(""),
-        "root_prompt_version": _role_prompt(""),
-        "company_provider": _role_provider("company_article_"),
-        "company_model": _role_model("company_article_"),
-        "company_prompt_version": _role_prompt("company_article_"),
-        "macro_provider": _role_provider("macro_article_"),
-        "macro_model": _role_model("macro_article_"),
-        "macro_prompt_version": _role_prompt("macro_article_"),
-        "event_provider": _role_provider("event_maintenance_"),
-        "event_model": _role_model("event_maintenance_"),
-        "event_prompt_version": _role_prompt("event_maintenance_"),
-        "overlay_provider": _role_provider("overlay_"),
-        "overlay_model": _role_model("overlay_"),
-        "overlay_prompt_version": _role_prompt("overlay_"),
-        "azure_endpoint": str(settings.get("azure_openai_endpoint") or "").strip(),
-        "azure_api_version": str(settings.get("azure_openai_api_version") or "").strip(),
-        "openai_base_url": str(settings.get("openai_base_url") or "").strip(),
-        "use_toon_format": bool(settings.get("use_toon_format", True)),
-        "graph_feature_version": str(settings.get("graph_feature_version") or "nexus_hybrid_v1"),
-        "history_scope_salt": str(settings.get("history_scope_salt") or "").strip(),
-        "max_daily_alpaca_articles": int(settings.get("max_daily_alpaca_articles", 50)),
-        "max_daily_google_news_articles": int(settings.get("max_daily_google_news_articles", 50)),
-        "num_articles_for_llm": int(settings.get("num_articles_for_llm", 30)),
-        "min_articles": int(settings.get("min_articles", 20)),
-        "google_news_enabled": bool(settings.get("google_news_enabled", True)),
-        # NOTE: Trading-rule keys (buy_threshold, fast_loser_cut_pct, etc.) are NOT
-        # included here because changing them would change the instance_id and orphan
-        # all lookback data (forcing a 2-hour rebuild). Instead, trading-rule changes
-        # are detected in the cleanup marker's trading_config_hash (graph_nexus_analysis.py).
-    }
-
-
-def _nexus_history_scope_id(settings):
-    settings = settings if isinstance(settings, dict) else {}
-    explicit = str(settings.get("history_scope_id") or "").strip()
-    if explicit:
-        return explicit
-    scope_doc = _nexus_history_scope_doc(settings)
-    return hashlib.sha256(
-        json.dumps(scope_doc, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-    ).hexdigest()[:24]
+# The history-scope identity now lives in the shared, broker-free
+# `nexus_config_identity` module so the "preserve history" re-stamp feature and
+# this boot path compute byte-identical hashes. These thin aliases keep the
+# existing in-module call sites (`_resolve_nexus_runtime_identity`, etc.) working.
+from nexus_config_identity import (
+    history_scope_doc as _nexus_history_scope_doc,
+    history_scope_id as _nexus_history_scope_id,
+    live_config_hash as _nexus_live_config_hash,
+)
 
 
 def _resolve_nexus_runtime_identity(base_instance_id, settings):
@@ -5656,13 +5587,8 @@ elif mode == MODE_LIVE:
                         except Exception as _ehp_e:
                             _log(f"[snapshot] config-hash spec preload failed (non-fatal): {_ehp_e}", "yellow")
                     _bt_cfg_load = (_nexus_spec_for_load or {}).get("config") or {}
-                    _current_config_hash = _compute_config_hash({
-                        "strategy_name": _nexus_name,
-                        "prompt_versions": _collect_prompt_versions(_bt_cfg_load),
-                        "llm_stages": _collect_llm_stages(_bt_cfg_load),
-                        "history_scope_id_inputs": _collect_history_scope_inputs(_bt_cfg_load),
-                        "lookback_learning_days": int(_bt_cfg_load.get("lookback_learning_days", 120) or 120),
-                    })
+                    # Shared identity (matches the re-stamp feature byte-for-byte).
+                    _current_config_hash = _nexus_live_config_hash(_bt_cfg_load, strategy_name=_nexus_name)
                     _nexus_module_path = _resolve_nexus_module_path() or ""
                     _current_module_hash = _compute_module_hash(_nexus_module_path) if _nexus_module_path else "missing"
                     _snap_cache, _snap_reason, _gap_dates, _snap_origin = _invoke_load_snapshot_with_gap(

--- a/backend/interactive_utils.py
+++ b/backend/interactive_utils.py
@@ -4910,7 +4910,7 @@ def action_create_strategy(conn, name, strategies):
     raise RuntimeError("Could not generate unique strategy id after %d attempts" % max_attempts)
 
 
-def action_edit_strategy(conn, strategy_id, name=None, strategies=None):
+def action_edit_strategy(conn, strategy_id, name=None, strategies=None, preserve_history=False):
     try:
         sid = int(strategy_id)
     except (TypeError, ValueError):
@@ -4922,6 +4922,7 @@ def action_edit_strategy(conn, strategy_id, name=None, strategies=None):
     update = {}
     if name is not None:
         update["name"] = str(name).strip()
+    normalized = None
     if strategies is not None:
         if not isinstance(strategies, list):
             raise ValueError("strategies must be a list")
@@ -4934,7 +4935,49 @@ def action_edit_strategy(conn, strategy_id, name=None, strategies=None):
     if not update:
         return {"updated": True, "id": sid}
     r.db(DB_NAME).table("Strategies").get(sid).update(update).run(conn)
-    return {"updated": True, "id": sid}
+    result = {"updated": True, "id": sid}
+    # "Preserve history": re-stamp existing Nexus saved-state to the new model
+    # identities so the next boot reuses it instead of running a destructive
+    # lookback + cleanup. Best-effort — a re-stamp failure must not fail the save.
+    if preserve_history and normalized is not None:
+        result.update(_apply_preserve_history(conn, sid, normalized))
+    return result
+
+
+def _apply_preserve_history(conn, sid, normalized):
+    """Re-stamp every instance linked to strategy ``sid`` to the new identities.
+
+    Returns ``{"restamp": [...]}`` on success or ``{"restamp_error": str}`` on
+    failure — never raises, so a re-stamp problem cannot fail an otherwise-good
+    config save.
+    """
+    try:
+        import nexus_restamp as _nr
+        nexus_cfg = _nr._nexus_config_from_strategies(normalized)
+        resolved = _nr.resolve_for_identity(conn, nexus_cfg)
+        restamps = [
+            _nr.restamp_instance(conn, r, base_id, resolved)
+            for base_id in _nr.linked_base_instance_ids(conn, r, sid)
+        ]
+        return {"restamp": restamps}
+    except Exception as e:  # surface but never block the save
+        return {"restamp_error": str(e)}
+
+
+def action_preview_strategy_config_change(conn, strategy_id, strategies):
+    """Read-only: would the proposed config change trigger a Nexus rebuild?
+
+    Returns ``nexus_restamp.preview_change`` output: ``needs_prompt`` plus a
+    per-linked-instance ``would_rebuild`` / ``snapshot_exists`` breakdown.
+    """
+    try:
+        sid = int(strategy_id)
+    except (TypeError, ValueError):
+        raise ValueError("Strategy ID must be an integer")
+    if strategies is not None and not isinstance(strategies, list):
+        raise ValueError("strategies must be a list")
+    import nexus_restamp as _nr
+    return _nr.preview_change(conn, r, sid, strategies or [])
 
 
 def action_delete_strategy(conn, strategy_id, force=False):

--- a/backend/nexus_config_identity.py
+++ b/backend/nexus_config_identity.py
@@ -1,0 +1,149 @@
+"""Single source of truth for the two ``graph_nexus_analysis`` boot identities.
+
+Changing an instance's LLM model alters two independent identities, each with a
+distinct consequence on the next live boot:
+
+* ``live_config_hash`` (16-char) -- the snapshot-reuse identity. The live-boot
+  snapshot lookup (``strategy_cache_persistence.load_with_fallback``) keys on it;
+  a mismatch returns ``no_match`` and forces a historic lookback.
+* ``history_scope_id`` (24-char) -- the cleanup identity. The config-change
+  cleanup marker (``GraphNexusLearningCache`` row ``cleanup_done|<instance_id>``)
+  compares it; a mismatch fires the destructive per-instance cleanup.
+
+Both the broker boot path and the "preserve history" re-stamp feature import
+these functions so a re-stamped row can never carry an identity that boot would
+not match. This module deliberately has **no** dependency on ``broker`` -- it
+only touches leaf helpers (``llm_utils``, ``broker_snapshot_helpers``,
+``strategy_cache_persistence``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from llm_utils import llm_model_reference, normalize_reasoning_effort
+from broker_snapshot_helpers import (
+    _collect_prompt_versions,
+    _collect_llm_stages,
+    _collect_history_scope_inputs,
+)
+import strategy_cache_persistence as _scp
+
+# Default learning-window length used by boot when the config omits it.
+DEFAULT_LOOKBACK_LEARNING_DAYS = 120
+# The only strategy that participates in the snapshot/lookback machinery.
+NEXUS_STRATEGY_NAME = "graph_nexus_analysis"
+
+
+def live_config_hash(
+    resolved_cfg: dict,
+    *,
+    strategy_name: str = NEXUS_STRATEGY_NAME,
+    lookback_days_default: int = DEFAULT_LOOKBACK_LEARNING_DAYS,
+) -> str:
+    """Compute the 16-char snapshot-reuse hash for a *resolved* strategy config.
+
+    Mirrors the broker boot computation exactly (broker.py snapshot-load block):
+    the config must already have ``*_llm_model_id`` refs resolved to inline
+    ``*_llm_provider`` / ``*_llm_model`` values, and live overrides applied, so
+    the hash matches a live boot.
+    """
+    cfg = resolved_cfg if isinstance(resolved_cfg, dict) else {}
+    return _scp._compute_config_hash({
+        "strategy_name": strategy_name,
+        "prompt_versions": _collect_prompt_versions(cfg),
+        "llm_stages": _collect_llm_stages(cfg),
+        "history_scope_id_inputs": _collect_history_scope_inputs(cfg),
+        "lookback_learning_days": int(
+            cfg.get("lookback_learning_days", lookback_days_default) or lookback_days_default
+        ),
+    })
+
+
+def history_scope_doc(settings: dict) -> dict:
+    """Build the canonical doc whose hash is the ``history_scope_id``.
+
+    Moved verbatim from ``broker._nexus_history_scope_doc``. Includes per-role
+    provider/model/prompt so a model change changes the scope id; deliberately
+    excludes trading-rule keys (those flow through the cleanup marker's
+    ``trading_config_hash`` instead).
+    """
+    settings = settings if isinstance(settings, dict) else {}
+
+    def _role_provider(prefix):
+        return str(
+            settings.get(f"{prefix}llm_provider")
+            or settings.get("llm_provider")
+            or ""
+        ).strip().lower()
+
+    def _role_reasoning(prefix):
+        return normalize_reasoning_effort(
+            settings.get(f"{prefix}llm_reasoning_effort")
+            or settings.get("llm_reasoning_effort")
+            or ""
+        )
+
+    def _role_model(prefix):
+        model = str(
+            settings.get(f"{prefix}llm_model")
+            or settings.get("llm_model")
+            or ""
+        ).strip()
+        return llm_model_reference(model, _role_reasoning(prefix))
+
+    def _role_prompt(prefix):
+        if prefix:
+            return str(
+                settings.get(f"{prefix}llm_prompt_version")
+                or settings.get("llm_prompt_version")
+                or ""
+            ).strip()
+        return str(settings.get("llm_prompt_version") or "").strip()
+
+    return {
+        "scope_version": "nexus_history_model_scope_v3",
+        "root_provider": _role_provider(""),
+        "root_model": _role_model(""),
+        "root_prompt_version": _role_prompt(""),
+        "company_provider": _role_provider("company_article_"),
+        "company_model": _role_model("company_article_"),
+        "company_prompt_version": _role_prompt("company_article_"),
+        "macro_provider": _role_provider("macro_article_"),
+        "macro_model": _role_model("macro_article_"),
+        "macro_prompt_version": _role_prompt("macro_article_"),
+        "event_provider": _role_provider("event_maintenance_"),
+        "event_model": _role_model("event_maintenance_"),
+        "event_prompt_version": _role_prompt("event_maintenance_"),
+        "overlay_provider": _role_provider("overlay_"),
+        "overlay_model": _role_model("overlay_"),
+        "overlay_prompt_version": _role_prompt("overlay_"),
+        "azure_endpoint": str(settings.get("azure_openai_endpoint") or "").strip(),
+        "azure_api_version": str(settings.get("azure_openai_api_version") or "").strip(),
+        "openai_base_url": str(settings.get("openai_base_url") or "").strip(),
+        "use_toon_format": bool(settings.get("use_toon_format", True)),
+        "graph_feature_version": str(settings.get("graph_feature_version") or "nexus_hybrid_v1"),
+        "history_scope_salt": str(settings.get("history_scope_salt") or "").strip(),
+        "max_daily_alpaca_articles": int(settings.get("max_daily_alpaca_articles", 50)),
+        "max_daily_google_news_articles": int(settings.get("max_daily_google_news_articles", 50)),
+        "num_articles_for_llm": int(settings.get("num_articles_for_llm", 30)),
+        "min_articles": int(settings.get("min_articles", 20)),
+        "google_news_enabled": bool(settings.get("google_news_enabled", True)),
+    }
+
+
+def history_scope_id(settings: dict) -> str:
+    """Compute the 24-char history-scope id (cleanup identity).
+
+    Moved verbatim from ``broker._nexus_history_scope_id``. An explicit
+    ``history_scope_id`` in the config wins (used by tests / pinned scopes).
+    """
+    settings = settings if isinstance(settings, dict) else {}
+    explicit = str(settings.get("history_scope_id") or "").strip()
+    if explicit:
+        return explicit
+    scope_doc = history_scope_doc(settings)
+    return hashlib.sha256(
+        json.dumps(scope_doc, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()[:24]

--- a/backend/nexus_restamp.py
+++ b/backend/nexus_restamp.py
@@ -1,0 +1,215 @@
+"""Model-switch "preserve history" preview + re-stamp.
+
+When an operator changes a ``graph_nexus_analysis`` instance's LLM model and
+chooses "preserve history", we re-stamp the existing saved state to the NEW boot
+identities so the next live boot reuses everything instead of running a
+destructive lookback + cleanup:
+
+* ``NexusStrategyCache`` snapshot row -- keyed by the **base** instance id;
+  re-stamp its ``config_hash`` (and the hash embedded in ``id``) to the new
+  ``live_config_hash``.
+* ``GraphNexusLearningCache`` cleanup marker ``cleanup_done|<scoped>`` -- keyed
+  by the **scoped** instance id; set its ``config_hash`` field to the new
+  ``history_scope_id`` so the config-change cleanup sees "no change".
+
+Identities come from :mod:`nexus_config_identity`, the same module the broker
+boot path uses, so a re-stamped row can never carry an identity boot won't match.
+
+DB access is funneled through the small ``_fetch_*`` / ``_write_*`` / ``_update_*``
+helpers so tests can substitute in-memory fakes without emulating RethinkDB.
+"""
+
+from __future__ import annotations
+
+import time
+
+from model_resolver import resolve_model_refs_in_config
+import nexus_config_identity as nci
+
+try:  # public name; broker aliases it to ``_apply_live_overrides``
+    from live_mode_overrides import apply_live_overrides as _apply_live_overrides
+except Exception:  # pragma: no cover - defensive: never block a save on overrides
+    def _apply_live_overrides(cfg):
+        return cfg
+
+DB_NAME = "IntelliStock"
+SNAPSHOT_TABLE = "NexusStrategyCache"
+LEARNING_CACHE_TABLE = "GraphNexusLearningCache"
+INSTANCES_TABLE = "Instances"
+NEXUS_STRATEGY_NAME = nci.NEXUS_STRATEGY_NAME
+
+
+# --------------------------------------------------------------------------- #
+# Pure identity helpers                                                        #
+# --------------------------------------------------------------------------- #
+
+def resolve_for_identity(conn, raw_cfg: dict) -> dict:
+    """Resolve a raw strategy config the same way live boot does.
+
+    ``resolve_model_refs_in_config(force_refresh=True)`` expands ``*_llm_model_id``
+    refs into inline provider/model, then live overrides are applied. The result
+    is what the identity hashes must be computed from.
+    """
+    cfg = raw_cfg if isinstance(raw_cfg, dict) else {}
+    try:
+        cfg = resolve_model_refs_in_config(conn, cfg, force_refresh=True)
+    except Exception:
+        # If the Models lookup fails, fall back to the raw cfg rather than
+        # blocking the save; identities will still be internally consistent.
+        pass
+    return _apply_live_overrides(cfg)
+
+
+def _identities_for(resolved_cfg: dict) -> tuple[str, str]:
+    """Return ``(live_config_hash, history_scope_id)`` for a resolved config."""
+    return (
+        nci.live_config_hash(resolved_cfg),
+        nci.history_scope_id(resolved_cfg),
+    )
+
+
+def _nexus_config_from_strategies(strategies) -> dict:
+    """Pluck the ``graph_nexus_analysis`` sub-strategy config from a payload list."""
+    for s in (strategies or []):
+        if not isinstance(s, dict):
+            continue
+        if str(s.get("strategy") or "").strip().lower() == NEXUS_STRATEGY_NAME:
+            return dict(s.get("config") or {})
+    return {}
+
+
+# --------------------------------------------------------------------------- #
+# DB access helpers (monkeypatched in tests)                                   #
+# --------------------------------------------------------------------------- #
+
+def _fetch_linked_base_instance_ids(conn, r, strategy_id) -> list[str]:
+    rows = list(
+        r.db(DB_NAME).table(INSTANCES_TABLE)
+        .filter(lambda d: d["strategy_id"] == strategy_id)
+        .pluck("id")
+        .run(conn)
+    )
+    return [str(row.get("id")) for row in rows if row.get("id") is not None]
+
+
+def _fetch_live_snapshot_rows(conn, r, base_instance_id: str) -> list[dict]:
+    """All new-schema *live* snapshot rows for an instance (have config_hash)."""
+    rows = list(
+        r.db(DB_NAME).table(SNAPSHOT_TABLE)
+        .filter(lambda d: (d["instance_id"] == base_instance_id)
+                & (d["strategy_name"] == NEXUS_STRATEGY_NAME)
+                & (d["origin"] == "live"))
+        .run(conn)
+    )
+    return [row for row in rows if row.get("config_hash") and row.get("end_date")]
+
+
+def _write_snapshot_row(conn, r, row: dict) -> None:
+    r.db(DB_NAME).table(SNAPSHOT_TABLE).insert(row, conflict="replace").run(conn)
+
+
+def _fetch_cleanup_markers(conn, r, base_instance_id: str) -> list[dict]:
+    """Cleanup markers whose scoped instance id belongs to this base id."""
+    rows = list(
+        r.db(DB_NAME).table(LEARNING_CACHE_TABLE)
+        .filter(lambda d: d["id"].match("^cleanup_done\\|"))
+        .run(conn)
+    )
+    out = []
+    for row in rows:
+        iid = str(row.get("instance_id") or "")
+        if iid == base_instance_id or iid.startswith(base_instance_id + "|"):
+            out.append(row)
+    return out
+
+
+def _update_marker_hash(conn, r, marker_id: str, new_scope: str) -> None:
+    r.db(DB_NAME).table(LEARNING_CACHE_TABLE).get(marker_id).update(
+        {"config_hash": new_scope}
+    ).run(conn)
+
+
+# --------------------------------------------------------------------------- #
+# Public API                                                                   #
+# --------------------------------------------------------------------------- #
+
+def linked_base_instance_ids(conn, r, strategy_id) -> list[str]:
+    return _fetch_linked_base_instance_ids(conn, r, strategy_id)
+
+
+def restamp_instance(conn, r, base_instance_id: str, resolved_cfg: dict) -> dict:
+    """Re-stamp one instance's saved state to the new identities. Idempotent.
+
+    Returns a summary ``{snapshots_restamped, markers_restamped, config_hash,
+    history_scope_id}``.
+    """
+    new_hash, new_scope = _identities_for(resolved_cfg)
+    snapshots_restamped = 0
+    markers_restamped = 0
+
+    for row in _fetch_live_snapshot_rows(conn, r, base_instance_id):
+        if str(row.get("config_hash")) == new_hash:
+            continue  # already current -> idempotent no-op
+        end_date = row.get("end_date")
+        new_row = dict(row)
+        new_row["config_hash"] = new_hash
+        new_row["id"] = f"{base_instance_id}|{NEXUS_STRATEGY_NAME}|{new_hash}|live|{end_date}"
+        new_row["updated_at"] = r.now()
+        new_row["updated_at_epoch"] = time.time()
+        _write_snapshot_row(conn, r, new_row)
+        snapshots_restamped += 1
+
+    for marker in _fetch_cleanup_markers(conn, r, base_instance_id):
+        if str(marker.get("config_hash")) == new_scope:
+            continue  # already current -> idempotent no-op
+        _update_marker_hash(conn, r, str(marker.get("id")), new_scope)
+        markers_restamped += 1
+
+    return {
+        "base_instance_id": base_instance_id,
+        "snapshots_restamped": snapshots_restamped,
+        "markers_restamped": markers_restamped,
+        "config_hash": new_hash,
+        "history_scope_id": new_scope,
+    }
+
+
+def preview_change(conn, r, strategy_id, proposed_strategies) -> dict:
+    """Read-only: would the proposed config change trigger a rebuild per instance?
+
+    ``needs_prompt`` is true only when at least one linked instance both has
+    existing live state (``snapshot_exists``) AND would otherwise rebuild
+    (``would_rebuild``) -- i.e. there is something to preserve.
+    """
+    resolved = resolve_for_identity(conn, _nexus_config_from_strategies(proposed_strategies))
+    new_hash, new_scope = _identities_for(resolved)
+
+    instances = []
+    needs_prompt = False
+    for base in _fetch_linked_base_instance_ids(conn, r, strategy_id):
+        snap_rows = _fetch_live_snapshot_rows(conn, r, base)
+        snapshot_exists = bool(snap_rows)
+        snap_hash_match = any(str(s.get("config_hash")) == new_hash for s in snap_rows)
+
+        markers = _fetch_cleanup_markers(conn, r, base)
+        marker_scope_match = bool(markers) and all(
+            str(m.get("config_hash")) == new_scope for m in markers
+        )
+
+        would_rebuild = (snapshot_exists and not snap_hash_match) or (
+            bool(markers) and not marker_scope_match
+        )
+        if would_rebuild and snapshot_exists:
+            needs_prompt = True
+        instances.append({
+            "base_instance_id": base,
+            "would_rebuild": would_rebuild,
+            "snapshot_exists": snapshot_exists,
+        })
+
+    return {
+        "needs_prompt": needs_prompt,
+        "config_hash": new_hash,
+        "history_scope_id": new_scope,
+        "instances": instances,
+    }

--- a/backend/nexus_restamp.py
+++ b/backend/nexus_restamp.py
@@ -49,14 +49,18 @@ def resolve_for_identity(conn, raw_cfg: dict) -> dict:
     ``resolve_model_refs_in_config(force_refresh=True)`` expands ``*_llm_model_id``
     refs into inline provider/model, then live overrides are applied. The result
     is what the identity hashes must be computed from.
+
+    A resolver FAILURE is propagated (NOT swallowed): if we silently fell back to
+    the unresolved config, we would write an identity hash that boot — which
+    resolves successfully later — will not reproduce, silently triggering the
+    exact destructive rebuild this feature prevents. Letting it raise records a
+    ``restamp_error`` instead (``_apply_preserve_history``), so the save is kept
+    but the operator is told preserve did not take. Note: a deleted/missing
+    ``model_id`` is NOT a failure here — ``resolve_model_refs_in_config`` skips it
+    and falls through to env/provider defaults, exactly as boot does.
     """
     cfg = raw_cfg if isinstance(raw_cfg, dict) else {}
-    try:
-        cfg = resolve_model_refs_in_config(conn, cfg, force_refresh=True)
-    except Exception:
-        # If the Models lookup fails, fall back to the raw cfg rather than
-        # blocking the save; identities will still be internally consistent.
-        pass
+    cfg = resolve_model_refs_in_config(conn, cfg, force_refresh=True)
     return _apply_live_overrides(cfg)
 
 
@@ -69,7 +73,16 @@ def _identities_for(resolved_cfg: dict) -> tuple[str, str]:
 
 
 def _nexus_config_from_strategies(strategies) -> dict:
-    """Pluck the ``graph_nexus_analysis`` sub-strategy config from a payload list."""
+    """Pluck the ``graph_nexus_analysis`` sub-strategy config from a payload list.
+
+    Reads ``config`` only (not ``conditions``). This matches boot's snapshot
+    ``live_config_hash`` (config-only) and is also correct for the cleanup
+    ``history_scope_id`` (merged conditions+config) because every strategy saved
+    through ``action_edit_strategy`` is run through
+    ``_normalize_strategy_payload_item``, which folds ``conditions`` into
+    ``config`` and emits ``conditions: {}``. So for the only path that triggers a
+    re-stamp, ``config`` already holds the merged keys.
+    """
     for s in (strategies or []):
         if not isinstance(s, dict):
             continue
@@ -92,13 +105,20 @@ def _fetch_linked_base_instance_ids(conn, r, strategy_id) -> list[str]:
     return [str(row.get("id")) for row in rows if row.get("id") is not None]
 
 
-def _fetch_live_snapshot_rows(conn, r, base_instance_id: str) -> list[dict]:
-    """All new-schema *live* snapshot rows for an instance (have config_hash)."""
+def _fetch_snapshot_rows(conn, r, base_instance_id: str) -> list[dict]:
+    """All new-schema snapshot rows for an instance that boot could load.
+
+    ``load_with_fallback`` keys purely on ``[instance_id, config_hash]`` and does
+    NOT filter on ``origin`` -- it will hydrate a ``backtest``-origin row just as
+    readily as a ``live`` one (common right after a rebuild, before a full live
+    day has been saved). So we must re-stamp every row the loader can consume,
+    not just live ones, or boot finds a stale-hash backtest row and rebuilds.
+    """
     rows = list(
         r.db(DB_NAME).table(SNAPSHOT_TABLE)
         .filter(lambda d: (d["instance_id"] == base_instance_id)
                 & (d["strategy_name"] == NEXUS_STRATEGY_NAME)
-                & (d["origin"] == "live"))
+                & ((d["origin"] == "live") | (d["origin"] == "backtest")))
         .run(conn)
     )
     return [row for row in rows if row.get("config_hash") and row.get("end_date")]
@@ -147,13 +167,18 @@ def restamp_instance(conn, r, base_instance_id: str, resolved_cfg: dict) -> dict
     snapshots_restamped = 0
     markers_restamped = 0
 
-    for row in _fetch_live_snapshot_rows(conn, r, base_instance_id):
+    for row in _fetch_snapshot_rows(conn, r, base_instance_id):
         if str(row.get("config_hash")) == new_hash:
             continue  # already current -> idempotent no-op
         end_date = row.get("end_date")
+        # Preserve the row's own origin segment ("live" / "backtest") -- the PK
+        # format is `{base}|{strategy}|{hash}|{origin}|{end_date}` and the
+        # respective writers (save_strategy_cache_to_db / persist_backtest_snapshot)
+        # expect it to match `origin`, or the next write inserts a duplicate.
+        seg = str(row.get("origin") or "live")
         new_row = dict(row)
         new_row["config_hash"] = new_hash
-        new_row["id"] = f"{base_instance_id}|{NEXUS_STRATEGY_NAME}|{new_hash}|live|{end_date}"
+        new_row["id"] = f"{base_instance_id}|{NEXUS_STRATEGY_NAME}|{new_hash}|{seg}|{end_date}"
         new_row["updated_at"] = r.now()
         new_row["updated_at_epoch"] = time.time()
         _write_snapshot_row(conn, r, new_row)
@@ -187,7 +212,7 @@ def preview_change(conn, r, strategy_id, proposed_strategies) -> dict:
     instances = []
     needs_prompt = False
     for base in _fetch_linked_base_instance_ids(conn, r, strategy_id):
-        snap_rows = _fetch_live_snapshot_rows(conn, r, base)
+        snap_rows = _fetch_snapshot_rows(conn, r, base)
         snapshot_exists = bool(snap_rows)
         snap_hash_match = any(str(s.get("config_hash")) == new_hash for s in snap_rows)
 

--- a/backend/tests/test_action_preview_and_preserve.py
+++ b/backend/tests/test_action_preview_and_preserve.py
@@ -1,0 +1,60 @@
+"""Action-layer tests for the preview endpoint + preserve-history re-stamp wiring."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import interactive_utils as iu
+import nexus_restamp as nr
+
+NEXUS = nr.NEXUS_STRATEGY_NAME
+
+
+def test_preview_delegates_to_restamp(monkeypatch):
+    captured = {}
+
+    def fake_preview(conn, r, sid, strategies):
+        captured["args"] = (conn, sid, strategies)
+        return {"needs_prompt": True, "instances": []}
+
+    monkeypatch.setattr(nr, "preview_change", fake_preview)
+    out = iu.action_preview_strategy_config_change("CONN", "179",
+                                                   [{"strategy": NEXUS, "config": {}}])
+    assert out["needs_prompt"] is True
+    assert captured["args"][1] == 179  # sid coerced to int
+    assert captured["args"][2] == [{"strategy": NEXUS, "config": {}}]
+
+
+def test_preview_rejects_bad_strategy_id():
+    with pytest.raises(ValueError):
+        iu.action_preview_strategy_config_change("CONN", "not-an-int", [])
+
+
+def test_preview_rejects_non_list_strategies():
+    with pytest.raises(ValueError):
+        iu.action_preview_strategy_config_change("CONN", "179", {"strategy": NEXUS})
+
+
+def test_apply_preserve_history_restamps_each_instance(monkeypatch):
+    calls = []
+    monkeypatch.setattr(nr, "resolve_for_identity", lambda conn, cfg: {"resolved": True})
+    monkeypatch.setattr(nr, "linked_base_instance_ids",
+                        lambda conn, r, sid: ["alpaca-main", "alpaca-second"])
+    monkeypatch.setattr(nr, "restamp_instance",
+                        lambda conn, r, base, resolved: calls.append(base) or {"base_instance_id": base})
+
+    out = iu._apply_preserve_history("CONN", 179, [{"strategy": NEXUS, "config": {"x": 1}}])
+    assert calls == ["alpaca-main", "alpaca-second"]
+    assert [r["base_instance_id"] for r in out["restamp"]] == ["alpaca-main", "alpaca-second"]
+
+
+def test_apply_preserve_history_never_raises(monkeypatch):
+    def boom(conn, cfg):
+        raise RuntimeError("models table down")
+
+    monkeypatch.setattr(nr, "resolve_for_identity", boom)
+    out = iu._apply_preserve_history("CONN", 179, [{"strategy": NEXUS, "config": {}}])
+    assert "restamp_error" in out
+    assert "models table down" in out["restamp_error"]

--- a/backend/tests/test_nexus_config_identity.py
+++ b/backend/tests/test_nexus_config_identity.py
@@ -1,0 +1,55 @@
+"""Identity parity + sensitivity tests. Imports the shared module only (NOT broker)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import nexus_config_identity as nci
+
+BASE = {
+    "discovery_llm_provider": "bedrock", "discovery_llm_model": "kimi-k2.5",
+    "sentiment_llm_provider": "bedrock", "sentiment_llm_model": "kimi-k2.5",
+    "company_llm_provider": "bedrock", "company_llm_model": "kimi-k2.5",
+    "macro_llm_provider": "bedrock", "macro_llm_model": "kimi-k2.5",
+    "analyst_llm_provider": "bedrock", "analyst_llm_model": "kimi-k2.5",
+    # history-scope reads root-role keys (no prefix) + company_article_/macro_article_/...
+    "llm_provider": "bedrock", "llm_model": "kimi-k2.5",
+    "company_article_llm_provider": "bedrock", "company_article_llm_model": "kimi-k2.5",
+    "macro_article_llm_provider": "bedrock", "macro_article_llm_model": "kimi-k2.5",
+    "event_maintenance_llm_provider": "bedrock", "event_maintenance_llm_model": "kimi-k2.5",
+    "overlay_llm_provider": "bedrock", "overlay_llm_model": "kimi-k2.5",
+    "lookback_learning_days": 120,
+}
+
+
+def test_config_hash_stable_and_16char():
+    h = nci.live_config_hash(dict(BASE))
+    assert h == nci.live_config_hash(dict(BASE))
+    assert len(h) == 16
+
+
+def test_config_hash_changes_on_model():
+    a = nci.live_config_hash(dict(BASE))
+    b = nci.live_config_hash({**BASE, "analyst_llm_model": "nemotron-3-ultra"})
+    assert a != b
+
+
+def test_history_scope_24char_and_stable():
+    a = nci.history_scope_id(dict(BASE))
+    assert a == nci.history_scope_id(dict(BASE))
+    assert len(a) == 24
+
+
+def test_history_scope_changes_on_root_model():
+    a = nci.history_scope_id(dict(BASE))
+    b = nci.history_scope_id({**BASE, "llm_model": "nemotron-3-ultra"})
+    assert a != b
+
+
+def test_history_scope_stable_on_neutral_key():
+    a = nci.history_scope_id(dict(BASE))
+    assert a == nci.history_scope_id({**BASE, "buy_threshold": 0.9, "unrelated": "x"})
+
+
+def test_explicit_history_scope_id_passthrough():
+    assert nci.history_scope_id({"history_scope_id": "abc123"}) == "abc123"

--- a/backend/tests/test_nexus_restamp.py
+++ b/backend/tests/test_nexus_restamp.py
@@ -40,11 +40,12 @@ def _install_fake_db(monkeypatch, *, instances, snapshots, markers):
     monkeypatch.setattr(nr, "_fetch_linked_base_instance_ids",
                         lambda conn, r, sid: list(instances))
 
-    def _fetch_live(conn, r, base):
+    def _fetch_snaps(conn, r, base):
         return [dict(s) for s in state["snapshots"]
-                if s["instance_id"] == base and s.get("origin") == "live"
+                if s["instance_id"] == base
+                and s.get("origin") in ("live", "backtest")
                 and s.get("config_hash") and s.get("end_date")]
-    monkeypatch.setattr(nr, "_fetch_live_snapshot_rows", _fetch_live)
+    monkeypatch.setattr(nr, "_fetch_snapshot_rows", _fetch_snaps)
 
     def _write(conn, r, row):
         state["snapshots"] = [s for s in state["snapshots"] if s["id"] != row["id"]]
@@ -69,10 +70,10 @@ def _install_fake_db(monkeypatch, *, instances, snapshots, markers):
     return state
 
 
-def _snap(base, config_hash, end_date="2026-06-28"):
+def _snap(base, config_hash, end_date="2026-06-28", origin="live"):
     return {
-        "id": f"{base}|{NEXUS}|{config_hash}|live|{end_date}",
-        "instance_id": base, "strategy_name": NEXUS, "origin": "live",
+        "id": f"{base}|{NEXUS}|{config_hash}|{origin}|{end_date}",
+        "instance_id": base, "strategy_name": NEXUS, "origin": origin,
         "config_hash": config_hash, "nexus_module_hash": "modabc",
         "end_date": end_date, "cache_json": "{}", "updated_at_epoch": 1.0,
     }
@@ -104,6 +105,24 @@ def test_restamp_rewrites_snapshot_under_base_id(monkeypatch):
     assert new_row["nexus_module_hash"] == "modabc"  # other fields preserved
     # marker now carries the new history_scope_id (keyed by scoped id)
     assert state["markers"][0]["config_hash"] == new_scope
+
+
+def test_restamp_preserves_backtest_origin_in_id(monkeypatch):
+    # A backtest-origin snapshot is loadable by boot, so it must be re-stamped
+    # too -- and keep its `backtest` PK segment (not be rewritten as `live`).
+    old_hash = nci.live_config_hash(OLD_CFG)
+    new_hash = nci.live_config_hash(NEW_CFG)
+    state = _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", old_hash, origin="backtest")],
+        markers=[],
+    )
+    out = nr.restamp_instance(None, _FakeR(), "alpaca-main", NEW_CFG)
+    assert out["snapshots_restamped"] == 1
+    new_row = next(s for s in state["snapshots"] if s["config_hash"] == new_hash)
+    assert new_row["id"] == f"alpaca-main|{NEXUS}|{new_hash}|backtest|2026-06-28"
+    assert new_row["origin"] == "backtest"
 
 
 def test_restamp_is_idempotent(monkeypatch):

--- a/backend/tests/test_nexus_restamp.py
+++ b/backend/tests/test_nexus_restamp.py
@@ -1,0 +1,189 @@
+"""Re-stamp module tests. DB access is faked via the module's _fetch/_write helpers.
+
+Imports nexus_restamp only (no broker import).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import nexus_restamp as nr
+import nexus_config_identity as nci
+
+NEXUS = nr.NEXUS_STRATEGY_NAME
+
+# Change keys in BOTH identity namespaces so both hashes move:
+#   live_config_hash reads stage keys (analyst_llm_model, ...);
+#   history_scope_id reads root keys (llm_model, ...).
+OLD_CFG = {
+    "llm_provider": "bedrock", "llm_model": "kimi-k2.5",
+    "analyst_llm_provider": "bedrock", "analyst_llm_model": "kimi-k2.5",
+    "lookback_learning_days": 120,
+}
+NEW_CFG = {
+    "llm_provider": "bedrock", "llm_model": "nemotron-3-ultra",
+    "analyst_llm_provider": "bedrock", "analyst_llm_model": "nemotron-3-ultra",
+    "lookback_learning_days": 120,
+}
+
+
+class _FakeR:
+    """Stub `r` whose .now() is deterministic; other calls are unused in tests."""
+    def now(self):
+        return "NOW"
+
+
+def _install_fake_db(monkeypatch, *, instances, snapshots, markers):
+    """Wire the module's DB helpers to in-memory lists. Returns the live stores."""
+    state = {"snapshots": list(snapshots), "markers": list(markers)}
+
+    monkeypatch.setattr(nr, "_fetch_linked_base_instance_ids",
+                        lambda conn, r, sid: list(instances))
+
+    def _fetch_live(conn, r, base):
+        return [dict(s) for s in state["snapshots"]
+                if s["instance_id"] == base and s.get("origin") == "live"
+                and s.get("config_hash") and s.get("end_date")]
+    monkeypatch.setattr(nr, "_fetch_live_snapshot_rows", _fetch_live)
+
+    def _write(conn, r, row):
+        state["snapshots"] = [s for s in state["snapshots"] if s["id"] != row["id"]]
+        state["snapshots"].append(dict(row))
+    monkeypatch.setattr(nr, "_write_snapshot_row", _write)
+
+    def _fetch_markers(conn, r, base):
+        out = []
+        for m in state["markers"]:
+            iid = str(m.get("instance_id") or "")
+            if iid == base or iid.startswith(base + "|"):
+                out.append(dict(m))
+        return out
+    monkeypatch.setattr(nr, "_fetch_cleanup_markers", _fetch_markers)
+
+    def _update_marker(conn, r, marker_id, new_scope):
+        for m in state["markers"]:
+            if m["id"] == marker_id:
+                m["config_hash"] = new_scope
+    monkeypatch.setattr(nr, "_update_marker_hash", _update_marker)
+
+    return state
+
+
+def _snap(base, config_hash, end_date="2026-06-28"):
+    return {
+        "id": f"{base}|{NEXUS}|{config_hash}|live|{end_date}",
+        "instance_id": base, "strategy_name": NEXUS, "origin": "live",
+        "config_hash": config_hash, "nexus_module_hash": "modabc",
+        "end_date": end_date, "cache_json": "{}", "updated_at_epoch": 1.0,
+    }
+
+
+def _marker(scoped, config_hash):
+    return {"id": f"cleanup_done|{scoped}", "instance_id": scoped, "config_hash": config_hash}
+
+
+def test_restamp_rewrites_snapshot_under_base_id(monkeypatch):
+    old_hash = nci.live_config_hash(OLD_CFG)
+    new_hash = nci.live_config_hash(NEW_CFG)
+    new_scope = nci.history_scope_id(NEW_CFG)
+    scoped = f"alpaca-main|{nci.history_scope_id(OLD_CFG)}"
+    state = _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", old_hash)],
+        markers=[_marker(scoped, nci.history_scope_id(OLD_CFG))],
+    )
+    out = nr.restamp_instance(None, _FakeR(), "alpaca-main", NEW_CFG)
+
+    assert out["snapshots_restamped"] == 1
+    assert out["markers_restamped"] == 1
+    ids = [s["id"] for s in state["snapshots"]]
+    assert f"alpaca-main|{NEXUS}|{new_hash}|live|2026-06-28" in ids
+    new_row = next(s for s in state["snapshots"] if s["config_hash"] == new_hash)
+    assert new_row["instance_id"] == "alpaca-main"  # base id, not scoped
+    assert new_row["nexus_module_hash"] == "modabc"  # other fields preserved
+    # marker now carries the new history_scope_id (keyed by scoped id)
+    assert state["markers"][0]["config_hash"] == new_scope
+
+
+def test_restamp_is_idempotent(monkeypatch):
+    new_hash = nci.live_config_hash(NEW_CFG)
+    new_scope = nci.history_scope_id(NEW_CFG)
+    scoped = f"alpaca-main|{nci.history_scope_id(NEW_CFG)}"
+    _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", new_hash)],
+        markers=[_marker(scoped, new_scope)],
+    )
+    out = nr.restamp_instance(None, _FakeR(), "alpaca-main", NEW_CFG)
+    assert out["snapshots_restamped"] == 0
+    assert out["markers_restamped"] == 0
+
+
+def test_restamp_handles_multiple_scoped_markers(monkeypatch):
+    old_hash = nci.live_config_hash(OLD_CFG)
+    new_scope = nci.history_scope_id(NEW_CFG)
+    state = _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", old_hash)],
+        markers=[
+            _marker("alpaca-main|aaaa", "h1"),
+            _marker("alpaca-main|bbbb", "h2"),
+            _marker("other-instance|cccc", "h3"),  # must NOT be touched
+        ],
+    )
+    out = nr.restamp_instance(None, _FakeR(), "alpaca-main", NEW_CFG)
+    assert out["markers_restamped"] == 2
+    by_id = {m["id"]: m for m in state["markers"]}
+    assert by_id["cleanup_done|alpaca-main|aaaa"]["config_hash"] == new_scope
+    assert by_id["cleanup_done|alpaca-main|bbbb"]["config_hash"] == new_scope
+    assert by_id["cleanup_done|other-instance|cccc"]["config_hash"] == "h3"
+
+
+def test_preview_needs_prompt_when_changed_and_snapshot_exists(monkeypatch):
+    old_hash = nci.live_config_hash(OLD_CFG)
+    scoped = f"alpaca-main|{nci.history_scope_id(OLD_CFG)}"
+    _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", old_hash)],
+        markers=[_marker(scoped, nci.history_scope_id(OLD_CFG))],
+    )
+    monkeypatch.setattr(nr, "resolve_for_identity", lambda conn, cfg: NEW_CFG)
+    out = nr.preview_change(None, _FakeR(), 179,
+                            [{"strategy": NEXUS, "config": NEW_CFG}])
+    assert out["needs_prompt"] is True
+    assert out["instances"][0]["would_rebuild"] is True
+    assert out["instances"][0]["snapshot_exists"] is True
+
+
+def test_preview_no_prompt_when_unchanged(monkeypatch):
+    new_hash = nci.live_config_hash(NEW_CFG)
+    scoped = f"alpaca-main|{nci.history_scope_id(NEW_CFG)}"
+    _install_fake_db(
+        monkeypatch,
+        instances=["alpaca-main"],
+        snapshots=[_snap("alpaca-main", new_hash)],
+        markers=[_marker(scoped, nci.history_scope_id(NEW_CFG))],
+    )
+    monkeypatch.setattr(nr, "resolve_for_identity", lambda conn, cfg: NEW_CFG)
+    out = nr.preview_change(None, _FakeR(), 179,
+                            [{"strategy": NEXUS, "config": NEW_CFG}])
+    assert out["needs_prompt"] is False
+    assert out["instances"][0]["would_rebuild"] is False
+
+
+def test_preview_no_prompt_when_no_snapshot(monkeypatch):
+    _install_fake_db(
+        monkeypatch,
+        instances=["fresh-instance"],
+        snapshots=[],  # never ran -> nothing to preserve
+        markers=[],
+    )
+    monkeypatch.setattr(nr, "resolve_for_identity", lambda conn, cfg: NEW_CFG)
+    out = nr.preview_change(None, _FakeR(), 179,
+                            [{"strategy": NEXUS, "config": NEW_CFG}])
+    assert out["needs_prompt"] is False
+    assert out["instances"][0]["snapshot_exists"] is False

--- a/backend/tests/test_nexus_restamp_parity.py
+++ b/backend/tests/test_nexus_restamp_parity.py
@@ -1,0 +1,41 @@
+"""Keystone parity guard: re-stamp identities == the shared identities boot uses.
+
+The broker boot path computes the snapshot/cleanup identities via
+``nexus_config_identity.live_config_hash`` / ``history_scope_id`` (imported as
+``_nexus_live_config_hash`` / ``_nexus_history_scope_id`` in broker.py). The
+re-stamp path MUST compute byte-identical values, or "preserve" silently
+degrades to a destructive rebuild. This test fails loudly if the two ever drift.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import nexus_config_identity as nci
+import nexus_restamp as nr
+
+REPRESENTATIVE = {
+    "llm_provider": "bedrock", "llm_model": "nemotron-3-ultra",
+    "discovery_llm_provider": "bedrock", "discovery_llm_model": "nemotron-3-ultra",
+    "sentiment_llm_provider": "bedrock", "sentiment_llm_model": "nemotron-3-ultra",
+    "company_llm_provider": "bedrock", "company_llm_model": "nemotron-3-ultra",
+    "macro_llm_provider": "bedrock", "macro_llm_model": "nemotron-3-ultra",
+    "analyst_llm_provider": "bedrock", "analyst_llm_model": "nemotron-3-ultra",
+    "company_article_llm_model": "nemotron-3-ultra",
+    "macro_article_llm_model": "nemotron-3-ultra",
+    "event_maintenance_llm_model": "nemotron-3-ultra",
+    "overlay_llm_model": "nemotron-3-ultra",
+    "lookback_learning_days": 120,
+}
+
+
+def test_restamp_identities_match_shared_module():
+    cfg_hash, scope = nr._identities_for(REPRESENTATIVE)
+    assert cfg_hash == nci.live_config_hash(REPRESENTATIVE)
+    assert scope == nci.history_scope_id(REPRESENTATIVE)
+
+
+def test_restamp_uses_the_same_strategy_name_as_boot():
+    # Boot hashes under "graph_nexus_analysis"; re-stamp must too (default arg).
+    assert nr.NEXUS_STRATEGY_NAME == "graph_nexus_analysis"
+    assert nci.NEXUS_STRATEGY_NAME == "graph_nexus_analysis"

--- a/docs/superpowers/plans/2026-06-29-nexus-model-switch-preserve-history.md
+++ b/docs/superpowers/plans/2026-06-29-nexus-model-switch-preserve-history.md
@@ -1,0 +1,214 @@
+# Nexus Model Switch — Preserve History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a save-time "Preserve history" choice so changing a `graph_nexus_analysis` instance's LLM model re-stamps existing Nexus state to the new identities instead of triggering a destructive lookback + cleanup on next boot.
+
+**Architecture:** Centralize the two boot identities (`live_config_hash`, `history_scope_id`) in one broker-free module that boot also calls (parity guarantee). A re-stamp module updates the snapshot row (base instance id) and cleanup marker (scoped instance id) to the new identities. A read-only preview endpoint drives a three-button popup on web + mobile; the existing `PUT /strategies/{id}` gains a `preserve_history` flag.
+
+**Tech Stack:** Python (FastAPI, RethinkDB/`rethinkdb` driver, pytest), Vue 3 (web), Flutter/Dart (mobile).
+
+## Global Constraints
+
+- Real-money instance (`alpaca-main`, doc 179) — broker positions/P&L must never be touched; only Nexus analytical-layer DB rows.
+- **Hash parity is mandatory:** re-stamped identities MUST equal boot-computed identities for the same resolved config. Boot and the feature call the SAME functions.
+- Snapshot table `NexusStrategyCache` is keyed by **base** instance id; cleanup marker `GraphNexusLearningCache` `cleanup_done|<id>` is keyed by **scoped** instance id. Never mix them.
+- Resolve order mirrors boot exactly: `resolve_model_refs_in_config(force_refresh=True)` → `_apply_live_overrides` → compute identities.
+- Local env: use `python3` (3.14); `python-socketio` not installed (broker-import tests error at collection — avoid importing `broker` in new tests).
+- No test may hit prod RethinkDB.
+
+---
+
+### Task 1: Extract shared identity module + refactor boot to use it
+
+**Files:**
+- Create: `backend/nexus_config_identity.py`
+- Modify: `backend/broker.py` (history-scope helpers `_nexus_history_scope_doc`/`_nexus_history_scope_id` + their `_role_*` deps; boot config-hash site ~5659; history-scope site)
+- Test: `backend/tests/test_nexus_config_identity.py`
+
+**Interfaces:**
+- Produces:
+  - `live_config_hash(resolved_cfg: dict, *, strategy_name: str = "graph_nexus_analysis", lookback_days_default: int = 120) -> str` (16-char)
+  - `history_scope_id(resolved_cfg: dict) -> str` (24-char)
+
+- [ ] **Step 1: Write failing tests** (`backend/tests/test_nexus_config_identity.py`) — import `nexus_config_identity` only (NOT broker):
+
+```python
+import nexus_config_identity as nci
+
+BASE = {
+    "discovery_llm_provider": "bedrock", "discovery_llm_model": "kimi-k2.5",
+    "sentiment_llm_provider": "bedrock", "sentiment_llm_model": "kimi-k2.5",
+    "company_llm_provider": "bedrock", "company_llm_model": "kimi-k2.5",
+    "macro_llm_provider": "bedrock", "macro_llm_model": "kimi-k2.5",
+    "analyst_llm_provider": "bedrock", "analyst_llm_model": "kimi-k2.5",
+    "lookback_learning_days": 120,
+}
+
+def test_config_hash_stable_and_16char():
+    h = nci.live_config_hash(dict(BASE))
+    assert h == nci.live_config_hash(dict(BASE)) and len(h) == 16
+
+def test_config_hash_changes_on_model():
+    a = nci.live_config_hash(dict(BASE))
+    b = nci.live_config_hash({**BASE, "analyst_llm_model": "nemotron-3-ultra"})
+    assert a != b
+
+def test_history_scope_changes_on_model_stable_on_neutral():
+    a = nci.history_scope_id(dict(BASE))
+    assert a == nci.history_scope_id(dict(BASE)) and len(a) == 24
+    assert a == nci.history_scope_id({**BASE, "some_neutral_key": "x"})
+    assert a != nci.history_scope_id({**BASE, "analyst_llm_model": "nemotron-3-ultra"})
+
+def test_explicit_history_scope_id_passthrough():
+    assert nci.history_scope_id({"history_scope_id": "abc123"}) == "abc123"
+```
+
+- [ ] **Step 2: Run, verify import-fail.** `cd backend && python3 -m pytest tests/test_nexus_config_identity.py -q` → FAIL (module missing).
+
+- [ ] **Step 3: Read the source to move.** Read `backend/broker.py` lines ~2840-2935 for `_nexus_history_scope_doc`, `_nexus_history_scope_id`, and the `_role_provider`/`_role_model`/`_role_prompt` helpers they call. Read `backend/broker.py:5655-5675` for the exact `_compute_config_hash({...})` boot call.
+
+- [ ] **Step 4: Write `backend/nexus_config_identity.py`.** Move the history-scope functions verbatim, parameterized to take a `settings: dict` (the resolved config) explicitly with no broker globals. Wrap the snapshot hash:
+
+```python
+import strategy_cache_persistence as scp
+from broker_snapshot_helpers import (
+    _collect_prompt_versions, _collect_llm_stages, _collect_history_scope_inputs,
+)
+
+def live_config_hash(resolved_cfg, *, strategy_name="graph_nexus_analysis", lookback_days_default=120):
+    cfg = resolved_cfg or {}
+    return scp._compute_config_hash({
+        "strategy_name": strategy_name,
+        "prompt_versions": _collect_prompt_versions(cfg),
+        "llm_stages": _collect_llm_stages(cfg),
+        "history_scope_id_inputs": _collect_history_scope_inputs(cfg),
+        "lookback_learning_days": int(cfg.get("lookback_learning_days", lookback_days_default) or lookback_days_default),
+    })
+
+# _nexus_history_scope_doc(settings) and history_scope_id(settings) moved from broker.py
+```
+
+  Confirm `broker_snapshot_helpers` and `strategy_cache_persistence` import without pulling in `broker` (they do per investigation).
+
+- [ ] **Step 5: Refactor `broker.py`** to import from the new module and delete the moved bodies: at the boot config-hash site replace the inline `_compute_config_hash({...})` with `nexus_config_identity.live_config_hash(_bt_cfg_load)`; replace `_nexus_history_scope_id(...)` calls with `nexus_config_identity.history_scope_id(...)`. Keep names available via `from nexus_config_identity import history_scope_id as _nexus_history_scope_id` if other call sites use the old name.
+
+- [ ] **Step 6: Run tests + boot import smoke.** `python3 -m pytest tests/test_nexus_config_identity.py -q` → PASS. `python3 -c "import ast,sys; ast.parse(open('broker.py').read())"` → no syntax error.
+
+- [ ] **Step 7: Commit.** `git add backend/nexus_config_identity.py backend/tests/test_nexus_config_identity.py backend/broker.py && git commit -m "feat(nexus): extract shared config-identity module; boot uses it"`
+
+---
+
+### Task 2: Re-stamp module (preview + restamp)
+
+**Files:**
+- Create: `backend/nexus_restamp.py`
+- Test: `backend/tests/test_nexus_restamp.py`
+
+**Interfaces:**
+- Consumes: `nexus_config_identity.live_config_hash/history_scope_id`; `model_resolver.resolve_model_refs_in_config`; `live_mode_overrides._apply_live_overrides`; `strategy_cache_persistence` (table name `NexusStrategyCache`).
+- Produces:
+  - `resolve_for_identity(conn, raw_cfg: dict) -> dict`
+  - `linked_base_instance_ids(conn, strategy_id) -> list[str]`
+  - `preview_change(conn, strategy_id, proposed_strategies: list) -> dict` → `{"needs_prompt": bool, "instances": [{"base_instance_id", "would_rebuild", "snapshot_exists"}]}`
+  - `restamp_instance(conn, base_instance_id: str, resolved_cfg: dict) -> dict` → `{"snapshots_restamped": int, "markers_restamped": int, "config_hash", "history_scope_id"}`
+
+- [ ] **Step 1: Write failing tests** using a fake RethinkDB conn/`r` (in-memory dicts) — do NOT import broker. Test that:
+  - `restamp_instance` writes a new `NexusStrategyCache` row keyed by **base** id with `id` ending `|{newhash}|live|{end_date}` and `config_hash == newhash`, leaving the old row.
+  - It sets every `GraphNexusLearningCache` row `cleanup_done|<scoped>` whose `instance_id` startswith base to `config_hash == history_scope_id(resolved_cfg)`.
+  - Idempotent: second call makes no further changes.
+  - `preview_change` returns `needs_prompt=False` when proposed identities equal current; `True` when changed and a snapshot exists; `needs_prompt=False` when changed but no snapshot exists.
+
+  (Inject `r` and `conn` so the test substitutes fakes; the module takes `r`/`conn` as params or imports the project's `r` — match `strategy_cache_persistence` style which uses module-level `r`.)
+
+- [ ] **Step 2: Run, verify fail.** `python3 -m pytest tests/test_nexus_restamp.py -q` → FAIL.
+
+- [ ] **Step 3: Implement `backend/nexus_restamp.py`.** Use the same `r`/DB_NAME import pattern as `strategy_cache_persistence.py`. `resolve_for_identity` = `resolve_model_refs_in_config(conn, raw_cfg, force_refresh=True)` then `_apply_live_overrides`. `linked_base_instance_ids` queries `Instances.filter(strategy_id == sid).pluck("id")`. Snapshot re-stamp: read latest live-origin row(s) for `instance_id == base`, copy with new `id`/`config_hash`, refresh `updated_at*`, `insert(conflict="replace")`. Marker re-stamp: `table("GraphNexusLearningCache").filter(id matches "^cleanup_done\\|" AND instance_id startswith base).update({"config_hash": new_scope})`. Pull the proposed sub-strategy config out of `proposed_strategies` by matching `strategy == "graph_nexus_analysis"`.
+
+- [ ] **Step 4: Run tests** → PASS.
+
+- [ ] **Step 5: Commit.** `git add backend/nexus_restamp.py backend/tests/test_nexus_restamp.py && git commit -m "feat(nexus): preview + restamp module for model-switch preserve"`
+
+---
+
+### Task 3: Parity test (keystone)
+
+**Files:**
+- Test: `backend/tests/test_nexus_restamp_parity.py`
+
+- [ ] **Step 1: Write the parity test.** For a representative resolved config, assert `nexus_restamp` and `nexus_config_identity` agree, and that the identity strings are exactly what boot derives — by importing `nexus_config_identity` (the single source boot now uses) and asserting `restamp_instance`'s computed `config_hash`/`history_scope_id` equal `live_config_hash`/`history_scope_id` of the same resolved cfg. (This guards that re-stamp can never write an identity boot won't match.)
+
+```python
+import nexus_config_identity as nci
+import nexus_restamp as nr
+
+def test_restamp_identities_match_boot(monkeypatch):
+    cfg = {"analyst_llm_provider":"bedrock","analyst_llm_model":"nemotron-3-ultra","lookback_learning_days":120}
+    # stub resolve_for_identity to return cfg unchanged
+    monkeypatch.setattr(nr, "resolve_for_identity", lambda conn, c: c)
+    out = nr._identities_for(cfg)  # small helper returning (config_hash, history_scope_id)
+    assert out == (nci.live_config_hash(cfg), nci.history_scope_id(cfg))
+```
+
+- [ ] **Step 2: Add `_identities_for(cfg)` helper** to `nexus_restamp.py` if not present (returns the tuple used by `restamp_instance`).
+- [ ] **Step 3: Run** → PASS.
+- [ ] **Step 4: Commit.** `git commit -am "test(nexus): parity guard restamp identities == boot identities"`
+
+---
+
+### Task 4: Backend action handlers + API endpoints
+
+**Files:**
+- Modify: `backend/interactive_utils.py` (`action_edit_strategy`; new `action_preview_strategy_config_change`)
+- Modify: `backend/api/main.py` (`EditStrategyBody`; new preview route)
+- Test: `backend/tests/test_action_preview_and_preserve.py`
+
+**Interfaces:**
+- Consumes: `nexus_restamp.preview_change/restamp_instance/resolve_for_identity/linked_base_instance_ids`.
+- Produces: `action_preview_strategy_config_change(conn, strategy_id, strategies) -> dict`; `action_edit_strategy(conn, strategy_id, name=None, strategies=None, preserve_history=False) -> dict`.
+
+- [ ] **Step 1: Write failing tests** for `action_edit_strategy(..., preserve_history=True)` calling `restamp_instance` for each linked instance (monkeypatch `nexus_restamp`), and `preserve_history=False` NOT calling it; `action_preview_strategy_config_change` delegating to `preview_change`.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.** Add `preserve_history=False` param to `action_edit_strategy`; after the existing `Strategies.update`, if true: for each `base_id` in `linked_base_instance_ids`, `resolved = resolve_for_identity(conn, <new graph_nexus config>)`, `restamp_instance(conn, base_id, resolved)`; include a `restamp` summary in the return. Add `action_preview_strategy_config_change`. In `api/main.py`: add `preserve_history: bool = False` to `EditStrategyBody`, pass through; add `POST /strategies/{strategy_id}/config-change-preview` mirroring the `clear-state` dry-run wiring (`_run`, `conn_dependency`, `get_current_user`).
+
+- [ ] **Step 4: Run tests** → PASS.
+- [ ] **Step 5: Commit.** `git commit -am "feat(api): config-change preview endpoint + preserve_history on edit"`
+
+---
+
+### Task 5: Web popup (InstanceDetailView.vue)
+
+**Files:**
+- Modify: `frontend/src/views/InstanceDetailView.vue` (`submitEditStrategy` + new modal state)
+
+- [ ] **Step 1: Add preview call + modal.** In `submitEditStrategy`, before the `PUT`, `POST ${API_BASE}/strategies/${d.id}/config-change-preview` with `{strategies: d.strategies}`. If `body.needs_prompt`, set modal state listing affected instances and STOP (await user choice) instead of PUTting. Add a `<div>` modal with three buttons → handlers that call a shared `doSaveStrategy(preserveHistory)` which performs the existing `PUT` with `preserve_history` added to the body. Non-prompt path calls `doSaveStrategy(false)` directly.
+
+- [ ] **Step 2: Modal copy:** "Changing the analysis model for <names> would otherwise rebuild Nexus history. Preserve existing history and apply the new model going forward? Positions & P&L are unaffected; takes effect on next Stop→Start." Buttons: **Preserve & apply forward** / **Full rebuild** / **Cancel**.
+
+- [ ] **Step 3: Build.** `cd frontend && npm run build` → green.
+- [ ] **Step 4: Commit.** `git commit -am "feat(web): model-switch preserve-history popup"`
+
+---
+
+### Task 6: Mobile confirm dialog
+
+**Files:**
+- Modify: `mobile/lib/features/strategies/data/strategy_repository.dart` (add `preview` + `preserveHistory` param on `update`)
+- Modify: the strategy config edit screen that calls `strategy_repository.update`
+
+- [ ] **Step 1: Repository.** Add `Future<Map<String,dynamic>> previewConfigChange(String id, List strategies)` → `POST /strategies/$id/config-change-preview`; add optional `bool preserveHistory = false` to `update`, injected into the body.
+
+- [ ] **Step 2: Screen.** Before saving, call `previewConfigChange`; if `needs_prompt`, `showDialog` AlertDialog with the three actions; pass `preserveHistory` to `update`.
+
+- [ ] **Step 3: Analyze.** `cd mobile && flutter analyze lib/features/strategies` → clean (pre-existing info lints OK).
+- [ ] **Step 4: Commit.** `git commit -am "feat(mobile): model-switch preserve-history confirm dialog"`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** shared identity module (T1) ✓; restamp base/scoped keying (T2) ✓; preview `needs_prompt` semantics (T2) ✓; parity (T3) ✓; preview endpoint + `preserve_history` (T4) ✓; web popup (T5) ✓; mobile dialog (T6) ✓.
+- **Placeholders:** none — concrete files/commands; broker history-scope helper bodies are moved verbatim during T1 Step 3 (read-then-move, not a placeholder).
+- **Type consistency:** `live_config_hash`/`history_scope_id`/`restamp_instance`/`preview_change` signatures used identically across tasks.

--- a/docs/superpowers/specs/2026-06-29-nexus-model-switch-preserve-history-design.md
+++ b/docs/superpowers/specs/2026-06-29-nexus-model-switch-preserve-history-design.md
@@ -1,0 +1,203 @@
+# Nexus Model Switch — "Preserve History" Design
+
+**Date:** 2026-06-29
+**Strategy affected:** `graph_nexus_analysis` (equities). Driving case: the live real-money `alpaca-main` instance (Strategies doc 179).
+**Status:** Approved design, ready for implementation plan.
+
+## Problem
+
+Changing the LLM model(s) for a `graph_nexus_analysis` instance — i.e. editing any
+`*_llm_model_id` key in the Strategies config — silently triggers a destructive,
+expensive transition on the next instance boot. The operator's intent ("just use the
+new model going forward, leave my history alone") is **not** what the code does today.
+
+A model change alters **two independent identities**, each with its own consequence:
+
+1. **`_compute_config_hash` (16-char)** — includes `llm_stages` (provider/model/effort).
+   Changing it makes the live-boot snapshot lookup return `no_match`
+   (`strategy_cache_persistence.load_with_fallback`), which signals a historic lookback.
+2. **`history_scope_id` (24-char)** — `broker._nexus_history_scope_doc` hashes the
+   per-role provider/model/prompt. Changing it makes the cleanup marker
+   (`GraphNexusLearningCache` row `cleanup_done|<instance_id>`) mismatch, which fires the
+   **destructive config-change cleanup**.
+
+### Why today's behavior is actively bad (not just a re-run)
+
+- The cleanup deletes, **by scoped instance id**, all rows for the instance in:
+  `GraphNexusDiscovered`, `GraphNexusTrends`, `GraphNexusActiveEvents`,
+  `GraphNexusActiveEventHistory`, `GraphNexusActiveEventMaintenance`,
+  `GraphNexusOutcomes`, and `GraphNexusLearningCache` (except the `cleanup_done|…` marker).
+- The lookback's resume logic (`nexus_lookback_db.historic_lookback_resume_dates`) gates
+  **only** on `instance_id + date_key`. Dates that already have `GraphNexusTradeContexts`
+  rows are **skipped**, so the lookback does **not** rebuild the wiped discoveries/trends/
+  events/learning for those dates.
+- Net result of a naive model swap: discoveries/trends/events/learning are **wiped and
+  not rebuilt**, while raw `TradeContexts`/`TradeOutcomes`/`OutcomeSeries` linger under the
+  **old** model's stamp — a degraded, half-reset analytical state.
+
+Real Alpaca positions and realized P&L are **never** touched by any of this (they live
+server-side at the broker). The damage is confined to the Nexus analytical layer that
+feeds decisions and the dashboard nexus cards.
+
+## Goal
+
+Give the operator an explicit, safe choice at save time. When an edit would change either
+identity for an instance that has existing live state, prompt:
+
+> **This changes the analysis model for `<instance>`. Preserve existing history and apply
+> the new model only going forward?**
+> **[ Preserve & apply forward ]  [ Full rebuild ]  [ Cancel ]**
+
+- **Preserve & apply forward** — re-stamp the existing saved state to the new identities so
+  the next boot reuses everything as-is and the new model applies only to new dates. No
+  lookback, no cleanup.
+- **Full rebuild** — today's behavior (full lookback + cleanup on next boot).
+- **Cancel** — abort the save.
+
+Non-goals: changing backtest behavior; changing what `_compute_config_hash` /
+`history_scope_id` mean globally; touching the broker adapter or live trading loop.
+
+## Approach
+
+**Centralize the two identities, then re-stamp on save.**
+
+The single biggest correctness risk is **hash parity**: the re-stamped hashes must exactly
+equal what the broker computes at boot, or "preserve" silently fails and the instance does
+the destructive rebuild anyway. To guarantee parity we extract the identity computations
+into one shared, broker-free module and make boot call the same functions the feature calls.
+
+Alternatives considered and rejected:
+- *One-off manual migration script* — does not give the reusable popup the operator wants.
+- *Make the model hash-agnostic globally* — breaks backtest comparability and snapshot
+  correctness everywhere.
+
+## Components
+
+### Backend
+
+1. **`backend/nexus_config_identity.py`** (new, no broker import)
+   - `live_config_hash(resolved_cfg: dict) -> str` — the 16-char snapshot identity. Wraps the
+     existing `_collect_prompt_versions` / `_collect_llm_stages` / `_collect_history_scope_inputs`
+     (from `broker_snapshot_helpers`) + `lookback_learning_days`, fed to
+     `strategy_cache_persistence._compute_config_hash`. Exactly mirrors `broker.py:5659`.
+   - `history_scope_id(resolved_cfg: dict) -> str` — the 24-char cleanup identity. Moves
+     `broker._nexus_history_scope_doc` + `_nexus_history_scope_id` here verbatim.
+   - **`broker.py` is refactored** to import and call these two functions at the boot
+     snapshot-hash site and the history-scope site, so there is one source of truth.
+     This is the parity guarantee; it is the only change to boot.
+
+2. **`backend/nexus_restamp.py`** (new, no broker import)
+   - `resolve_for_identity(conn, raw_cfg) -> dict` — `resolve_model_refs_in_config(force_refresh=True)`
+     then `live_mode_overrides._apply_live_overrides` (mirroring boot's order), so the
+     computed identities match a live boot.
+   - `preview_change(conn, strategy_id, proposed_strategies) -> dict` — for each instance
+     linked to the strategy doc (`Instances.strategy_id == strategy_id`), compute the
+     proposed `live_config_hash` + `history_scope_id`, compare against the instance's current
+     saved-state identities (current snapshot row `config_hash`; current `cleanup_done|…`
+     marker `config_hash`). Returns per-instance `{base_instance_id, would_rebuild,
+     snapshot_exists}` plus an overall `needs_prompt` boolean. Read-only.
+   - `restamp_instance(conn, base_instance_id, resolved_cfg) -> dict` — idempotent. Computes
+     the new identities and:
+     - **Snapshot** (`NexusStrategyCache`, keyed by **base** id): for each live-origin row of
+       this instance, write a re-stamped copy with the new `config_hash` and rebuilt
+       `id = "{base}|{strategy}|{newhash}|live|{end_date}"`; keep `nexus_module_hash`,
+       `end_date`, `cache_json` unchanged; refresh `updated_at`/`updated_at_epoch`. Leave the
+       old row in place (harmless, lets a revert still match).
+     - **Cleanup marker** (`GraphNexusLearningCache`, keyed by **scoped** id): for each
+       `cleanup_done|<scoped>` row whose scoped id starts with `<base>`, set its `config_hash`
+       field to the new `history_scope_id`. Scoped ids are **discovered from existing rows**,
+       not recomputed, to avoid drift.
+   - **Base-vs-scoped keying is explicit and tested** — snapshot uses base id, marker uses
+     scoped id; mixing them is how a "preserve" silently fails.
+
+3. **`backend/interactive_utils.py`**
+   - `action_preview_strategy_config_change(conn, strategy_id, strategies)` → wraps
+     `nexus_restamp.preview_change`.
+   - Extend `action_edit_strategy(conn, strategy_id, name, strategies, preserve_history=False)`:
+     after the existing config write, if `preserve_history` is true, resolve the new config and
+     call `restamp_instance` for each linked instance, returning a summary of what was re-stamped.
+
+4. **`backend/api/main.py`**
+   - `POST /strategies/{strategy_id}/config-change-preview` (read-only dry-run; mirrors the
+     existing `/instances/{id}/clear-state` `apply=false` pattern) → `action_preview_strategy_config_change`.
+   - Extend `PUT /strategies/{strategy_id}` body (`EditStrategyBody`) with optional
+     `preserve_history: bool = False`, passed through to `action_edit_strategy`.
+
+### Web (`frontend/src/views/InstanceDetailView.vue`)
+
+- `submitEditStrategy` first POSTs to `config-change-preview` with the proposed `strategies`.
+- If `needs_prompt`, open a modal listing the affected instance(s) with the three choices.
+  - **Preserve & apply forward** → `PUT /strategies/{id}` with `preserve_history: true`.
+  - **Full rebuild** → `PUT` with `preserve_history: false` (current behavior).
+  - **Cancel** → abort, leave the editor open.
+- If `!needs_prompt`, save directly as today (no behavior change for non-hash edits).
+- Modal copy states: takes effect on next Stop→Start; positions/P&L are unaffected; the
+  preserved learned state was trained on the prior model and the new model inherits it.
+
+### Mobile (Flutter)
+
+- On the strategy config screen (the `*_llm_model_id` picker that calls
+  `strategy_repository.update` → `PUT /strategies/:id`): before saving, call the preview
+  endpoint; if `needs_prompt`, show an `AlertDialog` with the same three choices; pass
+  `preserve_history` in the update body.
+- `strategy_repository` gains a preview call and a `preserveHistory` parameter on `update`.
+
+## Data flow
+
+```
+edit models → Save
+  → POST /strategies/{id}/config-change-preview {strategies}
+      → resolve proposed cfg → live_config_hash + history_scope_id per linked instance
+      → compare vs current snapshot.config_hash + marker.config_hash
+      → { needs_prompt, instances:[{base_instance_id, would_rebuild, snapshot_exists}] }
+  → if needs_prompt: popup [Preserve | Full rebuild | Cancel]
+  → PUT /strategies/{id} { name, strategies, preserve_history }
+      → write Strategies config (unchanged path)
+      → if preserve_history: for each linked instance, restamp_instance()
+          → re-stamp NexusStrategyCache row(s)  (BASE id)  → new live_config_hash
+          → set GraphNexusLearningCache cleanup_done marker(s) (SCOPED id) → new history_scope_id
+  → operator Stop → Start
+      → boot computes identities via shared module → snapshot MATCHES, marker MATCHES
+      → no lookback, no cleanup; new model applies to new dates only
+```
+
+## Edge cases & risks
+
+- **Hash parity (keystone).** Mitigated by the shared identity module + a parity test that
+  asserts `restamp_instance`'s computed hashes equal the values boot derives for the same
+  resolved config. If parity ever breaks, preserve degrades to full rebuild (safe-ish:
+  data loss, not money loss) — but the test must guard it.
+- **Multiple linked instances / scope-suffixed ids.** Re-stamp every linked base instance;
+  discover scoped marker rows from the DB rather than recomputing the scope suffix.
+- **No live snapshot exists** (instance never ran) → `would_rebuild` may be true but
+  `snapshot_exists` false → `needs_prompt` stays false; nothing to preserve, save directly.
+- **Running instance.** Re-stamp is a DB edit; it takes effect on the next Stop→Start (the
+  model change already requires a restart today). A running process writing a fresh snapshot
+  under the old hash after re-stamp is harmless — our new-hash row still exists.
+- **Partial config edits that change only `history_scope_id` but not `config_hash`** (or vice
+  versa). `preview_change` checks both independently and `restamp_instance` always updates
+  both targets, so either-direction drift is neutralized.
+- **Idempotency.** Re-running `restamp_instance` with the same config is a no-op (rows already
+  carry the new identities).
+
+## Testing
+
+- **Unit (`backend/`):**
+  - `live_config_hash` / `history_scope_id`: stable for unchanged config; both change when a
+    `*_llm_model_id` changes; `history_scope_id` unaffected by behaviorally-neutral keys.
+  - `restamp_instance`: writes snapshot row under **base** id with correct new `id`+`config_hash`;
+    sets marker(s) under **scoped** id to new `history_scope_id`; leaves other fields intact;
+    idempotent; handles multiple linked instances and multiple scoped markers.
+  - `preview_change`: `needs_prompt` true only when an identity changed **and** a snapshot
+    exists; correct per-instance flags.
+- **Parity/integration:** assert the identities written by `restamp_instance` equal those the
+  broker boot path computes for the same resolved config (import the shared module both sides).
+- **Web:** component test for the preview→modal→PUT branch (preserve / full / cancel).
+- **Mobile:** widget test for the confirm dialog + `preserveHistory` passthrough; `flutter analyze` clean.
+- No test touches prod RethinkDB; use a local/ephemeral DB or fakes.
+
+## Out of scope
+
+- Backtest cleanup/lookback semantics.
+- The Kalshi model path (`kalshi_config.model`) — different mechanism, unaffected.
+- Any change to live trading execution.

--- a/docs/superpowers/specs/2026-06-29-nexus-model-switch-preserve-history-design.md
+++ b/docs/superpowers/specs/2026-06-29-nexus-model-switch-preserve-history-design.md
@@ -196,6 +196,27 @@ edit models → Save
 - **Mobile:** widget test for the confirm dialog + `preserveHistory` passthrough; `flutter analyze` clean.
 - No test touches prod RethinkDB; use a local/ephemeral DB or fakes.
 
+## Implementation notes (discovered during build)
+
+- **Two disjoint identity namespaces.** `live_config_hash` reads the *stage*
+  keys (`discovery/sentiment/macro/company/analyst_llm_model`) while
+  `history_scope_id` reads *root + article-role* keys (`llm_model`,
+  `company_article_*`, `macro_article_*`, `event_maintenance_*`, `overlay_*`).
+  They are disjoint, so a given model edit may move one identity, the other, or
+  both. `preview_change` checks each independently and `restamp_instance` always
+  updates both targets, so any combination is handled.
+- **Mobile has no model-selection editor.** `strategy_detail_screen` is
+  read-only for strategy config (its form creates backtests). The mobile
+  deliverable is therefore the repository plumbing (`previewConfigChange` +
+  `update(preserveHistory:)`) with tests; the confirmation dialog will attach
+  when a mobile strategy-config editor exists. The web editor is the live path.
+- **Known gap — editing the Models-table row.** Changing a `Models` row's
+  underlying `model` (via the models screen) also changes the resolved
+  provider/model for every instance referencing that `model_id`, so it changes
+  the boot identities too — but it goes through `PUT /models`, not
+  `PUT /strategies`, so it bypasses this popup. Out of scope here; flagged for a
+  follow-up (the same `nexus_restamp` functions can back it).
+
 ## Out of scope
 
 - Backtest cleanup/lookback semantics.

--- a/frontend/src/views/InstanceDetailView.vue
+++ b/frontend/src/views/InstanceDetailView.vue
@@ -755,6 +755,16 @@ const editStrategyOk      = ref(false)
 const editStrategyData    = ref(null)
 const editStrategyPickName = ref('')
 const availableStrategies = ref([])
+// Preserve-history popup: shown when a save would change the Nexus model
+// identity for an instance that has existing live state.
+const showPreserveHistory = ref(false)
+const preserveHistoryInfo = ref(null)  // { instances: [{ base_instance_id, ... }] }
+const preserveHistoryAffectedNames = computed(() => {
+  const list = (preserveHistoryInfo.value?.instances || [])
+    .filter(i => i.would_rebuild && i.snapshot_exists)
+    .map(i => i.base_instance_id)
+  return list.length ? list.join(', ') : 'this instance'
+})
 const configJsonDrafts = ref({})
 const configJsonErrors = ref({})
 
@@ -1147,26 +1157,59 @@ async function submitEditStrategy() {
   if (!d.name?.trim()) { editStrategyMsg.value = 'Strategy name is required'; editStrategyOk.value = false; return }
   if (hasConfigEditorErrors()) { editStrategyMsg.value = 'Fix invalid JSON config fields before saving'; editStrategyOk.value = false; return }
   editStrategySaving.value = true
+  editStrategyMsg.value    = 'Checking for model changes...'
+  editStrategyOk.value     = false
+  // Ask the backend whether this save would rebuild Nexus history. If so, let
+  // the operator choose to preserve it; otherwise save straight through.
+  try {
+    const pres = await fetch(`${API_BASE}/strategies/${d.id}/config-change-preview`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ strategies: d.strategies }),
+    })
+    const presBody = await pres.json().catch(() => ({}))
+    if (pres.ok && presBody.needs_prompt) {
+      preserveHistoryInfo.value = presBody
+      showPreserveHistory.value = true
+      editStrategySaving.value  = false
+      editStrategyMsg.value     = ''
+      return
+    }
+  } catch { /* preview is advisory — fall through to a normal save */ }
+  await doSaveStrategy(false)
+}
+
+async function doSaveStrategy(preserveHistory) {
+  const d = editStrategyData.value
+  showPreserveHistory.value = false
+  editStrategySaving.value = true
   editStrategyMsg.value    = 'Saving...'
   editStrategyOk.value     = false
   try {
     const res = await fetch(`${API_BASE}/strategies/${d.id}`, {
       method: 'PUT',
       headers: authHeaders(),
-      body: JSON.stringify({ name: d.name.trim(), strategies: d.strategies }),
+      body: JSON.stringify({ name: d.name.trim(), strategies: d.strategies, preserve_history: !!preserveHistory }),
     })
     const body = await res.json().catch(() => ({}))
     if (!res.ok) throw new Error(body.detail || `HTTP ${res.status}`)
     editStrategyOk.value  = true
-    editStrategyMsg.value = 'Strategy saved.'
+    editStrategyMsg.value = preserveHistory
+      ? 'Saved. History preserved — takes effect on next Stop→Start.'
+      : 'Strategy saved.'
     await fetchInstance()
-    setTimeout(() => { showEditStrategy.value = false }, 1200)
+    setTimeout(() => { showEditStrategy.value = false }, 1400)
   } catch (e) {
     editStrategyOk.value  = false
     editStrategyMsg.value = e.message || 'Something went wrong'
   } finally {
     editStrategySaving.value = false
   }
+}
+
+function cancelPreserveHistory() {
+  showPreserveHistory.value = false
+  editStrategyMsg.value = 'Save cancelled.'
 }
 
 // ── Create Backtest modal ─────────────────────────────────────────────────────
@@ -2264,6 +2307,53 @@ async function submitCreateBacktest() {
               class="flex-1 py-2.5 rounded-lg bg-amber-500 text-black text-sm font-bold hover:bg-amber-400 transition-all disabled:opacity-50 flex items-center justify-center gap-2">
               <span v-if="editStrategySaving" class="material-symbols-outlined text-base animate-spin">progress_activity</span>
               {{ editStrategySaving ? 'Saving...' : 'Save Changes' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <!-- ── Preserve History confirmation (model/identity change) ────────────── -->
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="showPreserveHistory"
+        class="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+        @click.self="cancelPreserveHistory"
+      >
+        <div class="relative w-full max-w-lg bg-[#0f1318] border border-border-subtle rounded-2xl shadow-2xl flex flex-col">
+          <div class="flex items-center gap-3 px-6 py-5 border-b border-border-subtle">
+            <div class="size-9 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center shrink-0">
+              <span class="material-symbols-outlined text-violet-400 text-lg">history</span>
+            </div>
+            <h2 class="text-base font-bold">Analysis model changed</h2>
+          </div>
+          <div class="px-6 py-5 space-y-4 text-sm text-slate-300">
+            <p>
+              This change would otherwise rebuild Nexus analytical history for
+              <span class="font-semibold text-slate-100">{{ preserveHistoryAffectedNames }}</span>
+              (a full historic lookback + cleanup on next boot).
+            </p>
+            <p class="text-slate-400 leading-relaxed">
+              Preserve existing history and apply the new model only going forward?
+              Broker positions &amp; P&amp;L are unaffected either way. Takes effect on the
+              next Stop→Start. Preserved learned state was trained on the prior model and
+              the new model inherits it.
+            </p>
+          </div>
+          <div class="px-6 pb-6 pt-2 flex flex-col gap-2">
+            <button @click="doSaveStrategy(true)"
+              class="w-full py-2.5 rounded-lg bg-violet-500 text-white text-sm font-bold hover:bg-violet-400 transition-all">
+              Preserve &amp; apply forward
+            </button>
+            <button @click="doSaveStrategy(false)"
+              class="w-full py-2.5 rounded-lg border border-amber-500/40 text-amber-300 text-sm font-semibold hover:bg-amber-500/10 transition-colors">
+              Full rebuild (re-run lookback)
+            </button>
+            <button @click="cancelPreserveHistory"
+              class="w-full py-2.5 rounded-lg border border-border-subtle text-sm font-medium text-slate-400 hover:text-slate-200 transition-colors">
+              Cancel
             </button>
           </div>
         </div>

--- a/frontend/src/views/InstanceDetailView.vue
+++ b/frontend/src/views/InstanceDetailView.vue
@@ -1193,6 +1193,14 @@ async function doSaveStrategy(preserveHistory) {
     })
     const body = await res.json().catch(() => ({}))
     if (!res.ok) throw new Error(body.detail || `HTTP ${res.status}`)
+    if (preserveHistory && body.restamp_error) {
+      // Config saved, but the re-stamp failed — history was NOT preserved, so
+      // the next boot will rebuild. Surface it instead of a false success.
+      editStrategyOk.value  = false
+      editStrategyMsg.value = `Saved, but preserving history failed: ${body.restamp_error}. Next start will rebuild.`
+      await fetchInstance()
+      return
+    }
     editStrategyOk.value  = true
     editStrategyMsg.value = preserveHistory
       ? 'Saved. History preserved — takes effect on next Stop→Start.'

--- a/mobile/lib/features/strategies/data/strategy_repository.dart
+++ b/mobile/lib/features/strategies/data/strategy_repository.dart
@@ -25,8 +25,35 @@ class StrategyRepository {
   }
 
   /// PUT /strategies/:id
-  Future<Map<String, dynamic>> update(String id, Map<String, dynamic> body) async {
-    return _client.put<Map<String, dynamic>>('/strategies/$id', body: body);
+  ///
+  /// When [preserveHistory] is true, the backend re-stamps existing Nexus
+  /// saved-state to the new model identities so the next boot reuses it instead
+  /// of running a destructive lookback + cleanup. Set it only after the operator
+  /// confirms the preserve-history prompt (see [previewConfigChange]).
+  Future<Map<String, dynamic>> update(
+    String id,
+    Map<String, dynamic> body, {
+    bool preserveHistory = false,
+  }) async {
+    final payload = preserveHistory
+        ? {...body, 'preserve_history': true}
+        : body;
+    return _client.put<Map<String, dynamic>>('/strategies/$id', body: payload);
+  }
+
+  /// POST /strategies/:id/config-change-preview
+  ///
+  /// Read-only dry-run: returns `{needs_prompt, instances: [...]}` indicating
+  /// whether saving [strategies] would rebuild Nexus history for any linked
+  /// instance that has existing live state.
+  Future<Map<String, dynamic>> previewConfigChange(
+    String id,
+    List<dynamic> strategies,
+  ) async {
+    return _client.post<Map<String, dynamic>>(
+      '/strategies/$id/config-change-preview',
+      body: {'strategies': strategies},
+    );
   }
 
   /// GET /strategies/available → list of available strategy type names.

--- a/mobile/test/features/strategies/strategy_repository_preserve_test.dart
+++ b/mobile/test/features/strategies/strategy_repository_preserve_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intellistock_mobile/core/network/api_client.dart';
+import 'package:intellistock_mobile/features/strategies/data/strategy_repository.dart';
+
+/// Captures the path/body of the last put/post so we can assert the wire shape.
+class _FakeApiClient implements ApiClient {
+  String? lastPath;
+  Object? lastBody;
+  Map<String, dynamic> response = const {};
+
+  @override
+  Future<T> put<T>(String path, {Object? body}) async {
+    lastPath = path;
+    lastBody = body;
+    return response as T;
+  }
+
+  @override
+  Future<T> post<T>(String path, {Object? body, Map<String, dynamic>? query}) async {
+    lastPath = path;
+    lastBody = body;
+    return response as T;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('StrategyRepository preserve-history wiring', () {
+    test('update without preserveHistory omits the flag', () async {
+      final api = _FakeApiClient();
+      final repo = StrategyRepository(api);
+      await repo.update('179', {'name': 'X', 'strategies': []});
+      expect(api.lastPath, '/strategies/179');
+      final body = api.lastBody as Map<String, dynamic>;
+      expect(body.containsKey('preserve_history'), isFalse);
+    });
+
+    test('update with preserveHistory adds preserve_history: true', () async {
+      final api = _FakeApiClient();
+      final repo = StrategyRepository(api);
+      await repo.update('179', {'name': 'X', 'strategies': []},
+          preserveHistory: true);
+      final body = api.lastBody as Map<String, dynamic>;
+      expect(body['preserve_history'], isTrue);
+      expect(body['name'], 'X');
+    });
+
+    test('previewConfigChange posts strategies to the preview endpoint', () async {
+      final api = _FakeApiClient()..response = {'needs_prompt': true};
+      final repo = StrategyRepository(api);
+      final out = await repo.previewConfigChange('179', [
+        {'strategy': 'graph_nexus_analysis', 'config': {}}
+      ]);
+      expect(api.lastPath, '/strategies/179/config-change-preview');
+      expect((api.lastBody as Map)['strategies'], isA<List>());
+      expect(out['needs_prompt'], isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Changing a `graph_nexus_analysis` instance's LLM model (a `*_llm_model_id` edit) silently triggers a **destructive** transition on the next boot: it changes both the snapshot `config_hash` (→ full historic lookback) and `history_scope_id` (→ per-instance cleanup that wipes discoveries/trends/events/learning). The driving case is the **real-money `alpaca-main`** instance (doc 179), where the operator's intent is "just use the new model going forward, leave my history alone."

This adds a save-time popup: when an edit would rebuild Nexus history for an instance with existing state, the operator chooses **Preserve & apply forward** / **Full rebuild** / **Cancel**. Preserve re-stamps the existing saved-state to the new identities so the next boot reuses it — no lookback, no cleanup.

Broker positions/P&L are never touched (Alpaca-side); only the Nexus analytical layer.

## How

- **`backend/nexus_config_identity.py`** (new): single source of truth for `live_config_hash` (snapshot identity) and `history_scope_id` (cleanup identity). **Boot now calls these same functions** — the parity guarantee.
- **`backend/nexus_restamp.py`** (new): `preview_change` (read-only) + `restamp_instance` — updates the `NexusStrategyCache` row (base id) `config_hash` and the `GraphNexusLearningCache` `cleanup_done` marker(s) (scoped id) `history_scope_id` to the new identities. Idempotent.
- **API**: `POST /strategies/{id}/config-change-preview`; `preserve_history` flag on `PUT /strategies/{id}` (best-effort — a re-stamp failure never fails the save, it's reported as `restamp_error`).
- **Web**: preview-gated three-button modal in `InstanceDetailView.vue`.
- **Mobile**: repository plumbing (`previewConfigChange` + `update(preserveHistory:)`) + tests. Mobile strategy config is currently read-only, so the dialog attaches when a mobile editor exists (documented in the spec).

## Key correctness points (real-money)

- **Hash parity**: re-stamp and boot import the same identity module; a parity guard test fails loudly on drift.
- **base vs scoped keying**: snapshot keyed by base id, cleanup marker by scoped id — never mixed; prefix-collision guarded.
- **Loader-consumable rows**: re-stamps both `live` and `backtest` origin rows (boot's `load_with_fallback` ignores origin) and preserves each row's PK origin segment.
- **No silent divergence**: resolver failure propagates rather than hashing an unresolved config boot wouldn't reproduce.

## Adversarial bug sweep

3 parallel reviewers (data-integrity, boot-regression, API/UI). Boot refactor confirmed behavior-preserving. 3 real issues found & fixed in this branch: resolver fail-open, backtest-origin rows skipped + `|live|` PK hardcode, and a misleading success toast.

## Testing

- Backend: 20 new tests (identity sensitivity, restamp base/scoped keying, backtest-origin preservation, idempotency, preview semantics, parity guard, action wiring) — all pass; `test_strategy_cache_persistence` unaffected (27 pass).
- Web `npm run build` green; mobile `flutter analyze` clean + 3 repo tests pass.

## Known gaps (documented in spec)

- Editing the **Models-table row** directly (`PUT /models`) also changes identities but bypasses this popup — follow-up; the same `nexus_restamp` functions can back it.
- Mobile has no model-selection editor yet (data layer only).

Spec: `docs/superpowers/specs/2026-06-29-nexus-model-switch-preserve-history-design.md`
Plan: `docs/superpowers/plans/2026-06-29-nexus-model-switch-preserve-history.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)