### PR TITLE
fix(strategies): recognize openrouter in earnings/ml_news/ai_backtest

### DIFF
--- a/backend/engines/ai_backtest_engine.py
+++ b/backend/engines/ai_backtest_engine.py
@@ -376,7 +376,7 @@ def _env(key: str, default: str = "") -> str:
 
 def _normalize_llm_provider(provider: str) -> str:
     name = (provider or "gemini").strip().lower()
-    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "anthropic") else "gemini"
+    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "anthropic", "openrouter") else "gemini"
 
 
 def _default_model_for_provider(provider: str) -> str:
@@ -391,6 +391,8 @@ def _default_model_for_provider(provider: str) -> str:
         return "nvidia/nemotron-3-super-120b-a12b"
     if provider in ("claude-cli", "anthropic"):
         return "claude-sonnet-4-6"
+    if provider == "openrouter":
+        return _env("AI_BACKTESTING_AGENT_OPENROUTER_MODEL") or _env("OPENROUTER_MODEL")
     return "gemini-3-flash-preview"
 
 
@@ -410,6 +412,8 @@ def _default_api_key_for_provider(provider: str) -> str:
         # Sentinel so ``if not api_key`` short-circuits don't skip the
         # whole pipeline — claude-cli authenticates via the local binary.
         return "claude-cli-no-api-key"
+    if provider == "openrouter":
+        return _env("OPENROUTER_API_KEY")
     return _env("GEMINI_API_KEY")
 
 
@@ -445,6 +449,13 @@ def _provider_config_from_env(prefix: str, provider: str) -> dict[str, str]:
             or "https://integrate.api.nvidia.com/v1"
         )
         return {"base_url": base_url.strip()}
+    if provider == "openrouter":
+        # base_url has a sane default in llm_utils; forward an env override if set.
+        base_url = (
+            _env(f"{prefix}_OPENROUTER_BASE_URL")
+            or _env("OPENROUTER_BASE_URL")
+        )
+        return {"openrouter_base_url": base_url.strip()} if base_url.strip() else {}
     return {}
 
 

--- a/backend/strategies/earnings.py
+++ b/backend/strategies/earnings.py
@@ -317,7 +317,7 @@ def _to_bool(value, default: bool = False) -> bool:
 
 def _normalize_llm_provider(provider: str) -> str:
     name = (provider or "gemini").strip().lower()
-    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "codex-cli", "anthropic") else "gemini"
+    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "codex-cli", "anthropic", "openrouter") else "gemini"
 
 
 def _default_model_for_provider(provider: str) -> str:
@@ -336,11 +336,15 @@ def _default_model_for_provider(provider: str) -> str:
         return "claude-sonnet-4-6"
     if provider == "codex-cli":
         return "gpt-5-codex"
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_MODEL", "").strip()
     return "gemini-2.0-flash-exp"
 
 
 def _default_api_key_for_provider(provider: str) -> str:
     provider = _normalize_llm_provider(provider)
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_API_KEY", "").strip()
     if provider == "deepseek":
         return os.environ.get("DEEPSEEK_API_KEY", "").strip()
     if provider == "openai":
@@ -401,6 +405,23 @@ def _resolve_provider_config(config: dict, provider: str) -> dict:
         out = {"cli_path": cli_path}
         if extra_args:
             out["extra_args"] = extra_args
+        reasoning = (config.get("llm_reasoning_effort") or "").strip()
+        if reasoning:
+            out["reasoning_effort"] = reasoning
+        return out
+    if provider == "openrouter":
+        # base_url has a sane default in llm_utils; forward overrides +
+        # optional attribution headers when present.
+        out: dict = {}
+        base_url = (config.get("openrouter_base_url") or "").strip() or os.environ.get("OPENROUTER_BASE_URL", "").strip()
+        if base_url:
+            out["openrouter_base_url"] = base_url
+        referer = (config.get("openrouter_referer") or "").strip()
+        if referer:
+            out["openrouter_referer"] = referer
+        title = (config.get("openrouter_title") or "").strip()
+        if title:
+            out["openrouter_title"] = title
         reasoning = (config.get("llm_reasoning_effort") or "").strip()
         if reasoning:
             out["reasoning_effort"] = reasoning

--- a/backend/strategies/ml_news.py
+++ b/backend/strategies/ml_news.py
@@ -205,7 +205,7 @@ def _time_increment_to_seconds(ti) -> int | None:
 
 def _normalize_llm_provider(provider: str) -> str:
     name = (provider or "gemini").strip().lower()
-    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "codex-cli", "anthropic") else "gemini"
+    return name if name in ("gemini", "deepseek", "openai", "azure", "nvidia", "claude-cli", "codex-cli", "anthropic", "openrouter") else "gemini"
 
 
 def _default_model_for_provider(provider: str) -> str:
@@ -224,11 +224,15 @@ def _default_model_for_provider(provider: str) -> str:
         return "claude-sonnet-4-6"
     if provider == "codex-cli":
         return "gpt-5-codex"
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_MODEL", "").strip()
     return "gemini-2.0-flash-exp"
 
 
 def _default_api_key_for_provider(provider: str) -> str:
     provider = _normalize_llm_provider(provider)
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_API_KEY", "").strip()
     if provider == "deepseek":
         return os.environ.get("DEEPSEEK_API_KEY", "").strip()
     if provider == "openai":
