### PR TITLE
fix(nexus): recognize openrouter provider (was silently routed to gemini)

### DIFF
--- a/backend/strategies/graph_nexus_analysis.py
+++ b/backend/strategies/graph_nexus_analysis.py
@@ -626,6 +626,7 @@ _NEXUS_MACRO_PROMPT_BUDGET_CHARS = 8000
 _NEXUS_VALID_PROVIDERS = {
     "gemini", "deepseek", "openai", "azure", "nvidia",
     "claude-cli", "codex-cli", "anthropic", "ollama", "bedrock",
+    "openrouter",
 }
 # Module-level dedup cache for `LLM key source for role=...` diagnostic
 # log. Each (role, source_tag, masked_key) tuple is logged at most once
@@ -769,6 +770,9 @@ def _default_model_for_provider(provider: str) -> str:
             os.environ.get("GRAPH_NEXUS_BEDROCK_MODEL")
             or "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
         ).strip() or "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    if provider == "openrouter":
+        # No single canonical default; OpenRouter ids are "vendor/name".
+        return os.environ.get("GRAPH_NEXUS_OPENROUTER_MODEL", "").strip()
     return "gemini-3-flash-preview"
 
 
@@ -798,6 +802,8 @@ def _default_api_key_for_provider(provider: str) -> str:
         return "codex-cli-no-api-key"
     if provider == "bedrock":
         return os.environ.get("BEDROCK_API_KEY", "").strip()
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_API_KEY", "").strip()
     return os.environ.get("GEMINI_API_KEY", "").strip()
 
 
@@ -876,6 +882,37 @@ def _resolve_role_llm_provider_config_fields(config: dict, role: str) -> dict[st
             or "https://integrate.api.nvidia.com/v1"
         )
         out: dict[str, Any] = {"base_url": base_url}
+        if reasoning_effort:
+            out["reasoning_effort"] = reasoning_effort
+        return out
+    if provider == "openrouter":
+        # Forward the openrouter_* fields the model_resolver injects so the
+        # dispatcher's _resolve_provider_config receives them. base_url has a
+        # sane default in llm_utils (https://openrouter.ai/api/v1); referer/title
+        # are optional OpenRouter attribution headers.
+        out: dict[str, Any] = {}
+        base_url = (
+            _lb_cfg("openrouter_base_url")
+            or (config.get(f"{prefix}openrouter_base_url") or "").strip()
+            or (config.get("openrouter_base_url") or "").strip()
+            or os.environ.get("OPENROUTER_BASE_URL", "").strip()
+        )
+        if base_url:
+            out["openrouter_base_url"] = base_url
+        referer = (
+            _lb_cfg("openrouter_referer")
+            or (config.get(f"{prefix}openrouter_referer") or "").strip()
+            or (config.get("openrouter_referer") or "").strip()
+        )
+        if referer:
+            out["openrouter_referer"] = referer
+        title = (
+            _lb_cfg("openrouter_title")
+            or (config.get(f"{prefix}openrouter_title") or "").strip()
+            or (config.get("openrouter_title") or "").strip()
+        )
+        if title:
+            out["openrouter_title"] = title
         if reasoning_effort:
             out["reasoning_effort"] = reasoning_effort
         return out

--- a/backend/tests/test_graph_nexus_openrouter_provider.py
+++ b/backend/tests/test_graph_nexus_openrouter_provider.py
@@ -1,0 +1,45 @@
+"""Regression: graph_nexus must recognize the openrouter provider.
+
+Before the fix, `_normalize_llm_provider("openrouter")` returned "gemini"
+(openrouter missing from _NEXUS_VALID_PROVIDERS), so an OpenRouter model
+(e.g. nvidia/nemotron-3-ultra) was silently routed to gemini -> 401/404.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from strategies import graph_nexus_analysis as gna
+
+
+def test_openrouter_is_a_valid_provider():
+    assert "openrouter" in gna._NEXUS_VALID_PROVIDERS
+
+
+def test_normalize_keeps_openrouter():
+    assert gna._normalize_llm_provider("openrouter") == "openrouter"
+    assert gna._normalize_llm_provider("OpenRouter") == "openrouter"
+    # unknown providers still fall back to gemini (unchanged behavior)
+    assert gna._normalize_llm_provider("totally-unknown") == "gemini"
+
+
+def test_role_config_forwards_openrouter_fields():
+    cfg = {
+        "llm_provider": "openrouter",
+        "llm_model": "nvidia/nemotron-3-ultra-550b-a55b",
+        "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://intellistock.app",
+        "openrouter_title": "IntelliStock",
+    }
+    out = gna._resolve_role_llm_provider_config_fields(cfg, "")
+    assert out["openrouter_base_url"] == "https://openrouter.ai/api/v1"
+    assert out["openrouter_referer"] == "https://intellistock.app"
+    assert out["openrouter_title"] == "IntelliStock"
+
+
+def test_role_config_openrouter_defaults_empty_when_unset():
+    # base_url has a default downstream in llm_utils; we forward nothing extra.
+    cfg = {"llm_provider": "openrouter", "llm_model": "nvidia/nemotron-3-ultra-550b-a55b"}
+    out = gna._resolve_role_llm_provider_config_fields(cfg, "")
+    assert "openrouter_referer" not in out
+    assert "openrouter_title" not in out


### PR DESCRIPTION
## Problem (live, real-money)

After switching `alpaca-main` to nvidia/nemotron-3-ultra via OpenRouter, the boot log showed:

```
LLM provider/model mismatch hint for role=default: provider=gemini model='nvidia/nemotron-3-ultra-550b-a55b'
```

The strategy config is correct (`llm_provider='openrouter'` everywhere). The bug is in graph_nexus: `_normalize_llm_provider` maps any provider **not** in `_NEXUS_VALID_PROVIDERS` to `"gemini"`. `openrouter` (added in PRs #59–61 to `llm_utils` and the chatbot dock — the "3 separate LLM paths" gotcha) was never added to the **graph_nexus** allow-list. So nemotron-via-OpenRouter resolved to `provider=gemini` with an `sk-or` key → guaranteed 401/404 at the next full cycle (market open).

`llm_utils.call_llm_by_provider` (the actual call path graph_nexus uses) already fully supports openrouter — only the allow-list gate was blocking it.

## Fix

- Add `openrouter` to `_NEXUS_VALID_PROVIDERS`.
- Forward `openrouter_base_url`/`referer`/`title` (+ reasoning) in `_resolve_role_llm_provider_config_fields`, mirroring the nvidia branch.
- Defensive openrouter defaults in `_default_model_for_provider` / `_default_api_key_for_provider`.

## Verification

Resolved the **live doc-179 config** through the fixed code: `default`/`sentiment`/`event_maintenance`/`overlay` roles now resolve `provider=openrouter` (was gemini); `company_article`=bedrock and `macro_article`=codex-cli correctly unchanged; mismatch warning gone. New regression test `test_graph_nexus_openrouter_provider.py` (4 tests) + existing `test_openrouter_provider.py` pass (18 total).

## Deploy

Needs a backend redeploy + `alpaca-main` Stop→Start before the next full cycle (~06:30 PT). No config change required.

## Follow-up (not in this PR)

`earnings.py`, `ml_news.py`, `engines/ai_backtest_engine.py` each have their own `_normalize_llm_provider` with the same allow-list pattern — should be audited for the openrouter gap if those strategies are used with OpenRouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)