@@ -282,6 +286,23 @@ def _resolve_provider_config(config: dict, provider: str) -> dict:
         out = {"cli_path": cli_path}
         if extra_args:
             out["extra_args"] = extra_args
+        reasoning = (config.get("llm_reasoning_effort") or "").strip()
+        if reasoning:
+            out["reasoning_effort"] = reasoning
+        return out
+    if provider == "openrouter":
+        # base_url has a sane default in llm_utils; forward overrides + optional
+        # OpenRouter attribution headers when present.
+        out = {}
+        base_url = (config.get("openrouter_base_url") or "").strip() or os.environ.get("OPENROUTER_BASE_URL", "").strip()
+        if base_url:
+            out["openrouter_base_url"] = base_url
+        referer = (config.get("openrouter_referer") or "").strip()
+        if referer:
+            out["openrouter_referer"] = referer
+        title = (config.get("openrouter_title") or "").strip()
+        if title:
+            out["openrouter_title"] = title
         reasoning = (config.get("llm_reasoning_effort") or "").strip()
         if reasoning:
             out["reasoning_effort"] = reasoning

--- a/backend/tests/test_openrouter_other_strategies.py
+++ b/backend/tests/test_openrouter_other_strategies.py
@@ -1,0 +1,51 @@
+"""Regression: earnings, ml_news, and the AI backtest engine must recognize the
+openrouter provider (same allow-list gap that bit graph_nexus — see PR #63).
+
+Before the fix, each module's own `_normalize_llm_provider` mapped openrouter ->
+"gemini", silently routing OpenRouter models to the wrong endpoint (401/404).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from strategies import earnings
+from strategies import ml_news
+from engines import ai_backtest_engine
+
+
+def test_normalize_keeps_openrouter_in_all_three():
+    for mod in (earnings, ml_news, ai_backtest_engine):
+        assert mod._normalize_llm_provider("openrouter") == "openrouter", mod.__name__
+        # unknown still falls back to gemini (unchanged behavior)
+        assert mod._normalize_llm_provider("nope") == "gemini", mod.__name__
+
+
+def test_defaults_do_not_fall_back_to_gemini_for_openrouter():
+    # api-key default should read OPENROUTER_API_KEY, not GEMINI_API_KEY
+    for mod in (earnings, ml_news, ai_backtest_engine):
+        assert mod._default_api_key_for_provider.__module__  # exists
+    # model default returns an openrouter-shaped value (empty/env), never a gemini id
+    assert "gemini" not in earnings._default_model_for_provider("openrouter").lower()
+    assert "gemini" not in ml_news._default_model_for_provider("openrouter").lower()
+    assert "gemini" not in ai_backtest_engine._default_model_for_provider("openrouter").lower()
+
+
+def test_config_strategies_forward_openrouter_fields():
+    cfg = {
+        "llm_provider": "openrouter",
+        "openrouter_base_url": "https://openrouter.ai/api/v1",
+        "openrouter_referer": "https://intellistock.app",
+        "openrouter_title": "IntelliStock",
+    }
+    for mod in (earnings, ml_news):
+        out = mod._resolve_provider_config(cfg, "openrouter")
+        assert out["openrouter_base_url"] == "https://openrouter.ai/api/v1", mod.__name__
+        assert out["openrouter_referer"] == "https://intellistock.app", mod.__name__
+        assert out["openrouter_title"] == "IntelliStock", mod.__name__
+
+
+def test_ai_backtest_env_config_forwards_base_url(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+    out = ai_backtest_engine._provider_config_from_env("AI_BACKTESTING_AGENT", "openrouter")
+    assert out["openrouter_base_url"] == "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Problem

Follow-up to PR #63. The OpenRouter allow-list gap that silently routed `provider=openrouter` → `gemini` (→ 401/404) wasn't unique to graph_nexus — **`earnings.py`, `ml_news.py`, and `engines/ai_backtest_engine.py` each carry their own copy of `_normalize_llm_provider`** with the same `… else "gemini"` fallback and no `openrouter` in the tuple. Any of these run with an OpenRouter model would misroute.

All three already call through `llm_utils` (`call_llm_with_prompt_cache` / `call_structured_llm_by_provider`), which fully supports openrouter — only the allow-list gate was blocking it.

## Fix (per module)

- Add `openrouter` to `_normalize_llm_provider`.
- Forward `openrouter_base_url`/`referer`/`title` in the provider-config builder (`_resolve_provider_config` for earnings/ml_news; env-driven `_provider_config_from_env` for ai_backtest).
- Defensive openrouter defaults in `_default_model_for_provider` / `_default_api_key_for_provider` so an empty model/key never falls back to a gemini default.

## Testing

`test_openrouter_other_strategies.py` (4 tests): normalize keeps openrouter in all three; defaults don't fall back to gemini; provider-config builders forward the openrouter fields. All pass; `py_compile` clean.

## Not live-urgent

`alpaca-main` runs graph_nexus only (already fixed in #63). This is defensive parity for the other strategies/backtest engine.

## Known remaining gap (out of scope)

These same tuples still omit `ollama`/`bedrock` (and `codex-cli` for `ai_backtest_engine`) — a broader provider-parity inconsistency vs graph_nexus's fuller list. Flagged for a follow-up; would need each provider's config-builder branch too, not just the allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)