### PR TITLE
feat(kalshi): historical backtest (web + mobile)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -656,6 +656,17 @@ class CreateBacktestBody(BaseModel):
     initial_cash: Optional[float] = 100000.0
 
 
+class KalshiBacktestBody(BaseModel):
+    name: str = ""
+    instance_id: Optional[str] = None
+    leagues: List[str] = Field(default_factory=list)
+    start_date: str = Field(..., min_length=1)
+    end_date: str = Field(..., min_length=1)
+    bankroll_cents: int = 0
+    bankroll_dollars: Optional[float] = None
+    config: dict = Field(default_factory=dict)
+
+
 class AgentControlBody(BaseModel):
     running: Optional[bool] = None
     paused: Optional[bool] = None
@@ -4303,6 +4314,117 @@ def api_kalshi_update_instance(instance_id: str, body: UpdateKalshiInstanceBody,
         {"name": body.name.strip(), "kalshi_config": config}
     ).run(conn)
     return {"ok": True, "id": instance_id, "name": body.name.strip(), "config": config}
+
+
+# --- Kalshi backtests -----------------------------------------------------
+
+@app.post("/brokerages/{brokerage_id}/kalshi/backtests", response_class=JSONResponse)
+def api_kalshi_create_backtest(brokerage_id: str, body: KalshiBacktestBody, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    """Enqueue a Kalshi soccer backtest over the chosen leagues/date range with
+    the given tuning config. A background worker picks up the pending row."""
+    _kalshi_brokerage_row(conn, brokerage_id)
+    import uuid as _uuid, datetime as _dt
+    from kalshi import db as kdb
+    try:
+        kdb.ensure_tables(conn)
+    except Exception:
+        pass
+    # Merge the tuning knobs with leagues/date-range/bankroll into one config the
+    # replay reads via kalshi.backtest.config_from_body.
+    cfg = dict(body.config or {})
+    cfg["leagues"] = list(body.leagues or [])
+    cfg["start_date"] = body.start_date
+    cfg["end_date"] = body.end_date
+    if body.bankroll_cents:
+        cfg["bankroll_cents"] = int(body.bankroll_cents)
+    if body.bankroll_dollars is not None:
+        cfg["bankroll_dollars"] = float(body.bankroll_dollars)
+    # Inherit odds keys (sharp line) from the linked instance's config if given.
+    if body.instance_id:
+        try:
+            inst = _kalshi_instance_row(conn, body.instance_id)
+            icfg = inst.get("kalshi_config") or {}
+            for k in ("oddspapi_api_key", "odds_api_key"):
+                if not cfg.get(k) and icfg.get(k):
+                    cfg[k] = icfg.get(k)
+        except Exception:
+            pass
+    jid = str(_uuid.uuid4())
+    doc = kdb.backtest_job_doc(
+        id=jid, brokerage_id=brokerage_id, instance_id=body.instance_id,
+        name=(body.name or "").strip(), config=cfg, leagues=list(body.leagues or []),
+        start_date=body.start_date, end_date=body.end_date,
+        bankroll_cents=int(cfg.get("bankroll_cents", 0) or 0),
+        created_at=_dt.datetime.utcnow().isoformat() + "Z",
+    )
+    kdb.create_backtest_job(conn, doc)
+    return {"ok": True, "id": jid}
+
+
+@app.get("/brokerages/{brokerage_id}/kalshi/backtests", response_class=JSONResponse)
+def api_kalshi_list_backtests(brokerage_id: str, limit: int = 100, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    _kalshi_brokerage_row(conn, brokerage_id)
+    from kalshi import db as kdb
+    return {"backtests": kdb.list_backtests(conn, brokerage_id, limit=max(1, min(int(limit or 100), 500)))}
+
+
+@app.get("/kalshi/backtests/{backtest_id}/status", response_class=JSONResponse)
+def api_kalshi_backtest_status(backtest_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    from kalshi import db as kdb
+    row = kdb.get_backtest(conn, backtest_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="backtest not found")
+    return {
+        "id": backtest_id, "name": row.get("name"), "status": row.get("status"),
+        "progress": row.get("progress"), "summary": row.get("summary") or {},
+        "error": row.get("error"), "leagues": row.get("leagues"),
+        "start_date": row.get("start_date"), "end_date": row.get("end_date"),
+        "created_at": row.get("created_at"),
+    }
+
+
+@app.get("/kalshi/backtests/{backtest_id}/results", response_class=JSONResponse)
+def api_kalshi_backtest_results(backtest_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    from kalshi import db as kdb
+    row = kdb.get_backtest(conn, backtest_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="backtest not found")
+    return {"status": row.get("status"), "summary": row.get("summary") or {},
+            "result": kdb.get_backtest_result(conn, backtest_id)}
+
+
+@app.post("/kalshi/backtests/{backtest_id}/stop", response_class=JSONResponse)
+def api_kalshi_backtest_stop(backtest_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    from kalshi import db as kdb
+    if not kdb.get_backtest(conn, backtest_id):
+        raise HTTPException(status_code=404, detail="backtest not found")
+    kdb.set_backtest_run(conn, backtest_id, False)
+    return {"ok": True, "id": backtest_id}
+
+
+@app.delete("/kalshi/backtests/{backtest_id}", response_class=JSONResponse)
+def api_kalshi_backtest_delete(backtest_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    from kalshi import db as kdb
+    kdb.delete_backtest(conn, backtest_id)
+    return {"ok": True, "id": backtest_id}
+
+
+@app.on_event("startup")
+def _startup_kalshi_backtest_worker():
+    """Start the in-process Kalshi backtest worker (drains pending rows + watches
+    the changefeed). Never blocks API startup."""
+    import logging as _logging
+    _wlog = _logging.getLogger("uvicorn.error")
+    try:
+        from kalshi.backtest_worker import start_worker
+        from interactive_utils import r as _r_iu, RETHINKDB_HOST as _H, RETHINKDB_PORT as _P
+
+        def _cf():
+            return _r_iu.connect(host=_H, port=_P, timeout=10)
+
+        start_worker(_cf)
+    except Exception:
+        _wlog.exception("kalshi backtest worker failed to start")
 
 
 def _kalshi_instance_row(conn, instance_id: str) -> dict:

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -19,9 +19,12 @@ documented divergence from the live path for this per-fixture primitive.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, field
 
 from kalshi import instance_config
+from kalshi.client import yes_ask_close_at
+from kalshi.devig import power_devig, shin_devig, proportional_devig
 from kalshi.fees import DEFAULT_FEE_RATE
 from kalshi.intelligence.fusion import fuse, renormalize_group
 from kalshi.strategy.candidates import generate_candidates
@@ -29,7 +32,10 @@ from kalshi.capital.planner import allocate
 from kalshi.reconcile import reconcile_position
 from kalshi.risk import RiskCaps
 
+log = logging.getLogger(__name__)
+
 _DEVIG_METHODS = ("power", "shin", "proportional")
+_DEVIG_FUNCS = {"power": power_devig, "shin": shin_devig, "proportional": proportional_devig}
 
 
 # --------------------------------------------------------------------------
@@ -256,6 +262,10 @@ class BacktestResult:
     per_league: dict
     calibration: list
     trades: list
+    # Populated by run_backtest() with data-layer telemetry (api_calls/cache_hits
+    # from the BacktestDataProvider that fed it); aggregate() itself has no data
+    # provider to report on, so this defaults empty for direct aggregate() callers.
+    summary: dict = field(default_factory=dict)
 
 
 def settle(bet: SizedBet, result: str, fee_rate: float = DEFAULT_FEE_RATE) -> Trade:
@@ -362,3 +372,104 @@ def aggregate(trades: list[Trade], bankroll_cents: int) -> BacktestResult:
         calibration=calibration,
         trades=list(trades),
     )
+
+
+# --------------------------------------------------------------------------
+# Task 8: run_backtest() — orchestration over cached historical data
+# --------------------------------------------------------------------------
+
+
+def _sharp_probs_at(oddseries: list[dict], snap_ts: int, devig_method: str) -> dict:
+    """Devigged {home,draw,away} from the odds snapshot at/just-before
+    `snap_ts` (the latest snapshot with ts <= snap_ts; the earliest snapshot if
+    all of them are AFTER snap_ts — better than nothing pre-match; {} if there
+    are no snapshots at all). Same devig methods `evaluate`'s caller already
+    uses via `fair_value.fair_from_odds` (power/shin/proportional), applied
+    directly here since `fair_value.fair_from_odds` wants an `OddsQuote`, not a
+    raw historical-odds dict."""
+    if not oddseries:
+        return {}
+    before = [s for s in oddseries if int(s.get("ts", 0)) <= snap_ts]
+    snap = max(before, key=lambda s: int(s.get("ts", 0))) if before else min(
+        oddseries, key=lambda s: int(s.get("ts", 0)))
+    fn = _DEVIG_FUNCS.get(devig_method, power_devig)
+    raw = [1.0 / snap["home"], 1.0 / snap["draw"], 1.0 / snap["away"]]
+    p = fn(raw)
+    return {"home": p[0], "draw": p[1], "away": p[2]}
+
+
+def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None) -> BacktestResult:
+    """Replay `data`'s fixture history through `evaluate`/`settle`/`aggregate`,
+    in kickoff order, one decision snapshot per fixture.
+
+    For each fixture: `data.final_score(fx)` gates it in (None -> SKIP,
+    reason "unsettled"); `data.kalshi_tickers(fx)` resolves the Kalshi side
+    tickers (empty -> SKIP, reason "unmatched"). For each offset in
+    `cfg.decision_offsets_sec` (in order), `snap_ts = kickoff_ts + offset`;
+    `client.yes_ask_close_at` reads each side's Kalshi ask at-or-before
+    `snap_ts` from that side's candles, and `_sharp_probs_at` devigs the sharp
+    odds snapshot at-or-before `snap_ts`. The FIRST offset that produces at
+    least one Kalshi ask is used (one snapshot per fixture) — if none do,
+    SKIP with reason "no_candle_data". `model_fn(fx)` supplies model probs
+    (injected so tests don't need a live Elo table; `build_model_fn` wires the
+    production closure). `evaluate()` is called with the resolved tickers
+    threaded through `fixture["market_tickers"]` so it prices the REAL Kalshi
+    tickers instead of synthesizing placeholders; each returned `SizedBet` is
+    `settle()`d against the fixture result. `progress_cb(frac)` (if given) is
+    called once per fixture, reaching 1.0 on the last one (a no-op, frac=1.0,
+    single call when there are zero fixtures). Returns `aggregate()`'s result
+    with `data.api_calls`/`data.cache_hits` surfaced into `result.summary`.
+    """
+    fixtures = list(data.fixtures(cfg.leagues, cfg.start_date, cfg.end_date))
+    fixtures.sort(key=lambda fx: fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)
+
+    trades: list[Trade] = []
+    n = len(fixtures)
+    for i, fx in enumerate(fixtures):
+        fixture_id = fx.get("fixture_id", "")
+        result = data.final_score(fx)
+        if result is None:
+            log.info("run_backtest: skipping fixture_id=%s reason=unsettled", fixture_id)
+        else:
+            tickers = data.kalshi_tickers(fx)
+            if not tickers:
+                log.info("run_backtest: skipping fixture_id=%s reason=unmatched", fixture_id)
+            else:
+                kickoff_ts = int(fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)
+                candles_by_side = {side: data.candles(ticker) for side, ticker in tickers.items()}
+                oddseries = data.sharp_odds(fx)
+
+                kalshi_asks: dict = {}
+                sharp_probs: dict = {}
+                for offset in cfg.decision_offsets_sec:
+                    snap_ts = kickoff_ts + int(offset)
+                    asks = {}
+                    for side, candles in candles_by_side.items():
+                        ask = yes_ask_close_at(candles, snap_ts)
+                        if ask is not None:
+                            asks[side] = ask
+                    if asks:
+                        kalshi_asks = asks
+                        sharp_probs = _sharp_probs_at(oddseries, snap_ts, cfg.devig_method)
+                        break
+
+                if not kalshi_asks:
+                    log.info("run_backtest: skipping fixture_id=%s reason=no_candle_data", fixture_id)
+                else:
+                    model_probs = model_fn(fx) or {}
+                    fx_for_eval = dict(fx)
+                    fx_for_eval["market_tickers"] = tickers
+                    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fx_for_eval)
+                    for bet in bets:
+                        trades.append(settle(bet, result, cfg.fee_rate))
+
+        if progress_cb is not None:
+            progress_cb((i + 1) / n if n else 1.0)
+
+    out = aggregate(trades, cfg.bankroll_cents)
+    out.summary = {
+        "api_calls": getattr(data, "api_calls", 0),
+        "cache_hits": getattr(data, "cache_hits", 0),
+    }
+    return out
+

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -24,9 +24,13 @@ from dataclasses import dataclass, field
 
 from kalshi import instance_config
 from kalshi.client import yes_ask_close_at
+from kalshi.data.sources.clubelo import elo_for
 from kalshi.devig import power_devig, shin_devig, proportional_devig
 from kalshi.fees import DEFAULT_FEE_RATE
 from kalshi.intelligence.fusion import fuse, renormalize_group
+from kalshi.intelligence.pricing import model_market_probs
+from kalshi.quant.elo import elo_to_expected_goals
+from kalshi.quant.national_elo import is_national_team, national_elo_from
 from kalshi.strategy.candidates import generate_candidates
 from kalshi.capital.planner import allocate
 from kalshi.reconcile import reconcile_position
@@ -473,3 +477,50 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None) -> Backt
     }
     return out
 
+
+# --------------------------------------------------------------------------
+# Task 9: build_model_fn() — production model_fn via the live pricing chain
+# --------------------------------------------------------------------------
+
+
+def build_model_fn(nat_elo_table: dict | None, elo_table: dict | None):
+    """Production `model_fn(fx) -> {home, draw, away}` for `run_backtest`,
+    reusing the SAME pricing chain the live engine (`engine.py`'s tick loop)
+    uses: `quant.elo.elo_to_expected_goals` -> `intelligence.pricing
+    .model_market_probs`'s `winner` group (itself `quant.dixon_coles
+    .scoreline_matrix` + `quant.derive_markets.one_x_two`).
+
+    Per-team Elo lookup mirrors `engine.py`'s `_team_elo` closure: a team
+    recognized as a national side (`quant.national_elo.is_national_team`) is
+    priced off `nat_elo_table` (`national_elo_from` — falls back to the
+    built-in static table, then `DEFAULT_NATIONAL_ELO`, when the team is
+    unlisted); anything else is priced off the club `elo_table`
+    (`data.sources.clubelo.elo_for` — falls back to its own 1500.0 default).
+
+    CAVEAT — look-ahead: `nat_elo_table`/`elo_table` are single point-in-time
+    snapshots the caller injects (e.g. today's live ClubElo/eloratings.net
+    fetch), not a historical Elo as of each fixture's kickoff. A backtest run
+    over past fixtures is therefore priced with CURRENT team strength, not the
+    strength at the time of that match — this makes `build_model_fn`'s model
+    signal indicative-only (a rough form check proxy) until per-date historical
+    Elo snapshots are wired into the data layer; the sharp (Pinnacle) line
+    devigged in `run_backtest` remains the properly-dated pre-match probability
+    when it is present.
+    """
+    nat_elo_table = nat_elo_table or {}
+    elo_table = elo_table or {}
+
+    def _team_elo(name: str) -> float:
+        if is_national_team(name):
+            return national_elo_from(nat_elo_table, name)
+        return elo_for(elo_table, name)
+
+    def model_fn(fx: dict) -> dict:
+        home = fx.get("home", "")
+        away = fx.get("away", "")
+        home_elo, away_elo = _team_elo(home), _team_elo(away)
+        expected_goals = elo_to_expected_goals(home_elo, away_elo)
+        probs = model_market_probs(expected_goals)
+        return probs.get("winner", {})
+
+    return model_fn

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -3,7 +3,7 @@
 `run_backtest` (built separately) loops historical fixtures and calls the
 primitives in this module: `evaluate()` turns one fixture's model/sharp probs
 and Kalshi asks into sized bets using the SAME pricing/candidate/sizing code
-path the live bot uses (`intelligence.pricing.build_market_probs` ->
+path the live bot uses (`intelligence.fusion.fuse`/`renormalize_group` ->
 `strategy.candidates.generate_candidates` -> `capital.planner.allocate`);
 `settle()`/`aggregate()` grade those bets against the final result and roll
 them up into a `BacktestResult`.
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 
 from kalshi import instance_config
 from kalshi.fees import DEFAULT_FEE_RATE, fee_as_prob, fee_cents_for_order
-from kalshi.intelligence.pricing import build_market_probs
+from kalshi.intelligence.fusion import fuse, renormalize_group
 from kalshi.strategy.candidates import generate_candidates
 from kalshi.capital.planner import allocate
 from kalshi.risk import RiskCaps
@@ -120,38 +120,36 @@ def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
     engine targets); `kalshi_asks` is `{side: cents}`.
 
     This mirrors `orchestrator.plan_and_allocate`'s single-fixture call
-    sequence (build_market_probs -> generate_candidates -> allocate) with the
+    sequence (fuse per side -> generate_candidates -> allocate) with the
     live/in-play parts (LLM adjustments, player props, opportunity scoring
     across multiple fixtures) omitted — a backtest fixture has no LLM
-    rationale and is evaluated one match at a time."""
+    rationale and is evaluated one match at a time.
+
+    ADAPTATION from the brief: the brief named `intelligence.fusion.build_market_probs`
+    as the fuser, but that function actually lives in `intelligence.pricing`
+    and derives its OWN model probs from `expected_goals` (a Dixon-Coles
+    scoreline matrix) — it has no way to accept an externally-computed
+    `model_probs` dict, which is exactly what `evaluate()`'s signature takes.
+    Reusing it here would silently ignore the caller's `model_probs` whenever
+    `expected_goals` is absent from the fixture. Instead this fuses each side
+    directly with `intelligence.fusion.fuse` (the same per-side blend
+    `pricing.build_market_probs` calls internally) and renormalizes the
+    winner group with `fusion.renormalize_group` — the same two primitives,
+    without the Dixon-Coles detour."""
     fixture_id = fixture.get("fixture_id", "")
     tier = fixture.get("tier") or _TIER_FOR_MARKET_TYPES
-    league = fixture.get("league", "")
 
-    expected_goals = fixture.get("expected_goals")
     sharp_probs = sharp_probs or {}
     model_probs = model_probs or {}
     kalshi_asks = kalshi_asks or {}
 
-    # build_market_probs expects {market_type: {side: prob}}; evaluate()'s
-    # model_probs/sharp_probs are already scoped to one market ({side: prob}),
-    # so wrap them under "winner" before fusing.
+    base = {}
+    for side in set(model_probs) | set(sharp_probs):
+        sharp_v = sharp_probs.get(side)
+        model_v = model_probs.get(side, sharp_v if sharp_v is not None else 0.0)
+        base[side] = fuse(sharp=sharp_v, model=model_v, llm_adjustment=0.0, w_sharp=cfg.sharp_weight, llm_cap=0.05)
+    fused = {"winner": renormalize_group(base) if base else {}}
     sharp_by_type = {"winner": dict(sharp_probs)} if sharp_probs else {}
-    fused = build_market_probs(expected_goals, sharp_by_type, {}, w_sharp=cfg.sharp_weight)
-    # If there's no expected_goals model signal, fall back to the caller-supplied
-    # model_probs directly (fused would otherwise degrade to sharp-only).
-    if "winner" not in fused or not fused.get("winner"):
-        fused = dict(fused)
-        base = {}
-        for side in set(model_probs) | set(sharp_probs):
-            base[side] = dict(sharp_by_type.get("winner", {})).get(side) if side in sharp_probs else None
-        fused["winner"] = {
-            side: (
-                (cfg.sharp_weight * sharp_probs[side] + (1 - cfg.sharp_weight) * model_probs.get(side, sharp_probs[side]))
-                if side in sharp_probs else model_probs.get(side)
-            )
-            for side in (set(model_probs) | set(sharp_probs))
-        }
 
     kalshi_markets = [
         {

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -41,6 +41,12 @@ log = logging.getLogger(__name__)
 _DEVIG_METHODS = ("power", "shin", "proportional")
 _DEVIG_FUNCS = {"power": power_devig, "shin": shin_devig, "proportional": proportional_devig}
 
+# Candlestick fetch window around a fixture's kickoff. Kalshi's candlesticks
+# endpoint 400s on an unbounded range; a pre-match lookback of 14 days (hourly
+# candles -> ~336 rows) covers every decision snapshot under the request cap.
+CANDLE_LOOKBACK_SEC = 14 * 24 * 3600
+CANDLE_LOOKAHEAD_SEC = 6 * 3600
+
 
 # --------------------------------------------------------------------------
 # Task 5: BacktestConfig + config_from_body
@@ -440,7 +446,19 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None) -> Backt
                 log.info("run_backtest: skipping fixture_id=%s reason=unmatched", fixture_id)
             else:
                 kickoff_ts = int(fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)
-                candles_by_side = {side: data.candles(ticker) for side, ticker in tickers.items()}
+                # Bound the candlestick window around kickoff. Kalshi's endpoint
+                # rejects (400) an unbounded range — an hourly interval over
+                # 1970..2100 would be millions of candles. A pre-match window of
+                # ~14 days back to a few hours after kickoff covers every decision
+                # snapshot while staying well under the per-request candle cap.
+                if kickoff_ts > 0:
+                    _c_start = kickoff_ts - CANDLE_LOOKBACK_SEC
+                    _c_end = kickoff_ts + CANDLE_LOOKAHEAD_SEC
+                    candles_by_side = {side: data.candles(ticker, _c_start, _c_end)
+                                       for side, ticker in tickers.items()}
+                else:
+                    candles_by_side = {side: data.candles(ticker)
+                                       for side, ticker in tickers.items()}
                 oddseries = data.sharp_odds(fx)
 
                 kalshi_asks: dict = {}

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -10,16 +10,23 @@ them up into a `BacktestResult`.
 
 No network, no DB — every function here takes plain data in and returns plain
 data out, so it is unit-testable with fabricated inputs.
+
+CAVEAT: when a single fixture yields multiple candidates under a binding
+capital cap, `evaluate()` orders/allocates them by raw `edge` (candidate
+`score` fed to `capital.planner.allocate`), not live's `opportunity_score`
+(which also weighs recency/liquidity across fixtures). This is an accepted,
+documented divergence from the live path for this per-fixture primitive.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from kalshi import instance_config
-from kalshi.fees import DEFAULT_FEE_RATE, fee_as_prob, fee_cents_for_order
+from kalshi.fees import DEFAULT_FEE_RATE
 from kalshi.intelligence.fusion import fuse, renormalize_group
 from kalshi.strategy.candidates import generate_candidates
 from kalshi.capital.planner import allocate
+from kalshi.reconcile import reconcile_position
 from kalshi.risk import RiskCaps
 
 _DEVIG_METHODS = ("power", "shin", "proportional")
@@ -109,6 +116,8 @@ class SizedBet:
     edge: float
     market_type: str = ""
     fixture_id: str = ""
+    league: str = ""
+    kickoff: str | int = ""
 
 
 def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
@@ -137,6 +146,10 @@ def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
     winner group with `fusion.renormalize_group` — the same two primitives,
     without the Dixon-Coles detour."""
     fixture_id = fixture.get("fixture_id", "")
+    league = fixture.get("league", "")
+    # BacktestDataProvider.fixtures() dicts key kickoff as `kickoff_ts`; accept
+    # a plain `kickoff` too in case the caller passes an already-normalized dict.
+    kickoff = fixture.get("kickoff_ts", fixture.get("kickoff", ""))
     tier = fixture.get("tier") or _TIER_FOR_MARKET_TYPES
 
     sharp_probs = sharp_probs or {}
@@ -202,6 +215,8 @@ def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
             edge=c.edge,
             market_type=c.market_type,
             fixture_id=fixture_id,
+            league=league,
+            kickoff=kickoff,
         ))
     return out
 
@@ -227,7 +242,7 @@ class Trade:
     market_type: str = ""
     fixture_id: str = ""
     league: str = ""
-    kickoff: str = ""
+    kickoff: str | int = ""
 
 
 @dataclass
@@ -246,17 +261,23 @@ class BacktestResult:
 def settle(bet: SizedBet, result: str, fee_rate: float = DEFAULT_FEE_RATE) -> Trade:
     """Grade one `SizedBet` against the fixture result. `result` is the winning
     side ('home'/'away'/'draw', matching `bet.side`) — win when `result ==
-    bet.side`. Same settlement math as `reconcile.reconcile_position` (a
-    single-fill position, so its cost-weighted-average path collapses to the
-    plain formula): win -> (100-entry)*size - fee; loss -> -entry*size. CLV
-    is the fused fair (the closest thing to a pre-match "sharp close" this
-    per-fixture primitive has) vs the entry price."""
+    bet.side`. Settlement math is delegated to `reconcile.reconcile_position`
+    (the live settlement path) rather than reimplemented here: a `SizedBet` is
+    a single-fill position, so its cost-weighted-average path collapses to the
+    plain formula, and `bet.side` winning is exactly the position's YES side
+    winning. Kalshi charges the trading fee AT EXECUTION regardless of outcome,
+    so `reconcile_position` (and therefore this) charges it on wins AND losses:
+    win -> (100-entry)*size - fee; loss -> -entry*size - fee. CLV is the fused
+    fair (the closest thing to a pre-match "sharp close" this per-fixture
+    primitive has) vs the entry price — `reconcile_position`'s own CLV (which
+    grades vs a sharp/mid close, not the fused fair) is not used here."""
     won = (result == bet.side)
-    fee = fee_cents_for_order(bet.entry_cents, bet.size, fee_rate)
-    if won:
-        realized = (100 - bet.entry_cents) * bet.size - fee
-    else:
-        realized = -bet.entry_cents * bet.size
+    position = {
+        "market_ticker": bet.market_ticker,
+        "contracts": bet.size,
+        "avg_entry_cents": bet.entry_cents,
+    }
+    settled = reconcile_position(position, result=("yes" if won else "no"), fee_rate=fee_rate)
     clv = (bet.fused_fair * 100.0 - bet.entry_cents) / 100.0
     return Trade(
         side=bet.side,
@@ -267,11 +288,13 @@ def settle(bet: SizedBet, result: str, fee_rate: float = DEFAULT_FEE_RATE) -> Tr
         sharp_prob=bet.sharp_prob,
         fused_fair=bet.fused_fair,
         edge=bet.edge,
-        outcome="win" if won else "loss",
-        realized_pnl_cents=int(realized),
+        outcome=settled["outcome"],
+        realized_pnl_cents=int(settled["realized_pnl_cents"]),
         clv=round(clv, 4),
         market_type=bet.market_type,
         fixture_id=bet.fixture_id,
+        league=bet.league,
+        kickoff=bet.kickoff,
     )
 
 

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -1,0 +1,343 @@
+"""Kalshi soccer backtest replay engine — the pure per-fixture core.
+
+`run_backtest` (built separately) loops historical fixtures and calls the
+primitives in this module: `evaluate()` turns one fixture's model/sharp probs
+and Kalshi asks into sized bets using the SAME pricing/candidate/sizing code
+path the live bot uses (`intelligence.pricing.build_market_probs` ->
+`strategy.candidates.generate_candidates` -> `capital.planner.allocate`);
+`settle()`/`aggregate()` grade those bets against the final result and roll
+them up into a `BacktestResult`.
+
+No network, no DB — every function here takes plain data in and returns plain
+data out, so it is unit-testable with fabricated inputs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kalshi import instance_config
+from kalshi.fees import DEFAULT_FEE_RATE, fee_as_prob, fee_cents_for_order
+from kalshi.intelligence.pricing import build_market_probs
+from kalshi.strategy.candidates import generate_candidates
+from kalshi.capital.planner import allocate
+from kalshi.risk import RiskCaps
+
+_DEVIG_METHODS = ("power", "shin", "proportional")
+
+
+# --------------------------------------------------------------------------
+# Task 5: BacktestConfig + config_from_body
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class BacktestConfig:
+    leagues: list
+    start_date: str
+    end_date: str
+    bankroll_cents: int
+    caps: RiskCaps
+    sharp_weight: float
+    devig_method: str
+    decision_offsets_sec: tuple = (-3 * 3600,)
+    fee_rate: float = DEFAULT_FEE_RATE
+
+
+def config_from_body(body: dict) -> BacktestConfig:
+    """Build a `BacktestConfig` from an API request body, mapping the SAME
+    knobs the live instance uses (edge_threshold, no_sharp_edge_threshold,
+    kelly_fraction, order_size_min/max_cents, max_open_exposure_frac,
+    per_bet_cap_frac, min/max_price_cents, draw_min_edge, sharp_weight,
+    devig_method, bankroll_cents) into a `RiskCaps` via
+    `instance_config.risk_caps_from_config` — no reimplementation of the
+    live caps-building logic."""
+    body = dict(body or {})
+
+    # Dollar-denominated UI fields -> cents (mirrors instance_config.normalize_config).
+    bankroll_cents = instance_config._dollars_to_cents(
+        body.get("bankroll_dollars"), int(body.get("bankroll_cents", 0) or 0)
+    )
+    order_min_cents = instance_config._dollars_to_cents(
+        body.get("order_size_min_dollars"), int(body.get("order_size_min_cents", 0) or 0)
+    )
+    order_max_cents = instance_config._dollars_to_cents(
+        body.get("order_size_max_dollars"), int(body.get("order_size_max_cents", 0) or 0)
+    )
+
+    caps_config = dict(body)
+    caps_config["bankroll_cents"] = bankroll_cents
+    caps_config["order_size_min_cents"] = order_min_cents
+    caps_config["order_size_max_cents"] = order_max_cents
+    caps = instance_config.risk_caps_from_config(caps_config)
+
+    offsets = body.get("decision_offsets_sec")
+    decision_offsets_sec = tuple(offsets) if offsets is not None else (-3 * 3600,)
+
+    devig_method = str(body.get("devig_method") or "power").lower()
+    if devig_method not in _DEVIG_METHODS:
+        devig_method = "power"
+
+    return BacktestConfig(
+        leagues=list(body.get("leagues") or []),
+        start_date=str(body.get("start_date", "") or ""),
+        end_date=str(body.get("end_date", "") or ""),
+        bankroll_cents=bankroll_cents,
+        caps=caps,
+        sharp_weight=min(1.0, max(0.0, float(body.get("sharp_weight", 0.85)))),
+        devig_method=devig_method,
+        decision_offsets_sec=decision_offsets_sec,
+        fee_rate=float(body.get("fee_rate", DEFAULT_FEE_RATE)),
+    )
+
+
+# --------------------------------------------------------------------------
+# Task 6: evaluate() — per-fixture candidate generation + sizing
+# --------------------------------------------------------------------------
+
+_TIER_FOR_MARKET_TYPES = "max"  # widest allowed-markets set; caps still gate volume/size
+
+
+@dataclass(frozen=True)
+class SizedBet:
+    side: str
+    market_ticker: str
+    entry_cents: int
+    size: int
+    model_prob: float | None
+    sharp_prob: float | None
+    fused_fair: float
+    edge: float
+    market_type: str = ""
+    fixture_id: str = ""
+
+
+def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
+             kalshi_asks: dict, fixture: dict) -> list["SizedBet"]:
+    """Replicate the live pre-match decision path for ONE fixture:
+    fuse model+sharp probs -> generate edge-gated candidates -> size via the
+    quarter-Kelly/order-size-range planner. `model_probs`/`sharp_probs` are
+    `{side: prob}` for the fixture's `winner` market (the pre-match slice this
+    engine targets); `kalshi_asks` is `{side: cents}`.
+
+    This mirrors `orchestrator.plan_and_allocate`'s single-fixture call
+    sequence (build_market_probs -> generate_candidates -> allocate) with the
+    live/in-play parts (LLM adjustments, player props, opportunity scoring
+    across multiple fixtures) omitted — a backtest fixture has no LLM
+    rationale and is evaluated one match at a time."""
+    fixture_id = fixture.get("fixture_id", "")
+    tier = fixture.get("tier") or _TIER_FOR_MARKET_TYPES
+    league = fixture.get("league", "")
+
+    expected_goals = fixture.get("expected_goals")
+    sharp_probs = sharp_probs or {}
+    model_probs = model_probs or {}
+    kalshi_asks = kalshi_asks or {}
+
+    # build_market_probs expects {market_type: {side: prob}}; evaluate()'s
+    # model_probs/sharp_probs are already scoped to one market ({side: prob}),
+    # so wrap them under "winner" before fusing.
+    sharp_by_type = {"winner": dict(sharp_probs)} if sharp_probs else {}
+    fused = build_market_probs(expected_goals, sharp_by_type, {}, w_sharp=cfg.sharp_weight)
+    # If there's no expected_goals model signal, fall back to the caller-supplied
+    # model_probs directly (fused would otherwise degrade to sharp-only).
+    if "winner" not in fused or not fused.get("winner"):
+        fused = dict(fused)
+        base = {}
+        for side in set(model_probs) | set(sharp_probs):
+            base[side] = dict(sharp_by_type.get("winner", {})).get(side) if side in sharp_probs else None
+        fused["winner"] = {
+            side: (
+                (cfg.sharp_weight * sharp_probs[side] + (1 - cfg.sharp_weight) * model_probs.get(side, sharp_probs[side]))
+                if side in sharp_probs else model_probs.get(side)
+            )
+            for side in (set(model_probs) | set(sharp_probs))
+        }
+
+    kalshi_markets = [
+        {
+            "market_ticker": fixture.get("market_tickers", {}).get(side, f"{fixture_id}-{side.upper()}")
+                if isinstance(fixture.get("market_tickers"), dict) else f"{fixture_id}-{side.upper()}",
+            "market_type": "winner",
+            "side": side,
+            "yes_ask_cents": ask,
+        }
+        for side, ask in kalshi_asks.items()
+    ]
+
+    candidates = generate_candidates(
+        fixture_id, tier, fused, kalshi_markets,
+        fee_rate=cfg.fee_rate,
+        edge_threshold=cfg.caps.edge_threshold,
+        min_price_cents=cfg.caps.min_price_cents,
+        max_price_cents=cfg.caps.max_price_cents,
+        draw_min_edge=cfg.caps.draw_min_edge,
+        sharp_probs=sharp_by_type,
+        no_sharp_edge_threshold=cfg.caps.no_sharp_edge_threshold,
+    )
+    if not candidates:
+        return []
+
+    scored = [
+        {"id": c.market_ticker, "score": c.edge, "edge": c.edge,
+         "price_cents": c.price_cents, "has_sharp": c.has_sharp}
+        for c in candidates
+    ]
+    allocations = allocate(
+        scored, bankroll_cents=cfg.bankroll_cents, caps=cfg.caps,
+        reserve_frac=0.0, expected_better_soon=False,
+    )
+    alloc_by_id = {a["id"]: a for a in allocations}
+
+    out: list[SizedBet] = []
+    for c in candidates:
+        a = alloc_by_id.get(c.market_ticker)
+        if not a or a["contracts"] <= 0:
+            continue
+        out.append(SizedBet(
+            side=c.side,
+            market_ticker=c.market_ticker,
+            entry_cents=c.price_cents,
+            size=a["contracts"],
+            model_prob=model_probs.get(c.side),
+            sharp_prob=sharp_probs.get(c.side),
+            fused_fair=c.fair,
+            edge=c.edge,
+            market_type=c.market_type,
+            fixture_id=fixture_id,
+        ))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Task 7: settle() + aggregate()
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Trade:
+    side: str
+    market_ticker: str
+    entry_cents: int
+    size: int
+    model_prob: float | None
+    sharp_prob: float | None
+    fused_fair: float
+    edge: float
+    outcome: str
+    realized_pnl_cents: int
+    clv: float
+    market_type: str = ""
+    fixture_id: str = ""
+    league: str = ""
+    kickoff: str = ""
+
+
+@dataclass
+class BacktestResult:
+    pnl_cents: int
+    roi: float
+    n_bets: int
+    win_rate: float
+    clv_avg: float
+    equity_curve: list
+    per_league: dict
+    calibration: list
+    trades: list
+
+
+def settle(bet: SizedBet, result: str, fee_rate: float = DEFAULT_FEE_RATE) -> Trade:
+    """Grade one `SizedBet` against the fixture result. `result` is the winning
+    side ('home'/'away'/'draw', matching `bet.side`) — win when `result ==
+    bet.side`. Same settlement math as `reconcile.reconcile_position` (a
+    single-fill position, so its cost-weighted-average path collapses to the
+    plain formula): win -> (100-entry)*size - fee; loss -> -entry*size. CLV
+    is the fused fair (the closest thing to a pre-match "sharp close" this
+    per-fixture primitive has) vs the entry price."""
+    won = (result == bet.side)
+    fee = fee_cents_for_order(bet.entry_cents, bet.size, fee_rate)
+    if won:
+        realized = (100 - bet.entry_cents) * bet.size - fee
+    else:
+        realized = -bet.entry_cents * bet.size
+    clv = (bet.fused_fair * 100.0 - bet.entry_cents) / 100.0
+    return Trade(
+        side=bet.side,
+        market_ticker=bet.market_ticker,
+        entry_cents=bet.entry_cents,
+        size=bet.size,
+        model_prob=bet.model_prob,
+        sharp_prob=bet.sharp_prob,
+        fused_fair=bet.fused_fair,
+        edge=bet.edge,
+        outcome="win" if won else "loss",
+        realized_pnl_cents=int(realized),
+        clv=round(clv, 4),
+        market_type=bet.market_type,
+        fixture_id=bet.fixture_id,
+    )
+
+
+def _calibration_buckets(trades: list[Trade], n_buckets: int = 10) -> list[dict]:
+    """Predicted-probability vs actual-win-rate buckets (reliability curve)."""
+    buckets = [[] for _ in range(n_buckets)]
+    for t in trades:
+        p = t.fused_fair if t.fused_fair is not None else 0.0
+        idx = min(n_buckets - 1, max(0, int(p * n_buckets)))
+        buckets[idx].append(t)
+    out = []
+    for i, bucket in enumerate(buckets):
+        if not bucket:
+            continue
+        lo, hi = i / n_buckets, (i + 1) / n_buckets
+        n = len(bucket)
+        wins = sum(1 for t in bucket if t.outcome == "win")
+        out.append({
+            "bucket": [lo, hi],
+            "predicted_avg": sum(t.fused_fair for t in bucket) / n,
+            "actual_rate": wins / n,
+            "n": n,
+        })
+    return out
+
+
+def aggregate(trades: list[Trade], bankroll_cents: int) -> BacktestResult:
+    """Roll up settled trades into a `BacktestResult`. `trades` should already
+    be ordered by fixture kickoff (the caller — `run_backtest` — settles
+    fixtures in kickoff order); the equity curve is the running cumulative
+    P&L in that order."""
+    n_bets = len(trades)
+    pnl_cents = sum(t.realized_pnl_cents for t in trades)
+    roi = (pnl_cents / bankroll_cents) if bankroll_cents else 0.0
+    wins = sum(1 for t in trades if t.outcome == "win")
+    win_rate = (wins / n_bets) if n_bets else 0.0
+    clv_avg = (sum(t.clv for t in trades) / n_bets) if n_bets else 0.0
+
+    equity_curve = []
+    running = 0
+    for t in trades:
+        running += t.realized_pnl_cents
+        equity_curve.append(running)
+
+    per_league: dict = {}
+    for t in trades:
+        lg = t.league or "unknown"
+        row = per_league.setdefault(lg, {"pnl_cents": 0, "n_bets": 0, "wins": 0})
+        row["pnl_cents"] += t.realized_pnl_cents
+        row["n_bets"] += 1
+        row["wins"] += 1 if t.outcome == "win" else 0
+    for row in per_league.values():
+        row["win_rate"] = row["wins"] / row["n_bets"] if row["n_bets"] else 0.0
+
+    calibration = _calibration_buckets(trades)
+
+    return BacktestResult(
+        pnl_cents=int(pnl_cents),
+        roi=roi,
+        n_bets=n_bets,
+        win_rate=win_rate,
+        clv_avg=round(clv_avg, 4),
+        equity_curve=equity_curve,
+        per_league=per_league,
+        calibration=calibration,
+        trades=list(trades),
+    )

--- a/backend/kalshi/backtest_data.py
+++ b/backend/kalshi/backtest_data.py
@@ -11,8 +11,9 @@ Design:
   OddsPapi-fixture-result fallback (used only when Kalshi has no ticker match or
   no client is configured). An unsettled cache row is retried on every call
   until it settles; a settled row is never re-fetched.
-- `candles`/`sharp_odds` are simple fetch-or-cache: a cache hit never touches
-  the network; a cache miss fetches once and stores the result.
+- `fixtures`/`candles`/`sharp_odds` are simple fetch-or-cache: a cache hit
+  never touches the network; a cache miss fetches once and stores the result.
+  `fixtures` keys its cache on the (leagues, start_date, end_date) query.
 - All OddsPapi calls (the metered ~250/mo free tier) are guarded by
   `ingest_odds.should_scan`; a budget-exhausted call returns cached-or-None and
   LOGS the skip — it is never silently dropped.
@@ -134,7 +135,16 @@ class BacktestDataProvider:
         dates, YYYY-MM-DD). Each dict carries the parsed OddsPapi fields
         (home/away/kickoff_ts/home_score/away_score/result/settled) plus
         fixture_id/sport/league — a superset of the plain Fixture DTO so
-        `final_score`'s fallback has the data it needs without a second call."""
+        `final_score`'s fallback has the data it needs without a second call.
+
+        The listing itself is cached per (leagues, start_date, end_date) query
+        — a backtest is over a past, immutable window, so re-running it never
+        re-hits OddsPapi for the fixture list."""
+        cache_key = "fixturelist|" + ",".join(sorted(leagues or [])) + "|" + start_date + "|" + end_date
+        cached = self._table_get("KalshiBtFixtureList", cache_key)
+        if cached is not None:
+            self.cache_hits += 1
+            return cached.get("fixtures", [])
         out: list[dict] = []
         if self.oddspapi_client is None:
             return out
@@ -165,6 +175,8 @@ class BacktestDataProvider:
                     "result": r.get("result"),
                     "settled": r.get("settled", False),
                 })
+        if out:
+            self._table_put("KalshiBtFixtureList", {"id": cache_key, "fixtures": out}, "id")
         return out
 
     # --- candles (Kalshi price history — immutable once traded) ---

--- a/backend/kalshi/backtest_data.py
+++ b/backend/kalshi/backtest_data.py
@@ -1,0 +1,307 @@
+"""Data layer for the Kalshi soccer backtest.
+
+`run_backtest` (built separately) replays historical fixtures tick-by-tick; this
+module gives it everything it needs — the fixture list, final scores, Kalshi
+price candles, and sharp (Pinnacle) odds — while fetching from the network APIs
+ONCE and caching the immutable historical data, so re-running the same backtest
+costs zero additional API calls.
+
+Design:
+- `final_score` is Kalshi-primary (settled markets, free/public) with an
+  OddsPapi-fixture-result fallback (used only when Kalshi has no ticker match or
+  no client is configured). An unsettled cache row is retried on every call
+  until it settles; a settled row is never re-fetched.
+- `candles`/`sharp_odds` are simple fetch-or-cache: a cache hit never touches
+  the network; a cache miss fetches once and stores the result.
+- All OddsPapi calls (the metered ~250/mo free tier) are guarded by
+  `ingest_odds.should_scan`; a budget-exhausted call returns cached-or-None and
+  LOGS the skip — it is never silently dropped.
+- The RethinkDB table access is abstracted behind `_table_get`/`_table_put` so
+  tests can inject a plain in-memory dict (`tables={}`) instead of a live `conn`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from kalshi.client import result_side_from_markets
+from kalshi.data.sources.odds_api import match_event
+from kalshi.data.ticker_names import parse_market_ticker
+from kalshi.ingest_odds import should_scan
+from kalshi.normalize import normalize_team
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_SOCCER_SERIES = ("KXWCGAME",)
+_DEFAULT_MARKET_STATUSES = ("open", "settled")
+
+# OddsPapi sport_id is unconfirmed (Phase 0 note in ingest_odds.py); soccer
+# defaults to 1 and is easy to extend per-league once the real catalog is known.
+_SPORT_ID_BY_LEAGUE = {"world cup": 1}
+_DEFAULT_SPORT_ID = 1
+
+
+def _fx_get(fx: Any, key: str, default: Any = None) -> Any:
+    """Read a field off a fixture that may be a dict or a dataclass-like object."""
+    if isinstance(fx, dict):
+        return fx.get(key, default)
+    return getattr(fx, key, default)
+
+
+def _event_prefix(ticker: str) -> str:
+    """Drop the trailing '-<PICK>' suffix, leaving the shared event prefix
+    ('KXWCGAME-26JUL01ENGCOD-ENG' -> 'KXWCGAME-26JUL01ENGCOD')."""
+    return (ticker or "").rsplit("-", 1)[0]
+
+
+def _group_tickers_by_event(tickers: list[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    for t in tickers:
+        if not t:
+            continue
+        groups.setdefault(_event_prefix(t), []).append(t)
+    return groups
+
+
+class BacktestDataProvider:
+    """Fetch-or-cache data provider for the Kalshi soccer backtest. All
+    dependencies are injectable so unit tests run with fakes and no network."""
+
+    def __init__(
+        self,
+        *,
+        kalshi_client: Any = None,
+        oddspapi_client: Any = None,
+        conn: Any = None,
+        tables: Optional[dict[str, dict[str, dict]]] = None,
+        budget_used_getter: Optional[Callable[[], int]] = None,
+        budget_bumper: Optional[Callable[[], None]] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self.kalshi_client = kalshi_client
+        self.oddspapi_client = oddspapi_client
+        self.conn = conn
+        # `tables` (even an empty dict) opts into the in-memory fake store used
+        # by unit tests; `None` means "use the real `conn`" (or no-op if that's
+        # also None — a provider with zero storage backend still functions, it
+        # just never caches).
+        self._tables = tables
+        self._budget_used_getter = budget_used_getter or (lambda: 0)
+        self._budget_bumper = budget_bumper or (lambda: None)
+        self.log = logger or log
+        self.api_calls = 0
+        self.cache_hits = 0
+
+    # --- table access (fake dict OR live RethinkDB `conn`) ---
+
+    def _table_get(self, table: str, key: Optional[str]) -> Optional[dict]:
+        if key is None:
+            return None
+        if self._tables is not None:
+            return self._tables.get(table, {}).get(key)
+        if self.conn is None:
+            return None
+        try:
+            from kalshi import db
+            return db._r.db(db.DB_NAME).table(table).get(key).run(self.conn)
+        except Exception:
+            return None
+
+    def _table_put(self, table: str, doc: dict, pk_field: str) -> None:
+        key = doc.get(pk_field)
+        if key is None:
+            return
+        if self._tables is not None:
+            self._tables.setdefault(table, {})[key] = doc
+            return
+        if self.conn is None:
+            return
+        try:
+            from kalshi import db
+            db._r.db(db.DB_NAME).table(table).insert(doc, conflict="replace").run(self.conn)
+        except Exception:
+            pass
+
+    # --- OddsPapi budget guard ---
+
+    def _oddspapi_allowed(self, cost: int = 1) -> bool:
+        return should_scan(self._budget_used_getter(), cost)
+
+    # --- fixtures ---
+
+    def fixtures(self, leagues: list[str], start_date: str, end_date: str) -> list[dict]:
+        """Fixture list for `leagues` over [start_date, end_date] (OddsPapi
+        dates, YYYY-MM-DD). Each dict carries the parsed OddsPapi fields
+        (home/away/kickoff_ts/home_score/away_score/result/settled) plus
+        fixture_id/sport/league — a superset of the plain Fixture DTO so
+        `final_score`'s fallback has the data it needs without a second call."""
+        out: list[dict] = []
+        if self.oddspapi_client is None:
+            return out
+        for league in leagues or []:
+            if not self._oddspapi_allowed(1):
+                self.log.warning(
+                    "BacktestDataProvider.fixtures: OddsPapi budget exhausted, "
+                    "skipping league=%s %s..%s", league, start_date, end_date)
+                continue
+            sport_id = _SPORT_ID_BY_LEAGUE.get((league or "").strip().lower(), _DEFAULT_SPORT_ID)
+            try:
+                rows = self.oddspapi_client.list_fixtures(sport_id, start_date, end_date)
+            except Exception:
+                self.log.warning("BacktestDataProvider.fixtures: list_fixtures failed for league=%s", league)
+                continue
+            self.api_calls += 1
+            self._budget_bumper()
+            for r in rows:
+                out.append({
+                    "fixture_id": r.get("fixture_id"),
+                    "sport": "soccer",
+                    "league": league,
+                    "home": normalize_team(r.get("home", "")),
+                    "away": normalize_team(r.get("away", "")),
+                    "kickoff_ts": r.get("kickoff_ts"),
+                    "home_score": r.get("home_score"),
+                    "away_score": r.get("away_score"),
+                    "result": r.get("result"),
+                    "settled": r.get("settled", False),
+                })
+        return out
+
+    # --- candles (Kalshi price history — immutable once traded) ---
+
+    def candles(self, ticker: str, start_ts: int = 0, end_ts: int = 4102444800) -> list[dict]:
+        """Kalshi candlesticks for `ticker`, cached forever once fetched (the
+        history of a settled/closed market never changes)."""
+        cached = self._table_get("KalshiHistCandles", ticker)
+        if cached is not None:
+            self.cache_hits += 1
+            return cached.get("candles", [])
+        if self.kalshi_client is None:
+            return []
+        rows = self.kalshi_client.get_candlesticks(ticker, start_ts, end_ts)
+        self.api_calls += 1
+        self._table_put("KalshiHistCandles", {"id": ticker, "candles": rows}, "id")
+        return rows
+
+    # --- sharp odds (OddsPapi historical odds — metered, budget-guarded) ---
+
+    def sharp_odds(self, fx: Any) -> list[dict]:
+        """Historical sharp-book odds snapshots for a fixture, cached forever
+        once fetched. Budget-gated: an exhausted OddsPapi budget returns
+        cached-or-empty and logs the skip; it never calls the client."""
+        fixture_id = _fx_get(fx, "fixture_id")
+        cached = self._table_get("KalshiHistOdds", fixture_id)
+        if cached is not None:
+            self.cache_hits += 1
+            return cached.get("snapshots", [])
+        if self.oddspapi_client is None:
+            return []
+        if not self._oddspapi_allowed(1):
+            self.log.warning(
+                "BacktestDataProvider.sharp_odds: OddsPapi budget exhausted, "
+                "skipping fixture_id=%s (returning cached-or-empty)", fixture_id)
+            return []
+        rows = self.oddspapi_client.historical_odds(fixture_id)
+        self.api_calls += 1
+        self._budget_bumper()
+        self._table_put("KalshiHistOdds", {"id": fixture_id, "snapshots": rows}, "id")
+        return rows
+
+    # --- final score (Kalshi-primary, OddsPapi-fallback, settled-aware cache) ---
+
+    def final_score(self, fx: Any) -> Optional[str]:
+        """'home' | 'draw' | 'away', or None if unsettled/unknown. A cached
+        settled result is returned without any network call; a cached
+        unsettled result is retried (the game may have finished since)."""
+        fixture_id = _fx_get(fx, "fixture_id")
+        cached = self._table_get("KalshiHistFixtures", fixture_id)
+        if cached is not None and cached.get("settled"):
+            self.cache_hits += 1
+            return cached.get("result")
+        result, settled = self._resolve_final_score(fx)
+        self._table_put(
+            "KalshiHistFixtures",
+            {"fixture_key": fixture_id, "settled": settled, "result": result},
+            "fixture_key",
+        )
+        return result
+
+    def _resolve_final_score(self, fx: Any) -> tuple[Optional[str], bool]:
+        # PRIMARY: Kalshi settled markets (free/public).
+        tickers = self.kalshi_tickers(fx)
+        if tickers and self.kalshi_client is not None:
+            any_ticker = next(iter(tickers.values()))
+            prefix = _event_prefix(any_ticker)
+            series = prefix.split("-", 1)[0]
+            try:
+                markets = self.kalshi_client.list_settled_markets(series)
+                self.api_calls += 1
+            except Exception:
+                markets = []
+            side = result_side_from_markets(markets, prefix)
+            if side:
+                return side, True
+        # FALLBACK: OddsPapi's own fixture result, if the caller already has it
+        # (e.g. from `fixtures()`) — never an extra network call.
+        if _fx_get(fx, "settled"):
+            return _fx_get(fx, "result"), True
+        return None, False
+
+    # --- fixture <-> Kalshi ticker resolution ---
+
+    def kalshi_tickers(
+        self,
+        fx: Any,
+        *,
+        series_options: tuple[str, ...] = _DEFAULT_SOCCER_SERIES,
+        statuses: tuple[str, ...] = _DEFAULT_MARKET_STATUSES,
+    ) -> dict[str, str]:
+        """Resolve an OddsPapi/normalized fixture to its Kalshi side tickers:
+        {"home": ticker, "draw": ticker, "away": ticker}. Reuses
+        `ticker_names.parse_market_ticker` to fold a ticker into (home, away,
+        pick), and `odds_api.match_event`'s fuzzy-uniqueness matcher to find the
+        one Kalshi event that safely corresponds to the fixture. Unmatched
+        fixtures return {} and are LOGGED — never guessed."""
+        home, away = _fx_get(fx, "home", ""), _fx_get(fx, "away", "")
+        tickers = self._list_kalshi_tickers(series_options, statuses)
+        groups = _group_tickers_by_event(tickers)
+        if not groups:
+            self.log.warning(
+                "kalshi_tickers: no Kalshi markets available to match fixture %s vs %s", home, away)
+            return {}
+        events = []
+        for prefix, group_tickers in groups.items():
+            parsed = parse_market_ticker(group_tickers[0])
+            events.append({
+                "prefix": prefix,
+                "home": parsed.get("home", ""),
+                "away": parsed.get("away", ""),
+                "tickers": group_tickers,
+            })
+        ev = match_event(events, home, away)
+        if not ev:
+            self.log.warning(
+                "kalshi_tickers: unmatched fixture %s vs %s (no unique Kalshi event) — not guessing", home, away)
+            return {}
+        out: dict[str, str] = {}
+        for t in ev["tickers"]:
+            pick = parse_market_ticker(t).get("pick")
+            if pick in ("home", "away", "draw"):
+                out[pick] = t
+        return out
+
+    def _list_kalshi_tickers(self, series_options: tuple[str, ...], statuses: tuple[str, ...]) -> list[str]:
+        if self.kalshi_client is None:
+            return []
+        tickers: list[str] = []
+        for series in series_options:
+            for status in statuses:
+                try:
+                    d = self.kalshi_client.list_markets(status=status, series_ticker=series)
+                except Exception:
+                    continue
+                for m in (d.get("markets") or []):
+                    t = m.get("ticker") if isinstance(m, dict) else m
+                    if t:
+                        tickers.append(t)
+        return tickers

--- a/backend/kalshi/backtest_worker.py
+++ b/backend/kalshi/backtest_worker.py
@@ -1,0 +1,200 @@
+"""In-process background worker for Kalshi backtests.
+
+A queued `KalshiBacktests` row (status 'pending') is picked up — on boot (drain)
+and via a RethinkDB changefeed — and run to completion by `run_job`, which
+writes throttled progress back to the row and the result into
+`KalshiBacktestResults`. Unlike the heavy Docker-per-backtest stock engine, the
+Kalshi pre-match replay is cheap, so it runs in a small thread pool in-process.
+
+`run_job` is pure orchestration over injected collaborators (store / provider /
+model_fn / run function) so it unit-tests without a DB, network, or the real
+replay. Production wiring lives in `_build_job_context` + `start_worker`.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+
+from kalshi import db as _db
+from kalshi.backtest import config_from_body, run_backtest as _run_backtest
+
+log = logging.getLogger("kalshi.backtest_worker")
+
+
+def _iso_now() -> str:
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
+class _Stopped(Exception):
+    """Raised internally when the job's run flag is flipped off mid-replay."""
+
+
+def run_job(job, *, conn, provider, model_fn, store=_db, stop_check=None,
+            run_fn=_run_backtest) -> str:
+    """Run one backtest job to completion, writing status/progress/result via
+    `store`. Returns the terminal status ('finished' | 'stopped' | 'error').
+
+    Injectable collaborators keep this testable: `store` is the DB writer module
+    (`kalshi.db` by default), `provider`/`model_fn` feed `run_fn` (the replay,
+    `run_backtest` by default), and `stop_check() -> bool` reports whether the
+    job's run flag has been cleared (default: read it from `store`).
+    """
+    jid = job["id"]
+    if stop_check is None:
+        def stop_check():
+            row = store.get_backtest(conn, jid) or {}
+            return row.get("run") is False
+
+    try:
+        store.update_backtest_progress(conn, jid, status="running",
+                                       started_at=_iso_now(), progress=0.0)
+        cfg = config_from_body(job.get("config") or {})
+
+        last = [0.0]
+
+        def progress_cb(frac):
+            if stop_check():
+                raise _Stopped()
+            # throttle DB writes to every 2% (and always the final 100%).
+            if frac - last[0] >= 0.02 or frac >= 1.0:
+                last[0] = frac
+                store.update_backtest_progress(conn, jid, progress=round(frac * 100, 2))
+
+        result = run_fn(cfg, provider, model_fn, progress_cb=progress_cb)
+
+        store.save_backtest_result(conn, jid, result)
+        summary = dict(getattr(result, "summary", {}) or {})
+        summary.update({
+            "pnl_cents": getattr(result, "pnl_cents", 0),
+            "roi": getattr(result, "roi", 0.0),
+            "n_bets": getattr(result, "n_bets", 0),
+            "win_rate": getattr(result, "win_rate", 0.0),
+            "clv_avg": getattr(result, "clv_avg", 0.0),
+        })
+        store.update_backtest_progress(conn, jid, status="finished", progress=100.0,
+                                       finished_at=_iso_now(), summary=summary)
+        return "finished"
+    except _Stopped:
+        log.info("backtest %s stopped by run flag", jid)
+        store.update_backtest_progress(conn, jid, status="stopped",
+                                       finished_at=_iso_now())
+        return "stopped"
+    except Exception as e:  # pragma: no cover - defensive; unit-tested via run_fn raising
+        log.exception("backtest %s failed", jid)
+        store.update_backtest_progress(conn, jid, status="error", error=str(e),
+                                       finished_at=_iso_now())
+        return "error"
+
+
+# --- production wiring (integration; not unit-tested) --------------------
+
+def _used_this_month(conn) -> int:  # pragma: no cover - integration
+    try:
+        window = _db.scan_budget_window(_iso_now())
+        row = _db._r.db(_db.DB_NAME).table("kalshi_scan_budget").get(window).run(conn)
+        return int((row or {}).get("used", 0))
+    except Exception:
+        return 0
+
+
+def _build_job_context(job, conn):  # pragma: no cover - integration
+    """Build the (provider, model_fn) a job needs. Kalshi candlestick/settled
+    endpoints are PUBLIC, so a credential-less client suffices; OddsPapi (sharp
+    line) is optional — absent key -> model-only replay."""
+    from kalshi.client import KalshiClient
+    from kalshi.backtest_data import BacktestDataProvider
+    from kalshi.backtest import build_model_fn
+
+    cfg = dict(job.get("config") or {})
+    kalshi_client = KalshiClient(key_id="backtest", private_key_pem="", environment="prod")
+
+    oddspapi_client = None
+    key = cfg.get("oddspapi_api_key") or ""
+    if key:
+        from kalshi.ingest_odds import OddsPapiClient
+        oddspapi_client = OddsPapiClient(api_key=key)
+
+    provider = BacktestDataProvider(
+        kalshi_client=kalshi_client,
+        oddspapi_client=oddspapi_client,
+        conn=conn,
+        budget_used_getter=lambda: _used_this_month(conn),
+        budget_bumper=lambda: _db.bump_scan_budget(conn, _iso_now()),
+    )
+
+    nat_elo, elo = {}, {}
+    try:
+        from kalshi.data.sources.natelo import fetch_national_elo_table
+        nat_elo = fetch_national_elo_table() or {}
+    except Exception:
+        nat_elo = {}
+    try:
+        from kalshi.data.sources.clubelo import fetch_elo_table
+        elo = fetch_elo_table() or {}
+    except Exception:
+        elo = {}
+    model_fn = build_model_fn(nat_elo, elo)
+    return provider, model_fn
+
+
+def _run_job_production(job, conn):  # pragma: no cover - integration
+    provider, model_fn = _build_job_context(job, conn)
+    return run_job(job, conn=conn, provider=provider, model_fn=model_fn)
+
+
+def start_worker(conn_factory, *, max_workers: int = 2):  # pragma: no cover - integration
+    """Start the background worker: drain existing pending rows, then watch the
+    changefeed for new ones, running each in a small thread pool. `conn_factory`
+    returns a fresh RethinkDB connection (one per job thread — connections are
+    not thread-safe)."""
+    import concurrent.futures
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    seen: set = set()
+
+    def _dispatch(job):
+        jid = job.get("id")
+        if not jid or jid in seen:
+            return
+        seen.add(jid)
+
+        def _task():
+            c = conn_factory()
+            try:
+                _run_job_production(job, c)
+            finally:
+                seen.discard(jid)
+                try:
+                    c.close()
+                except Exception:
+                    pass
+
+        pool.submit(_task)
+
+    def _loop():
+        c = conn_factory()
+        # Drain rows left pending/running from a prior process.
+        try:
+            for row in _db.pending_or_running_backtests(c):
+                if row.get("status") == "running":
+                    # orphaned mid-run -> re-queue as pending
+                    _db.update_backtest_progress(c, row["id"], status="pending")
+                    row = {**row, "status": "pending"}
+                _dispatch(row)
+        except Exception:
+            log.exception("backtest worker drain failed")
+        # Watch for new pending jobs.
+        try:
+            feed = (_db._r.db(_db.DB_NAME).table("KalshiBacktests")
+                    .filter({"status": "pending"}).changes(include_initial=False).run(c))
+            for change in feed:
+                new = (change or {}).get("new_val")
+                if new and new.get("status") == "pending":
+                    _dispatch(new)
+        except Exception:
+            log.exception("backtest worker changefeed ended")
+
+    threading.Thread(target=_loop, name="kalshi-backtest-worker", daemon=True).start()
+    log.info("kalshi backtest worker started")
+    return pool

--- a/backend/kalshi/client.py
+++ b/backend/kalshi/client.py
@@ -17,6 +17,7 @@ import uuid as _uuid
 from typing import Any, Optional
 
 from kalshi.signing import access_headers
+from kalshi.data.ticker_names import parse_market_ticker
 from kalshi.models import (
     KalshiBalance,
     KalshiContractPosition,
@@ -74,6 +75,67 @@ def yes_ask_close_at(candles, ts) -> int | None:
         return int(round(float(cd) * 100))
     except (TypeError, ValueError):
         return None
+
+
+def result_side_from_markets(markets: list[dict], fixture_prefix: str) -> str | None:
+    """Map yes-resolved market side ticker to 'home', 'away', or 'draw'.
+
+    Given markets list from /markets?series_ticker=...&status=settled, find the
+    yes-resolved market and map its suffix to the fixture's home/away team codes.
+    E.g., KXWCGAME-26JUN30MEXECU with MEX-result=yes -> 'home'; TIE-result=yes -> 'draw'.
+    """
+    import re
+
+    # Find the yes-resolved market
+    yes_market = None
+    for m in markets:
+        if (m or {}).get("result") == "yes":
+            yes_market = m
+            break
+
+    if not yes_market:
+        return None
+
+    # Extract the suffix (last hyphen-separated segment)
+    ticker = yes_market.get("ticker", "")
+    parts = ticker.split("-")
+    if len(parts) < 3:
+        return None
+    suffix = parts[-1].upper()
+
+    # TIE / DRAW -> draw
+    if suffix in ("TIE", "DRAW"):
+        return "draw"
+
+    # Extract team codes from fixture_prefix
+    # E.g., KXWCGAME-26JUN30MEXECU -> extract "MEXECU" (after date)
+    fixture_parts = fixture_prefix.split("-")
+    if len(fixture_parts) < 2:
+        return None
+
+    fixture_blob = fixture_parts[-1]  # e.g., "26JUN30MEXECU"
+
+    # Use regex to find and skip the date (e.g., "26JUN30") then get teams
+    date_pattern = re.compile(r"^\d{2}[A-Z]{3}\d{2}", re.I)
+    match = date_pattern.match(fixture_blob)
+    if not match:
+        return None
+
+    teams = fixture_blob[match.end():].upper()  # e.g., "MEXECU"
+    if len(teams) < 6:
+        return None
+
+    # Split teams into home and away (first 3 chars each)
+    home_code = teams[:3]
+    away_code = teams[3:6]
+
+    # Map suffix to side
+    if suffix == home_code:
+        return "home"
+    elif suffix == away_code:
+        return "away"
+
+    return None
 
 
 class KalshiHTTPError(RuntimeError):
@@ -267,6 +329,33 @@ class KalshiClient:
         resp = self._session.request("GET", url, headers=headers, params=params, timeout=self.timeout)
         resp.raise_for_status()
         return parse_candlesticks(resp.json() if getattr(resp, "content", None) else {})
+
+    def list_settled_markets(self, series: str, limit: int = 1000) -> list[dict]:
+        """Fetch settled markets for a series (public, no auth). Paginates via cursor.
+        Host: external-api.kalshi.com. Free score source via result field."""
+        url = "https://external-api.kalshi.com/trade-api/v2/markets"
+        headers = {
+            "User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/126",
+            "Accept": "application/json"
+        }
+        out = []
+        cursor = None
+        while True:
+            params = {
+                "series_ticker": str(series),
+                "status": "settled",
+                "limit": max(1, min(int(limit), 1000))
+            }
+            if cursor:
+                params["cursor"] = cursor
+            resp = self._session.request("GET", url, headers=headers, params=params, timeout=self.timeout)
+            resp.raise_for_status()
+            d = resp.json() if getattr(resp, "content", None) else {}
+            out.extend(d.get("markets", []) or [])
+            cursor = d.get("cursor")
+            if not cursor:
+                break
+        return out
 
     # --- orders ---
     def submit_order(

--- a/backend/kalshi/client.py
+++ b/backend/kalshi/client.py
@@ -52,6 +52,30 @@ def _dollars_cents(v) -> float:
     return _fp(v) * 100.0
 
 
+# --- public candlesticks / settled markets (no auth) ---
+
+def parse_candlesticks(payload: dict) -> list[dict]:
+    """Extract candlesticks array from raw API response. Safe on empty/missing."""
+    return list((payload or {}).get("candlesticks") or [])
+
+
+def yes_ask_close_at(candles, ts) -> int | None:
+    """Last candle's yes_ask.close_dollars in cents at or before ts. None if absent/no book."""
+    best = None
+    for c in candles:
+        if int(c.get("end_period_ts", 0)) <= int(ts):
+            best = c
+        else:
+            break
+    cd = ((best or {}).get("yes_ask") or {}).get("close_dollars")
+    if cd is None:
+        return None
+    try:
+        return int(round(float(cd) * 100))
+    except (TypeError, ValueError):
+        return None
+
+
 class KalshiHTTPError(RuntimeError):
     """Typed Kalshi API error. Subclasses RuntimeError so existing callers that
     `except RuntimeError` / `except Exception` keep working. `status` lets callers
@@ -229,6 +253,20 @@ class KalshiClient:
         if series_ticker:
             params["series_ticker"] = series_ticker
         return self._request("GET", "/events", params=params)
+
+    def get_candlesticks(self, ticker: str, start_ts, end_ts, period_interval: int = 60) -> list[dict]:
+        """Fetch public candlesticks for a market (no auth). Host: external-api.kalshi.com.
+        Series is derived from ticker prefix (before first '-'). Period in seconds."""
+        series = str(ticker).split("-", 1)[0]
+        url = f"https://external-api.kalshi.com/trade-api/v2/series/{series}/markets/{ticker}/candlesticks"
+        headers = {
+            "User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/126",
+            "Accept": "application/json"
+        }
+        params = {"start_ts": int(start_ts), "end_ts": int(end_ts), "period_interval": int(period_interval)}
+        resp = self._session.request("GET", url, headers=headers, params=params, timeout=self.timeout)
+        resp.raise_for_status()
+        return parse_candlesticks(resp.json() if getattr(resp, "content", None) else {})
 
     # --- orders ---
     def submit_order(

--- a/backend/kalshi/client.py
+++ b/backend/kalshi/client.py
@@ -61,13 +61,19 @@ def parse_candlesticks(payload: dict) -> list[dict]:
 
 
 def yes_ask_close_at(candles, ts) -> int | None:
-    """Last candle's yes_ask.close_dollars in cents at or before ts. None if absent/no book."""
+    """Last candle's yes_ask.close_dollars in cents at or before ts. None if absent/no book.
+
+    Robust to unsorted input: selects the candle with the max end_period_ts
+    that is <= ts, rather than assuming ascending order.
+    """
+    ts = int(ts)
     best = None
+    best_end = None
     for c in candles:
-        if int(c.get("end_period_ts", 0)) <= int(ts):
+        end = int(c.get("end_period_ts", 0))
+        if end <= ts and (best_end is None or end > best_end):
             best = c
-        else:
-            break
+            best_end = end
     cd = ((best or {}).get("yes_ask") or {}).get("close_dollars")
     if cd is None:
         return None
@@ -83,9 +89,12 @@ def result_side_from_markets(markets: list[dict], fixture_prefix: str) -> str | 
     Given markets list from /markets?series_ticker=...&status=settled, find the
     yes-resolved market and map its suffix to the fixture's home/away team codes.
     E.g., KXWCGAME-26JUN30MEXECU with MEX-result=yes -> 'home'; TIE-result=yes -> 'draw'.
-    """
-    import re
 
+    The settled market's own ticker already carries the full
+    "<fixture_prefix>-<suffix>" shape parse_market_ticker understands (it's the
+    same ticker format used for the human-readable UI labels), so we reuse it
+    instead of hand-rolling a second team-code splitter.
+    """
     # Find the yes-resolved market
     yes_market = None
     for m in markets:
@@ -96,46 +105,12 @@ def result_side_from_markets(markets: list[dict], fixture_prefix: str) -> str | 
     if not yes_market:
         return None
 
-    # Extract the suffix (last hyphen-separated segment)
     ticker = yes_market.get("ticker", "")
-    parts = ticker.split("-")
-    if len(parts) < 3:
-        return None
-    suffix = parts[-1].upper()
-
-    # TIE / DRAW -> draw
-    if suffix in ("TIE", "DRAW"):
-        return "draw"
-
-    # Extract team codes from fixture_prefix
-    # E.g., KXWCGAME-26JUN30MEXECU -> extract "MEXECU" (after date)
-    fixture_parts = fixture_prefix.split("-")
-    if len(fixture_parts) < 2:
+    if fixture_prefix and not ticker.startswith(str(fixture_prefix)):
         return None
 
-    fixture_blob = fixture_parts[-1]  # e.g., "26JUN30MEXECU"
-
-    # Use regex to find and skip the date (e.g., "26JUN30") then get teams
-    date_pattern = re.compile(r"^\d{2}[A-Z]{3}\d{2}", re.I)
-    match = date_pattern.match(fixture_blob)
-    if not match:
-        return None
-
-    teams = fixture_blob[match.end():].upper()  # e.g., "MEXECU"
-    if len(teams) < 6:
-        return None
-
-    # Split teams into home and away (first 3 chars each)
-    home_code = teams[:3]
-    away_code = teams[3:6]
-
-    # Map suffix to side
-    if suffix == home_code:
-        return "home"
-    elif suffix == away_code:
-        return "away"
-
-    return None
+    pick = parse_market_ticker(ticker).get("pick")
+    return pick if pick in ("home", "away", "draw") else None
 
 
 class KalshiHTTPError(RuntimeError):
@@ -338,9 +313,10 @@ class KalshiClient:
             "User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/126",
             "Accept": "application/json"
         }
+        _MAX_PAGES = 50  # sane cap so a misbehaving/looping cursor can't hang forever
         out = []
         cursor = None
-        while True:
+        for _ in range(_MAX_PAGES):
             params = {
                 "series_ticker": str(series),
                 "status": "settled",

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -420,3 +420,118 @@ def settle_and_learn(conn, client, brokerage_id, *, fee_rate: float = 0.07) -> d
             }, conflict="replace").run(conn)
         settled += 1
     return {"settled": settled}
+
+
+# --- backtest jobs + results ---------------------------------------------
+# Pure doc builders (unit-tested); thin writers below run against a live DB.
+
+def backtest_job_doc(*, id, brokerage_id, instance_id=None, name="", config=None,
+                     leagues=None, start_date="", end_date="", bankroll_cents=0,
+                     created_at="") -> dict:
+    """A queued backtest job row: status 'pending', run True, progress 0."""
+    return {
+        "id": id,
+        "brokerage_id": brokerage_id,
+        "instance_id": instance_id,
+        "name": name or "",
+        "status": "pending",
+        "progress": 0.0,
+        "run": True,
+        "config": dict(config or {}),
+        "leagues": list(leagues or []),
+        "start_date": start_date or "",
+        "end_date": end_date or "",
+        "bankroll_cents": int(bankroll_cents or 0),
+        "created_at": created_at or "",
+        "started_at": None,
+        "finished_at": None,
+        "error": None,
+        "summary": {},
+    }
+
+
+def _as_plain(obj):
+    """dict passthrough; dataclass/obj -> its __dict__ copy."""
+    if isinstance(obj, dict):
+        return dict(obj)
+    return dict(getattr(obj, "__dict__", {}) or {})
+
+
+def backtest_result_doc(id, result) -> dict:
+    """Serialize a kalshi.backtest.BacktestResult (dataclass) or a dict into a
+    storable KalshiBacktestResults row."""
+    def g(k, default=None):
+        if isinstance(result, dict):
+            return result.get(k, default)
+        return getattr(result, k, default)
+    return {
+        "id": id,
+        "pnl_cents": int(g("pnl_cents", 0) or 0),
+        "roi": float(g("roi", 0.0) or 0.0),
+        "n_bets": int(g("n_bets", 0) or 0),
+        "win_rate": float(g("win_rate", 0.0) or 0.0),
+        "clv_avg": float(g("clv_avg", 0.0) or 0.0),
+        "equity_curve": list(g("equity_curve", []) or []),
+        "per_league": dict(g("per_league", {}) or {}),
+        "calibration": list(g("calibration", []) or []),
+        "trades": [_as_plain(t) for t in (g("trades", []) or [])],
+        "summary": dict(g("summary", {}) or {}),
+    }
+
+
+def create_backtest_job(conn, doc) -> None:
+    _r.db(DB_NAME).table("KalshiBacktests").insert(doc, conflict="replace").run(conn)
+
+
+def update_backtest_progress(conn, id, *, status=None, progress=None, error=None,
+                             started_at=None, finished_at=None, summary=None) -> None:
+    upd = {}
+    if status is not None:
+        upd["status"] = status
+    if progress is not None:
+        upd["progress"] = float(progress)
+    if error is not None:
+        upd["error"] = error
+    if started_at is not None:
+        upd["started_at"] = started_at
+    if finished_at is not None:
+        upd["finished_at"] = finished_at
+    if summary is not None:
+        upd["summary"] = summary
+    if upd:
+        _r.db(DB_NAME).table("KalshiBacktests").get(id).update(upd).run(conn)
+
+
+def save_backtest_result(conn, id, result) -> None:
+    _r.db(DB_NAME).table("KalshiBacktestResults").insert(
+        backtest_result_doc(id, result), conflict="replace").run(conn)
+
+
+def list_backtests(conn, brokerage_id, limit: int = 100) -> list:
+    rows = list(_r.db(DB_NAME).table("KalshiBacktests")
+                .filter({"brokerage_id": brokerage_id}).run(conn))
+    rows.sort(key=lambda r: r.get("created_at", ""), reverse=True)
+    return rows[:limit]
+
+
+def get_backtest(conn, id):
+    return _r.db(DB_NAME).table("KalshiBacktests").get(id).run(conn)
+
+
+def get_backtest_result(conn, id):
+    return _r.db(DB_NAME).table("KalshiBacktestResults").get(id).run(conn)
+
+
+def set_backtest_run(conn, id, run: bool) -> None:
+    _r.db(DB_NAME).table("KalshiBacktests").get(id).update({"run": bool(run)}).run(conn)
+
+
+def delete_backtest(conn, id) -> None:
+    _r.db(DB_NAME).table("KalshiBacktests").get(id).delete().run(conn)
+    _r.db(DB_NAME).table("KalshiBacktestResults").get(id).delete().run(conn)
+
+
+def pending_or_running_backtests(conn) -> list:
+    return list(_r.db(DB_NAME).table("KalshiBacktests")
+                .filter(lambda d: (d["status"] == "pending") | (d["status"] == "running"))
+                .run(conn))

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -46,6 +46,7 @@ KALSHI_TABLES: list[tuple[str, str]] = [
     ("KalshiHistCandles", "id"),         # cached Kalshi candlesticks, id = market ticker
     ("KalshiHistOdds", "id"),            # cached OddsPapi historical odds, id = fixture_id
     ("KalshiHistFixtures", "fixture_key"),  # cached per-fixture final-score resolution
+    ("KalshiBtFixtureList", "id"),  # cached fixture-list query results (zero-cost re-runs)
 ]
 
 

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -40,6 +40,12 @@ KALSHI_TABLES: list[tuple[str, str]] = [
     ("kalshi_live", "id"),   # live in-match cards: id = "{instance_id}|{fixture_id}"
     ("kalshi_fills", "id"),  # actual fills — ground-truth entry price for reconcile
     ("kalshi_edge_history", "id"),  # rolling per-side edge series for UI sparklines
+    # backtest data layer + jobs
+    ("KalshiBacktests", "id"),           # queued/running/finished backtest jobs
+    ("KalshiBacktestResults", "id"),     # per-job results (equity curve, trades, stats)
+    ("KalshiHistCandles", "id"),         # cached Kalshi candlesticks, id = market ticker
+    ("KalshiHistOdds", "id"),            # cached OddsPapi historical odds, id = fixture_id
+    ("KalshiHistFixtures", "fixture_key"),  # cached per-fixture final-score resolution
 ]
 
 

--- a/backend/kalshi/ingest_odds.py
+++ b/backend/kalshi/ingest_odds.py
@@ -9,6 +9,7 @@ client maps raw responses into.
 """
 from __future__ import annotations
 
+import datetime as _dt
 from typing import Any, Optional
 
 from kalshi.models import OddsQuote
@@ -47,6 +48,85 @@ def parse_three_way(raw: dict, book: str = "pinnacle") -> Optional[OddsQuote]:
         return None
 
 
+def _to_ts(entry: dict) -> int | None:
+    """Fixture kickoff as epoch seconds, accepting either a raw `kickoff_ts`
+    (int) or an ISO8601 `kickoff` string. None if neither is present/parseable."""
+    ts = entry.get("kickoff_ts")
+    if ts is not None:
+        try:
+            return int(ts)
+        except (TypeError, ValueError):
+            return None
+    iso = entry.get("kickoff")
+    if not iso:
+        return None
+    try:
+        s = str(iso).replace("Z", "+00:00")
+        dt = _dt.datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_dt.timezone.utc)
+        return int(dt.timestamp())
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_fixtures(raw: dict) -> list[dict]:
+    """Normalize an OddsPapi fixtures-list response into
+    [{fixture_id, home, away, kickoff_ts, home_score, away_score, result, settled}].
+    Settled = both scores present; result derived home/draw/away from the score,
+    None when either score is missing. Never raises; empty-safe."""
+    out = []
+    for f in (raw or {}).get("fixtures") or []:
+        hs, as_ = f.get("home_score"), f.get("away_score")
+        settled = hs is not None and as_ is not None
+        result = None
+        if settled:
+            try:
+                hs_n, as_n = float(hs), float(as_)
+                result = "home" if hs_n > as_n else ("away" if as_n > hs_n else "draw")
+            except (TypeError, ValueError):
+                settled = False
+        out.append({
+            "fixture_id": str(f.get("id", "")),
+            "home": f.get("home", ""),
+            "away": f.get("away", ""),
+            "kickoff_ts": _to_ts(f),
+            "home_score": hs if settled else None,
+            "away_score": as_ if settled else None,
+            "result": result,
+            "settled": settled,
+        })
+    return out
+
+
+def parse_hist_odds(raw: dict, books: tuple[str, ...] = ("pinnacle",)) -> list[dict]:
+    """Normalize an OddsPapi historical-odds response into decimal-odds
+    snapshots [{ts, home, draw, away}] for the first available book (in
+    priority order) per snapshot, sorted ascending by ts. Snapshots with none
+    of the requested books are skipped. Never raises; empty-safe."""
+    out = []
+    for snap in (raw or {}).get("odds") or []:
+        snap_books = (snap or {}).get("books") or {}
+        chosen = None
+        for b in books:
+            if b in snap_books:
+                chosen = snap_books[b]
+                break
+        if not chosen:
+            continue
+        try:
+            out.append({
+                "ts": int(snap.get("ts")),
+                "home": float(chosen["home"]),
+                "draw": float(chosen["draw"]),
+                "away": float(chosen["away"]),
+            })
+        except (KeyError, TypeError, ValueError):
+            continue
+    out.sort(key=lambda s: s["ts"])
+    return out
+
+
 class OddsPapiClient:
     def __init__(self, api_key: str, session: Any = None, base_url: str = "https://api.oddspapi.io"):
         self.api_key = api_key
@@ -62,3 +142,16 @@ class OddsPapiClient:
         resp = self._session.request("GET", f"{self.base_url}{path}", params=p, timeout=20.0)
         resp.raise_for_status()
         return resp.json() if resp.content else {}
+
+    def list_fixtures(self, sport_id: int, date_from: str, date_to: str) -> list[dict]:
+        """Fixtures for a sport in a date window, normalized (parsed)."""
+        raw = self.fetch_raw("/fixtures", {
+            "sport_id": sport_id, "date_from": date_from, "date_to": date_to,
+        })
+        return parse_fixtures(raw)
+
+    def historical_odds(self, fixture_id, books: tuple[str, ...] = ("pinnacle",)) -> list[dict]:
+        """Historical odds snapshots for a fixture, normalized (parsed) for the
+        first available book in `books` priority order."""
+        raw = self.fetch_raw("/historical-odds", {"fixture_id": fixture_id})
+        return parse_hist_odds(raw, books=books)

--- a/backend/tests/test_kalshi_backtest_config.py
+++ b/backend/tests/test_kalshi_backtest_config.py
@@ -1,0 +1,70 @@
+"""Tests for BacktestConfig + config_from_body — Task 5 of the Kalshi backtest
+replay engine. Reuses instance_config.risk_caps_from_config so the backtest's
+risk knobs are built the SAME way as the live instance."""
+from kalshi.backtest import BacktestConfig, config_from_body
+from kalshi.risk import RiskCaps
+
+
+def _body(**overrides):
+    body = {
+        "leagues": ["EPL"],
+        "start_date": "2025-01-01",
+        "end_date": "2025-06-01",
+        "bankroll_dollars": 1000,
+        "edge_threshold": 0.05,
+        "no_sharp_edge_threshold": 0.12,
+        "kelly_fraction": 0.2,
+        "order_size_min_dollars": 3,
+        "order_size_max_dollars": 9,
+        "max_open_exposure_frac": 0.3,
+        "per_bet_cap_frac": 0.08,
+        "min_price_cents": 20,
+        "max_price_cents": 85,
+        "draw_min_edge": 0.15,
+        "sharp_weight": 0.8,
+        "devig_method": "shin",
+    }
+    body.update(overrides)
+    return body
+
+
+def test_config_from_body_maps_live_knobs():
+    cfg = config_from_body(_body())
+    assert isinstance(cfg, BacktestConfig)
+    assert cfg.leagues == ["EPL"]
+    assert cfg.start_date == "2025-01-01"
+    assert cfg.end_date == "2025-06-01"
+    assert cfg.bankroll_cents == 100000
+    assert cfg.sharp_weight == 0.8
+    assert cfg.devig_method == "shin"
+    assert isinstance(cfg.caps, RiskCaps)
+    assert cfg.caps.edge_threshold == 0.05
+    assert cfg.caps.no_sharp_edge_threshold == 0.12
+    assert cfg.caps.kelly_fraction == 0.2
+    assert cfg.caps.order_size_min_cents == 300
+    assert cfg.caps.order_size_max_cents == 900
+    assert cfg.caps.max_open_exposure_frac == 0.3
+    assert cfg.caps.per_bet_cap_frac == 0.08
+    assert cfg.caps.min_price_cents == 20
+    assert cfg.caps.max_price_cents == 85
+    assert cfg.caps.draw_min_edge == 0.15
+    assert cfg.caps.bankroll_cents == 100000
+
+
+def test_config_from_body_defaults_when_missing():
+    cfg = config_from_body({})
+    assert cfg.leagues == []
+    assert cfg.bankroll_cents == 0
+    assert cfg.sharp_weight == 0.85          # instance_config default
+    assert cfg.devig_method == "power"       # instance_config default
+    assert cfg.decision_offsets_sec == (-3 * 3600,)
+    assert cfg.fee_rate == 0.07              # fees.DEFAULT_FEE_RATE
+    # caps still built via risk_caps_from_config's own defaults
+    assert cfg.caps.edge_threshold == 0.04
+    assert cfg.caps.kelly_fraction == 0.125
+
+
+def test_config_from_body_honors_explicit_fee_rate_and_offsets():
+    cfg = config_from_body(_body(fee_rate=0.0, decision_offsets_sec=[-7200, -3600]))
+    assert cfg.fee_rate == 0.0
+    assert cfg.decision_offsets_sec == (-7200, -3600)

--- a/backend/tests/test_kalshi_backtest_data.py
+++ b/backend/tests/test_kalshi_backtest_data.py
@@ -31,16 +31,62 @@ class FakeKalshiClient:
 
 
 class FakeOddsPapiClient:
-    def __init__(self, hist_odds=None):
+    def __init__(self, hist_odds=None, fixture_rows=None):
         self.hist_odds = hist_odds if hist_odds is not None else []
         self.hist_calls = 0
+        self.fixture_rows = fixture_rows if fixture_rows is not None else []
+        self.list_fixtures_calls = 0
 
     def historical_odds(self, fixture_id, books=("pinnacle",)):
         self.hist_calls += 1
         return self.hist_odds
 
     def list_fixtures(self, sport_id, date_from, date_to):
-        return []
+        self.list_fixtures_calls += 1
+        return self.fixture_rows
+
+
+# --- fixtures(): listing is cached per (leagues, start_date, end_date) query ---
+
+def test_fixtures_cache_miss_calls_client_once_and_stores():
+    op = FakeOddsPapiClient(fixture_rows=[
+        {"fixture_id": "fx1", "home": "England", "away": "DR Congo", "kickoff_ts": 100,
+         "home_score": None, "away_score": None, "result": None, "settled": False},
+    ])
+    provider = BacktestDataProvider(oddspapi_client=op, tables={}, budget_used_getter=lambda: 0)
+    rows = provider.fixtures(["world cup"], "2026-06-01", "2026-06-30")
+    assert len(rows) == 1
+    assert rows[0]["fixture_id"] == "fx1"
+    assert op.list_fixtures_calls == 1
+    assert provider.api_calls == 1
+    assert provider.cache_hits == 0
+
+
+def test_fixtures_second_identical_call_is_a_cache_hit_no_client_call():
+    op = FakeOddsPapiClient(fixture_rows=[
+        {"fixture_id": "fx1", "home": "England", "away": "DR Congo", "kickoff_ts": 100,
+         "home_score": None, "away_score": None, "result": None, "settled": False},
+    ])
+    provider = BacktestDataProvider(oddspapi_client=op, tables={}, budget_used_getter=lambda: 0)
+    rows1 = provider.fixtures(["world cup"], "2026-06-01", "2026-06-30")
+    rows2 = provider.fixtures(["world cup"], "2026-06-01", "2026-06-30")
+    assert rows1 == rows2
+    assert op.list_fixtures_calls == 1       # not called again
+    assert provider.api_calls == 1
+    assert provider.cache_hits == 1
+
+
+def test_fixtures_budget_exhausted_and_no_cache_returns_empty_and_logs(caplog):
+    op = FakeOddsPapiClient(fixture_rows=[
+        {"fixture_id": "fx1", "home": "England", "away": "DR Congo"},
+    ])
+    provider = BacktestDataProvider(oddspapi_client=op, tables={}, budget_used_getter=lambda: 250)
+    with caplog.at_level("WARNING"):
+        rows = provider.fixtures(["world cup"], "2026-06-01", "2026-06-30")
+    assert rows == []
+    assert op.list_fixtures_calls == 0
+    assert provider.api_calls == 0
+    assert any("budget" in r.message.lower() for r in caplog.records)
 
 
 # --- candles(): generic cache-miss / cache-hit pattern ---

--- a/backend/tests/test_kalshi_backtest_data.py
+++ b/backend/tests/test_kalshi_backtest_data.py
@@ -1,0 +1,176 @@
+"""Tests for BacktestDataProvider — fetch-or-cache data layer for the Kalshi
+soccer backtest. All clients + the DB table are FAKE/in-memory: no network."""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from kalshi.backtest_data import BacktestDataProvider
+
+
+class FakeKalshiClient:
+    def __init__(self, candles=None, settled_markets=None):
+        self.candles = candles or []
+        self.settled_markets = settled_markets or []
+        self.candle_calls = 0
+        self.settled_calls = 0
+        self.market_lists = {}  # (series, status) -> {"markets": [...]}
+
+    def get_candlesticks(self, ticker, start_ts, end_ts, period_interval=60):
+        self.candle_calls += 1
+        return self.candles
+
+    def list_settled_markets(self, series, limit=1000):
+        self.settled_calls += 1
+        return self.settled_markets
+
+    def list_markets(self, *, status="open", series_ticker=None, limit=200, cursor=None):
+        return self.market_lists.get((series_ticker, status), {"markets": []})
+
+
+class FakeOddsPapiClient:
+    def __init__(self, hist_odds=None):
+        self.hist_odds = hist_odds if hist_odds is not None else []
+        self.hist_calls = 0
+
+    def historical_odds(self, fixture_id, books=("pinnacle",)):
+        self.hist_calls += 1
+        return self.hist_odds
+
+    def list_fixtures(self, sport_id, date_from, date_to):
+        return []
+
+
+# --- candles(): generic cache-miss / cache-hit pattern ---
+
+def test_candles_cache_miss_calls_client_once_and_stores():
+    kc = FakeKalshiClient(candles=[{"end_period_ts": 1}])
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    rows = provider.candles("KXWCGAME-26JUL01ENGCOD-ENG")
+    assert rows == [{"end_period_ts": 1}]
+    assert kc.candle_calls == 1
+    assert provider.api_calls == 1
+    assert provider.cache_hits == 0
+
+
+def test_candles_second_call_is_a_cache_hit_no_client_call():
+    kc = FakeKalshiClient(candles=[{"end_period_ts": 1}])
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    provider.candles("TICK")
+    rows = provider.candles("TICK")
+    assert rows == [{"end_period_ts": 1}]
+    assert kc.candle_calls == 1          # not called again
+    assert provider.api_calls == 1
+    assert provider.cache_hits == 1
+
+
+# --- sharp_odds(): generic cache pattern + budget guard ---
+
+def test_sharp_odds_cache_miss_then_hit():
+    op = FakeOddsPapiClient(hist_odds=[{"ts": 1, "home": 2.0, "draw": 3.5, "away": 4.0}])
+    provider = BacktestDataProvider(oddspapi_client=op, tables={},
+                                     budget_used_getter=lambda: 0)
+    fx = {"fixture_id": "fx1"}
+    rows1 = provider.sharp_odds(fx)
+    rows2 = provider.sharp_odds(fx)
+    assert rows1 == rows2 == [{"ts": 1, "home": 2.0, "draw": 3.5, "away": 4.0}]
+    assert op.hist_calls == 1
+    assert provider.api_calls == 1
+    assert provider.cache_hits == 1
+
+
+def test_sharp_odds_budget_exhausted_skips_client_and_logs(caplog):
+    op = FakeOddsPapiClient(hist_odds=[{"ts": 1, "home": 2.0, "draw": 3.5, "away": 4.0}])
+    provider = BacktestDataProvider(oddspapi_client=op, tables={},
+                                     budget_used_getter=lambda: 250)  # exhausted
+    with caplog.at_level("WARNING"):
+        rows = provider.sharp_odds({"fixture_id": "fx1"})
+    assert rows == []
+    assert op.hist_calls == 0
+    assert provider.api_calls == 0
+    assert any("budget" in r.message.lower() for r in caplog.records)
+
+
+def test_sharp_odds_budget_exhausted_returns_cached_value_if_present():
+    op = FakeOddsPapiClient(hist_odds=[{"ts": 9, "home": 1.1, "draw": 9.0, "away": 20.0}])
+    tables = {"KalshiHistOdds": {"fx1": {"id": "fx1", "snapshots": [{"ts": 5, "home": 2.0, "draw": 3.0, "away": 3.0}]}}}
+    provider = BacktestDataProvider(oddspapi_client=op, tables=tables,
+                                     budget_used_getter=lambda: 250)
+    rows = provider.sharp_odds({"fixture_id": "fx1"})
+    assert rows == [{"ts": 5, "home": 2.0, "draw": 3.0, "away": 3.0}]
+    assert op.hist_calls == 0
+
+
+def test_sharp_odds_budget_bumper_called_on_real_fetch():
+    op = FakeOddsPapiClient(hist_odds=[{"ts": 1, "home": 2.0, "draw": 3.5, "away": 4.0}])
+    bumps = []
+    provider = BacktestDataProvider(oddspapi_client=op, tables={},
+                                     budget_used_getter=lambda: 0,
+                                     budget_bumper=lambda: bumps.append(1))
+    provider.sharp_odds({"fixture_id": "fx1"})
+    assert bumps == [1]
+
+
+# --- final_score(): Kalshi-primary, settled-tracking cache ---
+
+def test_final_score_primary_source_is_kalshi_settled_markets():
+    kc = FakeKalshiClient(settled_markets=[
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-ENG", "result": "yes"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-COD", "result": "no"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-TIE", "result": "no"},
+    ])
+    kc.market_lists[("KXWCGAME", "open")] = {"markets": [
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-ENG"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-COD"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-TIE"},
+    ]}
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    fx = {"fixture_id": "fx1", "home": "England", "away": "DR Congo",
+          "settled": True, "result": "away"}  # OddsPapi disagrees -> Kalshi wins
+    assert provider.final_score(fx) == "home"
+    assert kc.settled_calls == 1
+
+
+def test_final_score_unsettled_cached_row_is_refetched_until_settled():
+    kc = FakeKalshiClient(settled_markets=[])   # not settled yet on Kalshi
+    kc.market_lists[("KXWCGAME", "open")] = {"markets": [
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-ENG"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-COD"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-TIE"},
+    ]}
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    fx = {"fixture_id": "fx1", "home": "England", "away": "DR Congo", "settled": False, "result": None}
+
+    assert provider.final_score(fx) is None
+    assert kc.settled_calls == 1          # first fetch, still unsettled
+
+    assert provider.final_score(fx) is None
+    assert kc.settled_calls == 2          # unsettled cache -> re-fetched
+
+    # Now Kalshi settles the market.
+    kc.settled_markets = [
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-ENG", "result": "no"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-COD", "result": "yes"},
+        {"ticker": "KXWCGAME-26JUL01ENGCOD-TIE", "result": "no"},
+    ]
+    assert provider.final_score(fx) == "away"
+    assert kc.settled_calls == 3          # settled now -> fetched one more time
+
+    assert provider.final_score(fx) == "away"
+    assert kc.settled_calls == 3          # cached settled -> NEVER re-fetches again
+
+
+def test_final_score_falls_back_to_oddspapi_when_kalshi_unavailable():
+    provider = BacktestDataProvider(kalshi_client=None, tables={})
+    fx = {"fixture_id": "fx2", "home": "England", "away": "DR Congo",
+          "settled": True, "result": "draw"}
+    assert provider.final_score(fx) == "draw"
+
+
+def test_final_score_none_when_neither_source_has_it():
+    provider = BacktestDataProvider(kalshi_client=None, tables={})
+    fx = {"fixture_id": "fx3", "home": "England", "away": "DR Congo",
+          "settled": False, "result": None}
+    assert provider.final_score(fx) is None

--- a/backend/tests/test_kalshi_backtest_evaluate.py
+++ b/backend/tests/test_kalshi_backtest_evaluate.py
@@ -26,7 +26,7 @@ def _cfg(**cap_overrides):
 
 
 def _fixture():
-    return {"fixture_id": "f1", "league": "EPL", "expected_goals": None}
+    return {"fixture_id": "f1", "league": "EPL", "kickoff_ts": 1735689600, "expected_goals": None}
 
 
 def test_model_and_sharp_agree_home_edge_returns_sized_bet():
@@ -41,6 +41,8 @@ def test_model_and_sharp_agree_home_edge_returns_sized_bet():
     assert bet.side == "home"
     assert bet.size > 0
     assert bet.entry_cents == 45
+    assert bet.league == "EPL"
+    assert bet.kickoff == 1735689600
 
 
 def test_thin_edge_is_gated_out():

--- a/backend/tests/test_kalshi_backtest_evaluate.py
+++ b/backend/tests/test_kalshi_backtest_evaluate.py
@@ -1,0 +1,69 @@
+"""Tests for backtest.evaluate() — Task 6 of the Kalshi backtest replay engine.
+Wires the SAME pricing/candidate/sizing path the live bot uses
+(intelligence.pricing.build_market_probs -> strategy.candidates.generate_candidates
+-> capital.planner.allocate), one fixture at a time, no LLM/live parts."""
+from kalshi.backtest import BacktestConfig, SizedBet, evaluate
+from kalshi.risk import RiskCaps
+
+
+def _cfg(**cap_overrides):
+    defaults = dict(
+        edge_threshold=0.03,
+        kelly_fraction=0.25,
+        bankroll_cents=100_000,
+        min_price_cents=15,
+        max_price_cents=90,
+        draw_min_edge=0.10,
+        no_sharp_edge_threshold=0.10,
+        per_bet_cap_frac=0.10,
+    )
+    defaults.update(cap_overrides)
+    caps = RiskCaps(**defaults)
+    return BacktestConfig(
+        leagues=["EPL"], start_date="", end_date="", bankroll_cents=100_000,
+        caps=caps, sharp_weight=0.7, devig_method="power", fee_rate=0.07,
+    )
+
+
+def _fixture():
+    return {"fixture_id": "f1", "league": "EPL", "expected_goals": None}
+
+
+def test_model_and_sharp_agree_home_edge_returns_sized_bet():
+    cfg = _cfg()
+    model_probs = {"home": 0.55, "draw": 0.25, "away": 0.20}
+    sharp_probs = {"home": 0.50, "draw": 0.25, "away": 0.25}
+    kalshi_asks = {"home": 45}
+    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, _fixture())
+    assert len(bets) == 1
+    bet = bets[0]
+    assert isinstance(bet, SizedBet)
+    assert bet.side == "home"
+    assert bet.size > 0
+    assert bet.entry_cents == 45
+
+
+def test_thin_edge_is_gated_out():
+    cfg = _cfg()
+    model_probs = {"home": 0.55, "draw": 0.25, "away": 0.20}
+    sharp_probs = {"home": 0.44, "draw": 0.28, "away": 0.28}
+    kalshi_asks = {"home": 45}
+    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, _fixture())
+    assert bets == []
+
+
+def test_no_sharp_line_honors_no_sharp_edge_threshold():
+    cfg = _cfg(no_sharp_edge_threshold=0.20)
+    # Model-only side (no sharp price) with a modest edge that clears the
+    # plain edge_threshold (0.03) but NOT the no_sharp_edge_threshold (0.20).
+    model_probs = {"home": 0.50, "draw": 0.25, "away": 0.25}
+    sharp_probs = {}
+    kalshi_asks = {"home": 45}
+    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, _fixture())
+    assert bets == []
+
+    # A big enough model-only edge clears the higher no-sharp bar.
+    model_probs_big = {"home": 0.80, "draw": 0.10, "away": 0.10}
+    bets_big = evaluate(cfg, model_probs_big, sharp_probs, kalshi_asks, _fixture())
+    assert len(bets_big) == 1
+    assert bets_big[0].side == "home"

--- a/backend/tests/test_kalshi_backtest_job_docs.py
+++ b/backend/tests/test_kalshi_backtest_job_docs.py
@@ -1,0 +1,55 @@
+"""Pure doc-builder tests for backtest job/result rows (no DB)."""
+import sys, types
+
+# Stub socketio like the other kalshi tests (import side-effect guard).
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi.db import backtest_job_doc, backtest_result_doc
+
+
+def test_backtest_job_doc_defaults_pending_running_zero_progress():
+    d = backtest_job_doc(id="b1", brokerage_id="brk", instance_id="inst",
+                         name="My BT", config={"edge_threshold": 0.03},
+                         leagues=["World Cup"], start_date="2026-06-01",
+                         end_date="2026-06-30", bankroll_cents=5400,
+                         created_at="2026-07-01T00:00:00Z")
+    assert d["id"] == "b1"
+    assert d["status"] == "pending"
+    assert d["run"] is True
+    assert d["progress"] == 0.0
+    assert d["config"] == {"edge_threshold": 0.03}
+    assert d["leagues"] == ["World Cup"]
+    assert d["bankroll_cents"] == 5400
+    assert d["error"] is None
+    assert d["summary"] == {}
+
+
+def test_backtest_job_doc_empty_safe():
+    d = backtest_job_doc(id="b2", brokerage_id="brk")
+    assert d["leagues"] == [] and d["config"] == {} and d["bankroll_cents"] == 0
+
+
+def test_backtest_result_doc_from_dataclass():
+    from kalshi.backtest import Trade, BacktestResult
+    tr = Trade(side="home", market_ticker="KX-A", entry_cents=45, size=10,
+               model_prob=0.55, sharp_prob=0.5, fused_fair=0.52, edge=0.07,
+               outcome="win", realized_pnl_cents=550, clv=0.01,
+               market_type="winner", fixture_id="fx1", league="World Cup", kickoff=100)
+    res = BacktestResult(pnl_cents=550, roi=0.1, n_bets=1, win_rate=1.0, clv_avg=0.01,
+                         equity_curve=[{"ts": 100, "cum_pnl_cents": 550}],
+                         per_league={"World Cup": {"n": 1, "pnl_cents": 550}},
+                         calibration=[{"bucket_lo": 0.5, "bucket_hi": 0.6, "predicted": 0.55, "actual": 1.0, "n": 1}],
+                         trades=[tr])
+    res.summary = {"api_calls": 3, "cache_hits": 0}
+    d = backtest_result_doc("b1", res)
+    assert d["id"] == "b1"
+    assert d["pnl_cents"] == 550 and d["n_bets"] == 1
+    assert d["trades"][0]["side"] == "home" and d["trades"][0]["realized_pnl_cents"] == 550
+    assert d["per_league"]["World Cup"]["pnl_cents"] == 550
+    assert d["summary"] == {"api_calls": 3, "cache_hits": 0}
+
+
+def test_backtest_result_doc_from_dict():
+    d = backtest_result_doc("b3", {"pnl_cents": -100, "trades": [{"side": "away"}]})
+    assert d["pnl_cents"] == -100 and d["trades"][0]["side"] == "away"
+    assert d["roi"] == 0.0 and d["equity_curve"] == []

--- a/backend/tests/test_kalshi_backtest_modelfn.py
+++ b/backend/tests/test_kalshi_backtest_modelfn.py
@@ -1,0 +1,34 @@
+"""Tests for backtest.build_model_fn() — Task 9 of the Kalshi backtest replay
+engine. Wires the SAME Elo -> expected-goals -> Dixon-Coles pricing chain the
+live engine uses (quant.elo.elo_to_expected_goals ->
+intelligence.pricing.model_market_probs's 'winner' group), picking national vs
+club Elo per team exactly like engine.py's `_team_elo` closure."""
+from kalshi.backtest import build_model_fn
+
+
+def test_club_teams_three_way_sums_to_one():
+    elo_table = {"Real Madrid": 1950.0, "Getafe": 1550.0}
+    model_fn = build_model_fn(nat_elo_table={}, elo_table=elo_table)
+    fx = {"fixture_id": "f1", "home": "Real Madrid", "away": "Getafe"}
+    probs = model_fn(fx)
+    assert set(probs.keys()) == {"home", "draw", "away"}
+    assert abs(sum(probs.values()) - 1.0) < 1e-9
+    # Strong favorite at home -> home should be the most likely outcome.
+    assert probs["home"] > probs["away"]
+    assert probs["home"] > probs["draw"]
+
+
+def test_national_teams_use_national_elo_table_and_sum_to_one():
+    nat_elo_table = {"Argentina": 2200.0, "Iceland": 1400.0}
+    model_fn = build_model_fn(nat_elo_table=nat_elo_table, elo_table={})
+    fx = {"fixture_id": "f2", "home": "Argentina", "away": "Iceland"}
+    probs = model_fn(fx)
+    assert abs(sum(probs.values()) - 1.0) < 1e-9
+    assert probs["home"] > probs["away"]
+
+
+def test_unknown_club_team_falls_back_to_default_elo_and_still_sums_to_one():
+    model_fn = build_model_fn(nat_elo_table={}, elo_table={})
+    fx = {"fixture_id": "f3", "home": "Some Random FC", "away": "Another FC"}
+    probs = model_fn(fx)
+    assert abs(sum(probs.values()) - 1.0) < 1e-9

--- a/backend/tests/test_kalshi_backtest_run.py
+++ b/backend/tests/test_kalshi_backtest_run.py
@@ -1,0 +1,133 @@
+"""Tests for backtest.run_backtest() — Task 8 of the Kalshi backtest replay
+engine. Orchestrates a FULLY FAKE data provider + fake model_fn over multiple
+fixtures: kickoff-order looping, unsettled/unmatched skip reasons, one decision
+snapshot per fixture (yes_ask_close_at + devigged sharp odds at/just-before the
+snapshot ts), settle, aggregate, progress reporting, and api_calls/cache_hits
+surfaced into the result."""
+from kalshi.backtest import BacktestConfig, run_backtest
+from kalshi.risk import RiskCaps
+
+
+def _cfg(**overrides):
+    caps = RiskCaps(
+        edge_threshold=0.03,
+        kelly_fraction=0.25,
+        bankroll_cents=100_000,
+        min_price_cents=15,
+        max_price_cents=90,
+        draw_min_edge=0.10,
+        no_sharp_edge_threshold=0.10,
+        per_bet_cap_frac=0.10,
+    )
+    defaults = dict(
+        leagues=["EPL"], start_date="2026-01-01", end_date="2026-01-31",
+        bankroll_cents=100_000, caps=caps, sharp_weight=0.7, devig_method="power",
+        fee_rate=0.07, decision_offsets_sec=(-100,),
+    )
+    defaults.update(overrides)
+    return BacktestConfig(**defaults)
+
+
+class FakeDataProvider:
+    """No network — canned fixtures/score/candles/odds/tickers, mirroring the
+    real BacktestDataProvider's public surface run_backtest depends on."""
+
+    def __init__(self):
+        self.api_calls = 3
+        self.cache_hits = 5
+        self._fixtures = [
+            {"fixture_id": "f1", "league": "EPL", "home": "Team A", "away": "Team B",
+             "kickoff_ts": 1000},
+            {"fixture_id": "f2", "league": "EPL", "home": "Team C", "away": "Team D",
+             "kickoff_ts": 500},
+            {"fixture_id": "f3", "league": "EPL", "home": "Team E", "away": "Team F",
+             "kickoff_ts": 2000},
+        ]
+        self._scores = {"f1": "home", "f2": None, "f3": "home"}
+        self._tickers = {
+            "f1": {"home": "TICK-F1-HOME"},
+            "f2": {"home": "TICK-F2-HOME"},
+            "f3": {},  # unmatched
+        }
+        self._candles = {
+            "TICK-F1-HOME": [{"end_period_ts": 900, "yes_ask": {"close_dollars": 0.40}}],
+        }
+        self._odds = {
+            "f1": [{"ts": 800, "home": 2.0, "draw": 3.4, "away": 4.0}],
+            "f2": [],
+            "f3": [],
+        }
+
+    def fixtures(self, leagues, start_date, end_date):
+        return list(self._fixtures)
+
+    def final_score(self, fx):
+        return self._scores[fx["fixture_id"]]
+
+    def kalshi_tickers(self, fx):
+        return dict(self._tickers[fx["fixture_id"]])
+
+    def candles(self, ticker):
+        return list(self._candles.get(ticker, []))
+
+    def sharp_odds(self, fx):
+        return list(self._odds.get(fx["fixture_id"], []))
+
+
+def _fake_model_fn(fx):
+    return {"home": 0.55, "draw": 0.25, "away": 0.20}
+
+
+def test_bettable_fixture_produces_a_winning_bet():
+    cfg = _cfg()
+    data = FakeDataProvider()
+    result = run_backtest(cfg, data, _fake_model_fn)
+    assert result.n_bets >= 1
+    assert result.pnl_cents > 0
+    # the unsettled (f2) and unmatched (f3) fixtures contributed no trades
+    assert all(t.fixture_id == "f1" for t in result.trades)
+
+
+def test_unsettled_fixture_is_skipped():
+    cfg = _cfg()
+    data = FakeDataProvider()
+    result = run_backtest(cfg, data, _fake_model_fn)
+    fixture_ids = {t.fixture_id for t in result.trades}
+    assert "f2" not in fixture_ids
+
+
+def test_unmatched_fixture_is_skipped():
+    cfg = _cfg()
+    data = FakeDataProvider()
+    result = run_backtest(cfg, data, _fake_model_fn)
+    fixture_ids = {t.fixture_id for t in result.trades}
+    assert "f3" not in fixture_ids
+
+
+def test_progress_cb_reaches_one():
+    cfg = _cfg()
+    data = FakeDataProvider()
+    fracs = []
+    run_backtest(cfg, data, _fake_model_fn, progress_cb=fracs.append)
+    assert fracs, "progress_cb was never called"
+    assert fracs[-1] == 1.0
+    assert all(0.0 < f <= 1.0 for f in fracs)
+
+
+def test_api_calls_and_cache_hits_surfaced_into_result_summary():
+    cfg = _cfg()
+    data = FakeDataProvider()
+    result = run_backtest(cfg, data, _fake_model_fn)
+    assert result.summary["api_calls"] == data.api_calls
+    assert result.summary["cache_hits"] == data.cache_hits
+
+
+def test_no_fixtures_returns_empty_result_without_progress_div_by_zero():
+    class EmptyData(FakeDataProvider):
+        def fixtures(self, leagues, start_date, end_date):
+            return []
+    cfg = _cfg()
+    fracs = []
+    result = run_backtest(cfg, EmptyData(), _fake_model_fn, progress_cb=fracs.append)
+    assert result.n_bets == 0
+    assert result.trades == []

--- a/backend/tests/test_kalshi_backtest_run.py
+++ b/backend/tests/test_kalshi_backtest_run.py
@@ -67,7 +67,7 @@ class FakeDataProvider:
     def kalshi_tickers(self, fx):
         return dict(self._tickers[fx["fixture_id"]])
 
-    def candles(self, ticker):
+    def candles(self, ticker, start_ts=0, end_ts=4102444800):
         return list(self._candles.get(ticker, []))
 
     def sharp_odds(self, fx):

--- a/backend/tests/test_kalshi_backtest_settle.py
+++ b/backend/tests/test_kalshi_backtest_settle.py
@@ -1,33 +1,50 @@
 """Tests for backtest.settle() + backtest.aggregate() — Task 7 of the Kalshi
-backtest replay engine. settle() follows reconcile.reconcile_position's
-settlement math (single-fill position, so the cost-weighted-average path
-collapses to the plain formula): win -> (100-entry)*size - fee;
-loss -> -entry*size."""
+backtest replay engine. settle() delegates to reconcile.reconcile_position
+for settlement math (single-fill position, so the cost-weighted-average path
+collapses to the plain formula). Kalshi charges the trading fee AT EXECUTION
+regardless of outcome, so the fee applies on BOTH branches:
+win -> (100-entry)*size - fee; loss -> -entry*size - fee."""
 from kalshi.backtest import SizedBet, Trade, aggregate, settle
-from kalshi.fees import fee_cents_for_order
+from kalshi.reconcile import _fee_cents, reconcile_position
 
 
-def _bet(entry_cents=45, size=10, side="home", fused_fair=0.60):
+def _bet(entry_cents=45, size=10, side="home", fused_fair=0.60, league="", kickoff=""):
     return SizedBet(
         side=side, market_ticker="KX-HOME", entry_cents=entry_cents, size=size,
         model_prob=0.55, sharp_prob=0.50, fused_fair=fused_fair, edge=0.05,
+        league=league, kickoff=kickoff,
     )
 
 
 def test_settle_win_math():
     bet = _bet(entry_cents=45, size=10)
-    fee = fee_cents_for_order(45, 10, 0.07)
+    fee = _fee_cents(10, 45, 0.07)
     trade = settle(bet, "home", fee_rate=0.07)
     assert isinstance(trade, Trade)
     assert trade.outcome == "win"
     assert trade.realized_pnl_cents == (100 - 45) * 10 - fee
+    # win-branch fee must match reconcile_position's own fee exactly.
+    reconciled_win = reconcile_position(
+        {"market_ticker": "KX-HOME", "contracts": 10, "avg_entry_cents": 45},
+        result="yes", fee_rate=0.07,
+    )
+    assert trade.realized_pnl_cents == reconciled_win["realized_pnl_cents"]
 
 
 def test_settle_loss_math():
     bet = _bet(entry_cents=45, size=10)
+    fee = _fee_cents(10, 45, 0.07)
     trade = settle(bet, "away", fee_rate=0.07)
     assert trade.outcome == "loss"
-    assert trade.realized_pnl_cents == -450
+    # Kalshi charges the fee on losses too (charged at execution, not at
+    # settlement) — this is the Finding 1 fix: -entry*size - fee, not -450.
+    assert trade.realized_pnl_cents == -450 - fee
+    assert fee > 0
+    reconciled_loss = reconcile_position(
+        {"market_ticker": "KX-HOME", "contracts": 10, "avg_entry_cents": 45},
+        result="no", fee_rate=0.07,
+    )
+    assert trade.realized_pnl_cents == reconciled_loss["realized_pnl_cents"]
 
 
 def test_aggregate_pnl_winrate_equity_curve():
@@ -58,6 +75,38 @@ def test_aggregate_calibration_buckets_predicted_vs_actual():
     assert bucket["n"] == 2
     assert bucket["actual_rate"] == 0.5
     assert abs(bucket["predicted_avg"] - 0.85) < 1e-9
+
+
+def test_settle_copies_league_and_kickoff_onto_trade():
+    bet = _bet(entry_cents=45, size=10, league="EPL", kickoff=1735689600)
+    trade = settle(bet, "home", fee_rate=0.07)
+    assert trade.league == "EPL"
+    assert trade.kickoff == 1735689600
+
+
+def test_aggregate_per_league_buckets_by_real_league_and_equity_orders_by_kickoff():
+    # Two leagues, interleaved so kickoff order != insertion order matters.
+    epl_bet = _bet(entry_cents=40, size=10, side="home", league="EPL", kickoff=200)
+    laliga_bet = _bet(entry_cents=60, size=10, side="away", league="LaLiga", kickoff=100)
+    epl_trade = settle(epl_bet, "home", fee_rate=0.0)   # win
+    laliga_trade = settle(laliga_bet, "home", fee_rate=0.0)  # loss (result != side)
+
+    # Caller (run_backtest) is responsible for kickoff ordering before calling
+    # aggregate(); simulate that by sorting trades by kickoff here.
+    trades = sorted([epl_trade, laliga_trade], key=lambda t: t.kickoff)
+    result = aggregate(trades, bankroll_cents=100_000)
+
+    assert set(result.per_league.keys()) == {"EPL", "LaLiga"}
+    assert "unknown" not in result.per_league
+    assert result.per_league["EPL"]["n_bets"] == 1
+    assert result.per_league["EPL"]["wins"] == 1
+    assert result.per_league["LaLiga"]["n_bets"] == 1
+    assert result.per_league["LaLiga"]["wins"] == 0
+
+    # equity curve follows the kickoff-sorted order: laliga (kickoff=100, loss
+    # -600) settles before epl (kickoff=200, win +600).
+    assert result.equity_curve == [laliga_trade.realized_pnl_cents,
+                                   laliga_trade.realized_pnl_cents + epl_trade.realized_pnl_cents]
 
 
 def test_aggregate_empty_trades():

--- a/backend/tests/test_kalshi_backtest_settle.py
+++ b/backend/tests/test_kalshi_backtest_settle.py
@@ -1,0 +1,69 @@
+"""Tests for backtest.settle() + backtest.aggregate() — Task 7 of the Kalshi
+backtest replay engine. settle() follows reconcile.reconcile_position's
+settlement math (single-fill position, so the cost-weighted-average path
+collapses to the plain formula): win -> (100-entry)*size - fee;
+loss -> -entry*size."""
+from kalshi.backtest import SizedBet, Trade, aggregate, settle
+from kalshi.fees import fee_cents_for_order
+
+
+def _bet(entry_cents=45, size=10, side="home", fused_fair=0.60):
+    return SizedBet(
+        side=side, market_ticker="KX-HOME", entry_cents=entry_cents, size=size,
+        model_prob=0.55, sharp_prob=0.50, fused_fair=fused_fair, edge=0.05,
+    )
+
+
+def test_settle_win_math():
+    bet = _bet(entry_cents=45, size=10)
+    fee = fee_cents_for_order(45, 10, 0.07)
+    trade = settle(bet, "home", fee_rate=0.07)
+    assert isinstance(trade, Trade)
+    assert trade.outcome == "win"
+    assert trade.realized_pnl_cents == (100 - 45) * 10 - fee
+
+
+def test_settle_loss_math():
+    bet = _bet(entry_cents=45, size=10)
+    trade = settle(bet, "away", fee_rate=0.07)
+    assert trade.outcome == "loss"
+    assert trade.realized_pnl_cents == -450
+
+
+def test_aggregate_pnl_winrate_equity_curve():
+    win_bet = _bet(entry_cents=45, size=10, side="home")
+    loss_bet = _bet(entry_cents=45, size=10, side="home")
+    win_trade = settle(win_bet, "home", fee_rate=0.07)
+    loss_trade = settle(loss_bet, "away", fee_rate=0.07)
+    # Force exact figures per the brief's worked example (win 550, loss -450 —
+    # i.e. the zero-fee case) so aggregate()'s arithmetic is checked precisely.
+    win_trade = Trade(**{**win_trade.__dict__, "realized_pnl_cents": 550})
+    loss_trade = Trade(**{**loss_trade.__dict__, "realized_pnl_cents": -450})
+
+    result = aggregate([win_trade, loss_trade], bankroll_cents=100_000)
+    assert result.pnl_cents == 100
+    assert result.n_bets == 2
+    assert result.win_rate == 0.5
+    assert result.equity_curve == [550, 100]
+    assert result.roi == 100 / 100_000
+    assert isinstance(result.calibration, list)
+
+
+def test_aggregate_calibration_buckets_predicted_vs_actual():
+    high_conf_win = settle(_bet(entry_cents=80, size=5, fused_fair=0.85), "home", fee_rate=0.0)
+    high_conf_loss = settle(_bet(entry_cents=80, size=5, fused_fair=0.85), "away", fee_rate=0.0)
+    result = aggregate([high_conf_win, high_conf_loss], bankroll_cents=100_000)
+    assert len(result.calibration) == 1
+    bucket = result.calibration[0]
+    assert bucket["n"] == 2
+    assert bucket["actual_rate"] == 0.5
+    assert abs(bucket["predicted_avg"] - 0.85) < 1e-9
+
+
+def test_aggregate_empty_trades():
+    result = aggregate([], bankroll_cents=100_000)
+    assert result.pnl_cents == 0
+    assert result.n_bets == 0
+    assert result.win_rate == 0.0
+    assert result.equity_curve == []
+    assert result.calibration == []

--- a/backend/tests/test_kalshi_backtest_ticker_match.py
+++ b/backend/tests/test_kalshi_backtest_ticker_match.py
@@ -1,0 +1,78 @@
+"""Tests for BacktestDataProvider.kalshi_tickers — fixture -> Kalshi ticker
+resolution, reusing ticker_names parsing + odds_api's fuzzy-uniqueness match."""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from kalshi.backtest_data import BacktestDataProvider
+
+
+class FakeKalshiClient:
+    def __init__(self, market_lists):
+        # market_lists: {(series_ticker, status): {"markets": [...]}}
+        self.market_lists = market_lists
+
+    def list_markets(self, *, status="open", series_ticker=None, limit=200, cursor=None):
+        return self.market_lists.get((series_ticker, status), {"markets": []})
+
+
+_ENG_COD_MARKETS = {"markets": [
+    {"ticker": "KXWCGAME-26JUL01ENGCOD-ENG"},
+    {"ticker": "KXWCGAME-26JUL01ENGCOD-COD"},
+    {"ticker": "KXWCGAME-26JUL01ENGCOD-TIE"},
+]}
+
+
+def test_kalshi_tickers_resolves_three_sides():
+    kc = FakeKalshiClient({("KXWCGAME", "open"): _ENG_COD_MARKETS})
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    fx = {"home": "England", "away": "DR Congo"}
+    out = provider.kalshi_tickers(fx)
+    assert out == {
+        "home": "KXWCGAME-26JUL01ENGCOD-ENG",
+        "away": "KXWCGAME-26JUL01ENGCOD-COD",
+        "draw": "KXWCGAME-26JUL01ENGCOD-TIE",
+    }
+
+
+def test_kalshi_tickers_name_variant_still_matches():
+    kc = FakeKalshiClient({("KXWCGAME", "open"): _ENG_COD_MARKETS})
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    fx = {"home": "England", "away": "Congo DR"}   # variant spelling
+    out = provider.kalshi_tickers(fx)
+    assert out["home"] == "KXWCGAME-26JUL01ENGCOD-ENG"
+    assert out["away"] == "KXWCGAME-26JUL01ENGCOD-COD"
+
+
+def test_kalshi_tickers_unmatched_fixture_returns_empty_and_logs(caplog):
+    kc = FakeKalshiClient({("KXWCGAME", "open"): _ENG_COD_MARKETS})
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    fx = {"home": "Brazil", "away": "France"}   # no such Kalshi event
+    with caplog.at_level("WARNING"):
+        out = provider.kalshi_tickers(fx)
+    assert out == {}
+    assert any("kalshi_tickers" in r.message or "unmatched" in r.message.lower()
+               for r in caplog.records)
+
+
+def test_kalshi_tickers_no_client_returns_empty():
+    provider = BacktestDataProvider(kalshi_client=None, tables={})
+    assert provider.kalshi_tickers({"home": "England", "away": "DR Congo"}) == {}
+
+
+def test_kalshi_tickers_ambiguous_two_similar_events_returns_empty():
+    # Two events both partially resembling the fixture -> unique-match safety
+    # must refuse rather than guess.
+    markets = {"markets": [
+        {"ticker": "KXWCGAME-26JUL01GUIESP-GUI"},
+        {"ticker": "KXWCGAME-26JUL01GUIESP-ESP"},
+        {"ticker": "KXWCGAME-26JUL01GUIESP-TIE"},
+    ]}
+    kc = FakeKalshiClient({("KXWCGAME", "open"): markets})
+    provider = BacktestDataProvider(kalshi_client=kc, tables={})
+    # Requesting a fixture whose away team ("Brazil") matches nothing -> safe miss.
+    out = provider.kalshi_tickers({"home": "Guinea", "away": "Brazil"})
+    assert out == {}

--- a/backend/tests/test_kalshi_backtest_worker.py
+++ b/backend/tests/test_kalshi_backtest_worker.py
@@ -1,0 +1,79 @@
+"""run_job orchestration tests — fake store + stubbed replay (no DB/network)."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi.backtest_worker import run_job
+from kalshi.backtest import BacktestResult
+
+
+class FakeStore:
+    def __init__(self, run_flag=True):
+        self.updates = []      # list of kwargs dicts
+        self.saved = None
+        self.run_flag = run_flag
+
+    def update_backtest_progress(self, conn, jid, **kw):
+        self.updates.append(kw)
+
+    def save_backtest_result(self, conn, jid, result):
+        self.saved = result
+
+    def get_backtest(self, conn, jid):
+        return {"id": jid, "run": self.run_flag}
+
+    def statuses(self):
+        return [u["status"] for u in self.updates if "status" in u]
+
+
+def _result():
+    r = BacktestResult(pnl_cents=550, roi=0.1, n_bets=1, win_rate=1.0, clv_avg=0.02,
+                       equity_curve=[], per_league={}, calibration=[], trades=[])
+    r.summary = {"api_calls": 3, "cache_hits": 0}
+    return r
+
+
+def test_run_job_finished_saves_result_and_summary():
+    store = FakeStore()
+    job = {"id": "b1", "config": {"leagues": ["World Cup"], "bankroll_cents": 5400}}
+
+    def fake_run(cfg, provider, model_fn, progress_cb=None):
+        progress_cb(0.5); progress_cb(1.0)
+        return _result()
+
+    status = run_job(job, conn=None, provider=object(), model_fn=object(),
+                     store=store, run_fn=fake_run)
+    assert status == "finished"
+    assert store.statuses() == ["running", "finished"]
+    assert store.saved.pnl_cents == 550
+    final = [u for u in store.updates if u.get("status") == "finished"][0]
+    assert final["progress"] == 100.0
+    assert final["summary"]["pnl_cents"] == 550 and final["summary"]["api_calls"] == 3
+
+
+def test_run_job_stopped_when_run_flag_cleared():
+    store = FakeStore(run_flag=False)   # stop_check() -> True on first progress
+    job = {"id": "b2", "config": {}}
+
+    def fake_run(cfg, provider, model_fn, progress_cb=None):
+        progress_cb(0.1)   # should raise _Stopped inside
+        return _result()   # never reached
+
+    status = run_job(job, conn=None, provider=object(), model_fn=object(),
+                     store=store, run_fn=fake_run)
+    assert status == "stopped"
+    assert "stopped" in store.statuses()
+    assert store.saved is None
+
+
+def test_run_job_error_records_message():
+    store = FakeStore()
+    job = {"id": "b3", "config": {}}
+
+    def fake_run(cfg, provider, model_fn, progress_cb=None):
+        raise ValueError("boom")
+
+    status = run_job(job, conn=None, provider=object(), model_fn=object(),
+                     store=store, run_fn=fake_run)
+    assert status == "error"
+    err = [u for u in store.updates if u.get("status") == "error"][0]
+    assert "boom" in err["error"]

--- a/backend/tests/test_kalshi_client_candlesticks.py
+++ b/backend/tests/test_kalshi_client_candlesticks.py
@@ -1,0 +1,73 @@
+"""Tests for Kalshi candlesticks parsing (public data, no auth required)."""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from kalshi.client import parse_candlesticks, yes_ask_close_at, KalshiClient
+
+RAW = {"candlesticks": [
+    {"end_period_ts": 1000, "yes_bid": {"close_dollars": "0.40"}, "yes_ask": {"close_dollars": "0.44"}, "price": {}, "volume_fp": "5.00", "open_interest_fp": "10.00"},
+    {"end_period_ts": 2000, "yes_bid": {"close_dollars": "0.46"}, "yes_ask": {"close_dollars": "0.50"}, "price": {"close_dollars": "0.48"}, "volume_fp": "3.00", "open_interest_fp": "12.00"},
+]}
+
+
+def test_parse_candlesticks_extracts_rows():
+    rows = parse_candlesticks(RAW)
+    assert len(rows) == 2 and rows[0]["end_period_ts"] == 1000
+
+
+def test_yes_ask_close_at_returns_cents_of_last_on_or_before():
+    rows = parse_candlesticks(RAW)
+    assert yes_ask_close_at(rows, 1500) == 44   # 0.44 dollars -> 44c, last <= 1500
+    assert yes_ask_close_at(rows, 2500) == 50
+    assert yes_ask_close_at(rows, 500) is None   # nothing before
+
+
+def test_yes_ask_close_at_handles_missing_book():
+    assert yes_ask_close_at([{"end_period_ts": 1, "yes_ask": {}}], 5) is None
+
+
+def test_parse_candlesticks_empty_is_safe():
+    assert parse_candlesticks({}) == []
+
+
+def test_get_candlesticks_fetches_and_parses():
+    """Fake session test: verify URL, params, parsing."""
+    class FakeResp:
+        content = b'{"candlesticks": [...]}'
+        def json(self):
+            return RAW
+        def raise_for_status(self):
+            pass
+
+    class FakeSession:
+        def __init__(self):
+            self.last_call = None
+        def request(self, method, url, headers=None, params=None, timeout=None):
+            self.last_call = (method, url, headers, params)
+            return FakeResp()
+
+    session = FakeSession()
+    client = KalshiClient(
+        key_id="test",
+        private_key_pem="test",
+        session=session,
+    )
+
+    result = client.get_candlesticks("KXWCGAME-26JUN30MEXECU", 1000, 2000, period_interval=60)
+
+    # Verify URL and params
+    method, url, headers, params = session.last_call
+    assert method == "GET"
+    assert "external-api.kalshi.com" in url
+    assert "/series/KXWCGAME/" in url  # series derived from ticker
+    assert "KXWCGAME-26JUN30MEXECU" in url  # ticker in URL
+    assert params == {"start_ts": 1000, "end_ts": 2000, "period_interval": 60}
+    assert headers["User-Agent"] == "Mozilla/5.0 AppleWebKit/537.36 Chrome/126"
+
+    # Verify parsing
+    assert len(result) == 2
+    assert result[0]["end_period_ts"] == 1000

--- a/backend/tests/test_kalshi_client_candlesticks.py
+++ b/backend/tests/test_kalshi_client_candlesticks.py
@@ -30,6 +30,15 @@ def test_yes_ask_close_at_handles_missing_book():
     assert yes_ask_close_at([{"end_period_ts": 1, "yes_ask": {}}], 5) is None
 
 
+def test_yes_ask_close_at_robust_to_unsorted_input():
+    """Candles out of order must still pick the max end_period_ts <= ts, not
+    whichever comes last in iteration order."""
+    unsorted_rows = list(reversed(parse_candlesticks(RAW)))  # [2000, 1000]
+    assert yes_ask_close_at(unsorted_rows, 1500) == 44
+    assert yes_ask_close_at(unsorted_rows, 2500) == 50
+    assert yes_ask_close_at(unsorted_rows, 500) is None
+
+
 def test_parse_candlesticks_empty_is_safe():
     assert parse_candlesticks({}) == []
 

--- a/backend/tests/test_kalshi_client_settled.py
+++ b/backend/tests/test_kalshi_client_settled.py
@@ -1,0 +1,116 @@
+"""Tests for Kalshi settled markets (public data, no auth required)."""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from kalshi.client import result_side_from_markets, KalshiClient
+
+
+def test_result_side_from_markets_maps_yes_side_to_home():
+    """Fixture MEX (home) vs ECU (away). -MEX suffix resolves yes -> 'home'."""
+    markets = [
+        {"ticker": "KXWCGAME-26JUN30MEXECU-MEX", "result": "yes"},   # home wins
+        {"ticker": "KXWCGAME-26JUN30MEXECU-ECU", "result": "no"},    # away loses
+        {"ticker": "KXWCGAME-26JUN30MEXECU-TIE", "result": "no"},    # draw loses
+    ]
+    assert result_side_from_markets(markets, "KXWCGAME-26JUN30MEXECU") == "home"
+
+
+def test_result_side_from_markets_maps_away_side():
+    """Fixture MEX (home) vs ECU (away). -ECU suffix resolves yes -> 'away'."""
+    markets = [
+        {"ticker": "KXWCGAME-26JUN30MEXECU-MEX", "result": "no"},
+        {"ticker": "KXWCGAME-26JUN30MEXECU-ECU", "result": "yes"},   # away wins
+        {"ticker": "KXWCGAME-26JUN30MEXECU-TIE", "result": "no"},
+    ]
+    assert result_side_from_markets(markets, "KXWCGAME-26JUN30MEXECU") == "away"
+
+
+def test_result_side_from_markets_maps_tie_side():
+    """Fixture MEX vs ECU. -TIE suffix resolves yes -> 'draw'."""
+    markets = [
+        {"ticker": "KXWCGAME-26JUN30MEXECU-MEX", "result": "no"},
+        {"ticker": "KXWCGAME-26JUN30MEXECU-ECU", "result": "no"},
+        {"ticker": "KXWCGAME-26JUN30MEXECU-TIE", "result": "yes"},   # draw happens
+    ]
+    assert result_side_from_markets(markets, "KXWCGAME-26JUN30MEXECU") == "draw"
+
+
+def test_result_side_from_markets_returns_none_if_no_yes():
+    """No yes result found."""
+    markets = [
+        {"ticker": "KXWCGAME-26JUN30MEXECU-MEX", "result": "no"},
+        {"ticker": "KXWCGAME-26JUN30MEXECU-ECU", "result": "no"},
+        {"ticker": "KXWCGAME-26JUN30MEXECU-TIE", "result": "no"},
+    ]
+    assert result_side_from_markets(markets, "KXWCGAME-26JUN30MEXECU") is None
+
+
+def test_result_side_from_markets_returns_none_if_empty():
+    """Empty markets list."""
+    assert result_side_from_markets([], "KXWCGAME-26JUN30MEXECU") is None
+
+
+def test_list_settled_markets_fetches_and_paginates():
+    """Fake session test: verify URL, params, pagination via cursor."""
+    class FakeResp:
+        def __init__(self, markets, cursor=None):
+            self._markets = markets
+            self._cursor = cursor
+            self.content = b"..."
+
+        def json(self):
+            return {"markets": self._markets, "cursor": self._cursor}
+
+        def raise_for_status(self):
+            pass
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def request(self, method, url, headers=None, params=None, timeout=None):
+            self.calls.append((method, url, params))
+            # First page
+            if not params or not params.get("cursor"):
+                return FakeResp(
+                    [{"ticker": "KXWCGAME-26JUN30MEXECU-MEX", "result": "yes"}],
+                    cursor="page2"
+                )
+            # Second page (final)
+            return FakeResp(
+                [{"ticker": "KXWCGAME-26JUN30MEXECU-ECU", "result": "no"}],
+                cursor=None
+            )
+
+    session = FakeSession()
+    client = KalshiClient(
+        key_id="test",
+        private_key_pem="test",
+        session=session,
+    )
+
+    result = client.list_settled_markets("KXWCGAME", limit=50)
+
+    # Verify pagination
+    assert len(session.calls) == 2
+    assert len(result) == 2  # both pages combined
+
+    # Verify first call URL and params
+    method, url, params = session.calls[0]
+    assert method == "GET"
+    assert "external-api.kalshi.com" in url
+    assert params["series_ticker"] == "KXWCGAME"
+    assert params["status"] == "settled"
+    assert params["limit"] == 50
+
+    # Verify second call includes cursor
+    method, url, params = session.calls[1]
+    assert params["cursor"] == "page2"
+
+    # Verify results are combined
+    assert result[0]["ticker"] == "KXWCGAME-26JUN30MEXECU-MEX"
+    assert result[1]["ticker"] == "KXWCGAME-26JUN30MEXECU-ECU"

--- a/backend/tests/test_kalshi_db.py
+++ b/backend/tests/test_kalshi_db.py
@@ -16,8 +16,20 @@ def test_tables_cover_the_design():
         # v2 intelligence
         "kalshi_decisions", "match_features", "player_stats", "h2h_history",
         "lineups", "kalshi_market_listings", "kalshi_capital_plan",
+        # backtest data layer + jobs
+        "KalshiBacktests", "KalshiBacktestResults", "KalshiHistCandles",
+        "KalshiHistOdds", "KalshiHistFixtures",
     ]:
         assert required in names
+
+
+def test_backtest_tables_have_expected_primary_keys():
+    pk_by_name = dict(KALSHI_TABLES)
+    assert pk_by_name["KalshiBacktests"] == "id"
+    assert pk_by_name["KalshiBacktestResults"] == "id"
+    assert pk_by_name["KalshiHistCandles"] == "id"
+    assert pk_by_name["KalshiHistOdds"] == "id"
+    assert pk_by_name["KalshiHistFixtures"] == "fixture_key"
 
 
 def test_portfolio_snapshot_doc_id_is_scoped():

--- a/backend/tests/test_kalshi_ingest_odds_methods.py
+++ b/backend/tests/test_kalshi_ingest_odds_methods.py
@@ -1,0 +1,148 @@
+"""Tests for OddsPapi fixtures + historical-odds methods & pure parsers."""
+import os
+import sys
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from kalshi.ingest_odds import OddsPapiClient, parse_fixtures, parse_hist_odds
+
+
+# --- parse_fixtures ---
+
+def test_parse_fixtures_settled_home_win_derives_result():
+    raw = {"fixtures": [
+        {"id": 1, "home": "England", "away": "DR Congo", "kickoff_ts": 1780000000,
+         "status": "finished", "home_score": 2, "away_score": 0},
+    ]}
+    out = parse_fixtures(raw)
+    assert len(out) == 1
+    f = out[0]
+    assert f == {
+        "fixture_id": "1", "home": "England", "away": "DR Congo",
+        "kickoff_ts": 1780000000, "home_score": 2, "away_score": 0,
+        "result": "home", "settled": True,
+    }
+
+
+def test_parse_fixtures_settled_away_win_and_draw():
+    raw = {"fixtures": [
+        {"id": 2, "home": "A", "away": "B", "kickoff_ts": 1, "status": "finished",
+         "home_score": 0, "away_score": 1},
+        {"id": 3, "home": "A", "away": "B", "kickoff_ts": 2, "status": "finished",
+         "home_score": 1, "away_score": 1},
+    ]}
+    out = parse_fixtures(raw)
+    assert out[0]["result"] == "away"
+    assert out[1]["result"] == "draw"
+
+
+def test_parse_fixtures_unsettled_has_no_result():
+    raw = {"fixtures": [
+        {"id": 4, "home": "A", "away": "B", "kickoff_ts": 3, "status": "scheduled"},
+    ]}
+    out = parse_fixtures(raw)
+    assert out[0]["settled"] is False
+    assert out[0]["result"] is None
+    assert out[0]["home_score"] is None and out[0]["away_score"] is None
+
+
+def test_parse_fixtures_accepts_iso_kickoff():
+    raw = {"fixtures": [
+        {"id": 5, "home": "A", "away": "B", "kickoff": "2026-07-01T18:00:00Z", "status": "scheduled"},
+    ]}
+    out = parse_fixtures(raw)
+    assert out[0]["kickoff_ts"] == 1782928800
+
+
+def test_parse_fixtures_empty_safe():
+    assert parse_fixtures(None) == []
+    assert parse_fixtures({}) == []
+    assert parse_fixtures({"fixtures": []}) == []
+
+
+# --- parse_hist_odds ---
+
+def test_parse_hist_odds_sorted_by_ts():
+    raw = {"odds": [
+        {"ts": 200, "books": {"pinnacle": {"home": 1.9, "draw": 3.4, "away": 4.1}}},
+        {"ts": 100, "books": {"pinnacle": {"home": 2.0, "draw": 3.5, "away": 4.0}}},
+    ]}
+    out = parse_hist_odds(raw)
+    assert [s["ts"] for s in out] == [100, 200]
+    assert out[0] == {"ts": 100, "home": 2.0, "draw": 3.5, "away": 4.0}
+
+
+def test_parse_hist_odds_falls_back_through_book_priority():
+    raw = {"odds": [
+        {"ts": 100, "books": {"betfair": {"home": 2.1, "draw": 3.6, "away": 3.9}}},
+    ]}
+    out = parse_hist_odds(raw, books=("pinnacle", "betfair"))
+    assert out == [{"ts": 100, "home": 2.1, "draw": 3.6, "away": 3.9}]
+
+
+def test_parse_hist_odds_skips_snapshot_missing_all_requested_books():
+    raw = {"odds": [
+        {"ts": 100, "books": {"onexbet": {"home": 2.1, "draw": 3.6, "away": 3.9}}},
+    ]}
+    assert parse_hist_odds(raw, books=("pinnacle",)) == []
+
+
+def test_parse_hist_odds_empty_safe():
+    assert parse_hist_odds(None) == []
+    assert parse_hist_odds({}) == []
+    assert parse_hist_odds({"odds": []}) == []
+
+
+# --- thin client methods over fetch_raw ---
+
+class FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.content = b"{}"
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self, payload):
+        self._payload = payload
+        self.last_call = None
+
+    def request(self, method, url, params=None, timeout=None):
+        self.last_call = (method, url, params)
+        return FakeResp(self._payload)
+
+
+def test_list_fixtures_calls_fetch_raw_with_expected_params():
+    payload = {"fixtures": [{"id": 9, "home": "A", "away": "B", "kickoff_ts": 5,
+                              "status": "scheduled"}]}
+    sess = FakeSession(payload)
+    client = OddsPapiClient(api_key="KEY", session=sess)
+    out = client.list_fixtures(sport_id=1, date_from="2026-07-01", date_to="2026-07-02")
+    method, url, params = sess.last_call
+    assert method == "GET"
+    assert url.endswith("/fixtures")
+    assert params["sport_id"] == 1
+    assert params["date_from"] == "2026-07-01"
+    assert params["date_to"] == "2026-07-02"
+    assert params["apiKey"] == "KEY"
+    assert out[0]["fixture_id"] == "9"
+
+
+def test_historical_odds_calls_fetch_raw_with_expected_params():
+    payload = {"odds": [{"ts": 100, "books": {"pinnacle": {"home": 2.0, "draw": 3.5, "away": 4.0}}}]}
+    sess = FakeSession(payload)
+    client = OddsPapiClient(api_key="KEY", session=sess)
+    out = client.historical_odds(fixture_id=9, books=("pinnacle",))
+    method, url, params = sess.last_call
+    assert method == "GET"
+    assert url.endswith("/historical-odds")
+    assert params["fixture_id"] == 9
+    assert params["apiKey"] == "KEY"
+    assert out == [{"ts": 100, "home": 2.0, "draw": 3.5, "away": 4.0}]

--- a/docs/superpowers/plans/2026-07-01-kalshi-backtest.md
+++ b/docs/superpowers/plans/2026-07-01-kalshi-backtest.md
@@ -1,0 +1,352 @@
+# Kalshi Soccer Backtest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a historical backtest feature to the Kalshi soccer bot (backend replay + web + mobile UI) that replays real Kalshi prices vs real Pinnacle sharp lines over a user-chosen league/date range with tunable settings, caching all immutable historical data.
+
+**Architecture:** A pure `run_backtest` core replays per-fixture pre-match decisions by calling the SAME engine functions the live bot uses (fusion/edge/candidates/risk/planner/reconcile). A `BacktestDataProvider` fetches-or-caches fixtures, scores, public Kalshi candlesticks, and OddsPapi historical odds into persistent RethinkDB tables. A lightweight in-process worker runs queued jobs; web+mobile mirror the existing stock-backtest UX and poll for progress.
+
+**Tech Stack:** Python 3 / FastAPI / RethinkDB (backend), Vue 3 + ApexCharts (web), Flutter + Riverpod + syncfusion charts (mobile). Data: Kalshi public `/historical/.../candlesticks`, OddsPapi free tier.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-01-kalshi-backtest-design.md`.
+- **Caching is mandatory:** immutable historical data (settled fixtures' scores, candles, odds) is fetched once and never re-fetched; re-running a backtest over the same fixtures must cost **0 API calls**. Only uncached/unsettled fixtures hit the network.
+- OddsPapi free tier: ~250 req/mo, key is a **query param** (`apiKey`), reuse the existing budget guard (`ingest_odds.should_scan`/`fixtures_per_day_budget`, `db.bump_scan_budget`). Never overspend silently — log skips.
+- Kalshi historical candlesticks endpoint is **public (no auth)**: `GET {base}/trade-api/v2/historical/markets/{ticker}/candlesticks?start_ts&end_ts&period_interval`.
+- DB name `IntelliStock`; new tables via the idempotent `ensure_tables` idiom in `backend/kalshi/db.py`.
+- Reuse engine pure functions — do NOT reimplement pricing/edge/sizing/settlement.
+- Tests: pytest for backend (no network in unit tests — inject a fake data provider); local test stubs need `python3` + a stubbed `socketio` (per existing kalshi test setup). `flutter analyze` clean; web build passes.
+- National-team Elo is current-only → label model-only metrics "indicative".
+- New config field `oddspapi_api_key` alongside `odds_api_key`.
+- Backtest instance id (RethinkDB `Instances`) full form is `032f0c62-23a6-45a9-ad39-ed60ed13d106`; brokerage `09ba81b2-...`.
+- Commit after every green step. Branch: `feat/kalshi-backtest`.
+
+---
+
+## Phase 0 — Confirm live response schemas (spike, no production code)
+
+### Task 0: Probe Kalshi candlesticks + OddsPapi schemas
+**Files:** Create `scratchpad/probe_backtest_sources.py` (throwaway; not committed).
+**Interfaces:** Produces the confirmed JSON shapes for (a) Kalshi historical candlesticks, (b) OddsPapi `/v4/fixtures`, (c) OddsPapi `/v4/historical-odds`. These shapes are pasted into Tasks 1 & 3 as the parsing contract.
+
+- [ ] **Step 1:** Pull the OddsPapi key location: there is none yet — the probe uses a key from env `ODDSPAPI_API_KEY` (ask user to export, or skip OddsPapi probe if absent and rely on documented shape). Kalshi candlesticks need no key.
+- [ ] **Step 2:** Fetch one settled WC market's candlesticks: `GET https://api.elections.kalshi.com/trade-api/v2/historical/markets/{ticker}/candlesticks?start_ts=..&end_ts=..&period_interval=60` (try base `https://api.elections.kalshi.com` and `https://trading-api.kalshi.com`; confirm which the repo's `client.py` uses). Record the JSON: `{candlesticks:[{end_period_ts, yes_bid:{open,high,low,close}, yes_ask:{...}, price:{...}, volume, open_interest}]}`.
+- [ ] **Step 3:** If `ODDSPAPI_API_KEY` present: `GET https://api.oddspapi.io/v4/fixtures?sportId=10&from=..&to=..&apiKey=..` and `/v4/historical-odds?fixtureId=..&bookmakers=pinnacle&apiKey=..`. Record fixture fields (id, home, away, kickoff, score/result) and historical-odds shape (snapshots with ts + 3-way prices).
+- [ ] **Step 4:** Write the two confirmed shapes as comments into `backend/kalshi/client.py` (candlesticks) and `backend/kalshi/ingest_odds.py` (OddsPapi) near the new methods. No commit needed for the throwaway script.
+
+> If OddsPapi key is unavailable at build time, implement against the documented shape (spec §2) behind the normalized `parse_three_way` contract and mark the integration test `@pytest.mark.skipif` on missing key.
+
+---
+
+## Phase A — Backend data layer
+
+### Task 1: Kalshi historical candlesticks client method
+**Files:**
+- Modify: `backend/kalshi/client.py` (add method to the client class)
+- Test: `backend/tests/kalshi/test_client_candlesticks.py`
+
+**Interfaces:**
+- Produces: `KalshiClient.get_historical_candlesticks(ticker: str, start_ts: int, end_ts: int, period_interval: int = 60) -> list[dict]` returning a list of candlestick dicts each with keys `end_period_ts:int, yes_bid:dict, yes_ask:dict, price:dict, volume, open_interest`. Also a pure helper `parse_candlesticks(payload: dict) -> list[dict]` and `yes_ask_close_at(candles: list[dict], ts: int) -> int|None` (last candle with `end_period_ts <= ts`, returns `yes_ask['close']` in cents).
+
+- [ ] **Step 1: Write failing test** for the pure helpers (no network):
+
+```python
+# backend/tests/kalshi/test_client_candlesticks.py
+from kalshi.client import parse_candlesticks, yes_ask_close_at
+
+RAW = {"candlesticks": [
+    {"end_period_ts": 1000, "yes_bid": {"close": 40}, "yes_ask": {"close": 44}, "price": {"close": 42}, "volume": "5", "open_interest": "10"},
+    {"end_period_ts": 2000, "yes_bid": {"close": 46}, "yes_ask": {"close": 50}, "price": {"close": 48}, "volume": "3", "open_interest": "12"},
+]}
+
+def test_parse_candlesticks_extracts_rows():
+    rows = parse_candlesticks(RAW)
+    assert len(rows) == 2 and rows[0]["end_period_ts"] == 1000
+
+def test_yes_ask_close_at_returns_last_on_or_before():
+    rows = parse_candlesticks(RAW)
+    assert yes_ask_close_at(rows, 1500) == 44   # last <= 1500 is the 1000 candle
+    assert yes_ask_close_at(rows, 2500) == 50
+    assert yes_ask_close_at(rows, 500) is None   # nothing before
+
+def test_parse_candlesticks_empty_is_safe():
+    assert parse_candlesticks({}) == []
+```
+
+- [ ] **Step 2:** Run `pytest backend/tests/kalshi/test_client_candlesticks.py -v` → FAIL (import error).
+- [ ] **Step 3: Implement** pure helpers + the fetch method in `client.py`:
+
+```python
+def parse_candlesticks(payload: dict) -> list[dict]:
+    return list((payload or {}).get("candlesticks") or [])
+
+def yes_ask_close_at(candles: list[dict], ts: int):
+    best = None
+    for c in candles:
+        if int(c.get("end_period_ts", 0)) <= ts:
+            best = c
+        else:
+            break
+    if best is None:
+        return None
+    return int((best.get("yes_ask") or {}).get("close")) if (best.get("yes_ask") or {}).get("close") is not None else None
+```
+Add to the client class (mirror existing request style in `client.py`; historical endpoint is unauthenticated — plain GET):
+```python
+def get_historical_candlesticks(self, ticker, start_ts, end_ts, period_interval=60):
+    url = f"{self.base_url}/historical/markets/{ticker}/candlesticks"
+    params = {"start_ts": int(start_ts), "end_ts": int(end_ts), "period_interval": int(period_interval)}
+    resp = self._session.get(url, params=params, timeout=20)
+    resp.raise_for_status()
+    return parse_candlesticks(resp.json() if resp.content else {})
+```
+(Confirm `self.base_url`/`self._session` names against the existing client; adapt.)
+
+- [ ] **Step 4:** Run tests → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): historical candlesticks client method + pure price helpers`.
+
+### Task 2: OddsPapi fixtures + historical-odds methods
+**Files:**
+- Modify: `backend/kalshi/ingest_odds.py`
+- Test: `backend/tests/kalshi/test_ingest_odds_methods.py`
+
+**Interfaces:**
+- Produces: `OddsPapiClient.list_fixtures(sport_id: int, date_from: str, date_to: str) -> list[dict]`; `OddsPapiClient.historical_odds(fixture_id, books=("pinnacle",)) -> list[dict]`; pure parsers `parse_fixtures(raw) -> list[{fixture_id, home, away, kickoff_ts, home_score, away_score, result, settled}]` and `parse_hist_odds(raw) -> list[{ts, home, draw, away}]` (decimal odds per snapshot for the chosen book).
+
+- [ ] **Step 1: Write failing tests** for the pure parsers using the Phase 0 confirmed shape (or documented shape). Include: fixtures parse (settled with scores → result derived home/draw/away; unsettled → settled=False, result None), hist odds parse (snapshots sorted by ts), empty-safe.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** parsers + thin methods over `fetch_raw` (already exists). `result` from scores: home if hs>as, away if as>hs, draw if equal; None if score missing.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): OddsPapi fixtures + historical-odds methods & parsers`.
+
+### Task 3: Cache tables + BacktestDataProvider (fetch-or-cache)
+**Files:**
+- Create: `backend/kalshi/backtest_data.py`
+- Modify: `backend/kalshi/db.py` (add 3 cache tables + 2 job tables to `KALSHI_TABLES`)
+- Test: `backend/tests/kalshi/test_backtest_data.py`
+
+**Interfaces:**
+- Produces: `class BacktestDataProvider` with:
+  - `fixtures(leagues, start_date, end_date) -> list[Fixture]`
+  - `final_score(fx) -> str|None` (`home|draw|away`, None if unsettled)
+  - `candles(ticker) -> list[dict]`
+  - `sharp_odds(fx) -> list[dict]`  (snapshots)
+  - `kalshi_tickers(fx) -> dict[str,str]` (side→ticker)
+  - counters: `.api_calls`, `.cache_hits`
+  - Constructor injects `kalshi_client`, `oddspapi_client`, `conn`, `budget_used_getter/bumper` — all optional so tests pass fakes.
+- Consumes: Task 1 & 2 client methods; `db` table names.
+
+- [ ] **Step 1: Write failing tests** (inject FAKE clients + an in-memory dict "table"):
+  - cache miss → calls client once, stores row, `api_calls==1`
+  - second call same key → no client call, `cache_hits==1`, returns stored
+  - fixture with `settled=False` cached → `final_score` re-fetches (may now be settled); once `settled=True` → never re-fetches
+  - OddsPapi budget exhausted (`should_scan` false) → returns cached-or-None, logs skip, does NOT call client
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** the provider. Cache read/write against RethinkDB tables (or the injected fake). Keys per spec §5. Use `db.bump_scan_budget` for OddsPapi calls; guard with `should_scan`. Increment `.api_calls`/`.cache_hits`.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Add tables to `db.KALSHI_TABLES`: `("KalshiBacktests","id")`, `("KalshiBacktestResults","id")`, `("KalshiHistCandles","id")`, `("KalshiHistOdds","id")`, `("KalshiHistFixtures","fixture_key")`. Run `pytest backend/tests/kalshi/ -k db -v`.
+- [ ] **Step 6: Commit** `feat(kalshi): backtest cache tables + fetch-or-cache data provider`.
+
+### Task 4: Fixture ↔ Kalshi ticker resolution
+**Files:**
+- Modify: `backend/kalshi/backtest_data.py` (add `kalshi_tickers`)
+- Test: `backend/tests/kalshi/test_backtest_ticker_match.py`
+
+**Interfaces:**
+- Produces: `kalshi_tickers(fx) -> {"home": ticker, "draw": ticker, "away": ticker}` by matching an OddsPapi fixture to Kalshi market tickers, reusing `data/ticker_names.py` (`parse_market_ticker`, `name_for_code`) and `normalize.py`/`quant.national_elo.canonical_team` for name folding, with the fuzzy-uniqueness safety of `odds_api.match_event`.
+
+- [ ] **Step 1: Write failing test:** given a fake Kalshi market list for `KXWCGAME-26JUL01ENGCOD-*` and an OddsPapi fixture England/DR Congo, resolve the three side tickers; a name variant ("Congo DR"/"DR Congo") still matches; an unmatched fixture returns `{}` and is logged (not guessed).
+- [ ] **Step 2-4:** FAIL → implement (reuse crosswalk + fuzzy) → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): resolve OddsPapi fixture to Kalshi tickers`.
+
+---
+
+## Phase B — Backend replay engine
+
+### Task 5: BacktestConfig + caps builder
+**Files:**
+- Create: `backend/kalshi/backtest.py` (config dataclass + helpers)
+- Test: `backend/tests/kalshi/test_backtest_config.py`
+
+**Interfaces:**
+- Produces: `@dataclass BacktestConfig{ leagues, start_date, end_date, bankroll_cents, caps: RiskCaps, sharp_weight, devig_method, decision_offsets_sec: tuple=( -3*3600,), fee_rate }` and `config_from_body(dict) -> BacktestConfig` reusing `instance_config.risk_caps_from_config`.
+- Consumes: `instance_config`, `risk.RiskCaps`.
+
+- [ ] **Step 1-4 (TDD):** test that `config_from_body` maps the same knobs the live instance uses (edge_threshold, no_sharp_edge_threshold, kelly_fraction, order_size_min/max_cents, max_open_exposure_frac, per_bet_cap_frac, min/max_price_cents, draw_min_edge, sharp_weight, devig_method, bankroll_cents) into a `BacktestConfig`; defaults applied when missing. Implement. PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): backtest config + caps builder`.
+
+### Task 6: Per-fixture evaluate() — reuse fusion/edge/candidates/planner
+**Files:**
+- Modify: `backend/kalshi/backtest.py`
+- Test: `backend/tests/kalshi/test_backtest_evaluate.py`
+
+**Interfaces:**
+- Produces: `evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fixture) -> list[SizedBet]` where `SizedBet{ side, market_ticker, entry_cents, size, model_prob, sharp_prob, fused_fair, edge }`. Internally builds fused probs via `intelligence.fusion.build_market_probs`, generates candidates via `strategy.candidates.generate_candidates`, sizes via `capital.planner.allocate` with `cfg.caps`. `model_probs`/`sharp_probs` are `{side: prob}`; `kalshi_asks` is `{side: cents}`.
+- Consumes: fusion, candidates, planner, edge (all existing).
+
+- [ ] **Step 1: Write failing test:** with a fabricated model (home 0.55), a sharp line (home 0.50 devigged), and Kalshi ask home 45¢, edge>threshold → returns one home SizedBet with size>0; when sharp says 0.44 and ask 45¢ (edge≈0) → returns [] (gated out). A no-sharp case honors `no_sharp_edge_threshold`.
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implement** by wiring the existing functions (match their real signatures — read `orchestrator.py` `plan_and_allocate` for the exact call sequence and replicate the pre-match slice).
+- [ ] **Step 4:** PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): backtest per-fixture evaluate reuses live pricing/sizing`.
+
+### Task 7: settle() + aggregate()
+**Files:**
+- Modify: `backend/kalshi/backtest.py`
+- Test: `backend/tests/kalshi/test_backtest_settle.py`
+
+**Interfaces:**
+- Produces: `settle(bet: SizedBet, result: str, fee_rate) -> Trade{...bet fields, outcome, realized_pnl_cents, clv}` (reuse `reconcile.reconcile_position` semantics: win → (100-entry)*size - fee; loss → -entry*size); `aggregate(trades, bankroll_cents) -> BacktestResult{ pnl_cents, roi, n_bets, win_rate, clv_avg, equity_curve, per_league, calibration, trades }`. Equity curve ordered by fixture kickoff.
+- Consumes: `reconcile`.
+
+- [ ] **Step 1: Write failing test:** a home bet entry 45¢ size 10, result home → pnl = (100-45)*10 - fee; result away → -450. `aggregate` of [win 550, loss -450] → pnl_cents 100, n_bets 2, win_rate 0.5, equity_curve cumulative [550, 100] in kickoff order; calibration buckets predicted vs actual.
+- [ ] **Step 2-4:** FAIL → implement → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): backtest settlement + aggregation (equity/roi/clv/calibration)`.
+
+### Task 8: run_backtest() orchestration
+**Files:**
+- Modify: `backend/kalshi/backtest.py`
+- Test: `backend/tests/kalshi/test_backtest_run.py`
+
+**Interfaces:**
+- Produces: `run_backtest(cfg, data: BacktestDataProvider, model_fn, progress_cb=None) -> BacktestResult`. `model_fn(fx) -> {side: prob}` injected (so tests don't need Elo; production passes an Elo/Dixon-Coles closure). Loops fixtures in kickoff order, skips unsettled (score None) and unmatched (no tickers) fixtures with a logged reason, evaluates at `cfg.decision_offsets_sec` before kickoff using `yes_ask_close_at`+`sharp_at`, settles, calls `progress_cb(frac)`, returns aggregate. One decision snapshot per fixture (first offset that produces candles+odds).
+- Consumes: Tasks 3,6,7 + `client.yes_ask_close_at`.
+
+- [ ] **Step 1: Write failing test** with a fully FAKE data provider (2 fixtures: one bettable win, one gated-out) + fake model_fn → asserts result.n_bets==1, pnl>0, progress_cb called with 1.0, and that a fixture with score None is skipped. Assert `data.api_calls`/`cache_hits` are surfaced into `result.summary`.
+- [ ] **Step 2-4:** FAIL → implement → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): run_backtest orchestration over cached historical data`.
+
+### Task 9: Production model_fn (Elo/Dixon-Coles as-of) + wiring helper
+**Files:**
+- Modify: `backend/kalshi/backtest.py`
+- Test: `backend/tests/kalshi/test_backtest_modelfn.py`
+
+**Interfaces:**
+- Produces: `build_model_fn(nat_elo_table, elo_table) -> (fx -> {side:prob})` reusing `quant`/`intelligence.pricing.model_market_probs` (same path as engine). Documented look-ahead caveat (national elo current-only).
+- [ ] **Step 1-4 (TDD):** test that for a fabricated fixture with known Elos it returns a 3-way summing to 1.0 (reusing the real pricing chain). Implement. PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): production model_fn via live pricing chain (indicative nat-elo)`.
+
+---
+
+## Phase C — Backend API + worker
+
+### Task 10: Job row helpers + doc builders
+**Files:**
+- Modify: `backend/kalshi/db.py` (pure doc builders + thin writers)
+- Test: `backend/tests/kalshi/test_backtest_job_docs.py`
+
+**Interfaces:**
+- Produces: `backtest_job_doc(*, id, brokerage_id, instance_id, name, config, leagues, start_date, end_date, bankroll_cents, created_at) -> dict` (status="pending", run=True, progress=0); `backtest_result_doc(id, result: BacktestResult) -> dict`. Thin writers `create_backtest_job`, `update_backtest_progress`, `save_backtest_result`, `list_backtests`, `get_backtest`, `set_backtest_run`.
+- [ ] **Step 1-4 (TDD)** on pure doc builders (no DB). Implement. PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): backtest job + result doc builders and DB writers`.
+
+### Task 11: Background worker
+**Files:**
+- Create: `backend/kalshi/backtest_worker.py`
+- Test: `backend/tests/kalshi/test_backtest_worker.py`
+
+**Interfaces:**
+- Produces: `run_job(job: dict, *, conn, clients) -> None` (builds cfg+provider+model_fn, runs `run_backtest`, writes progress throttled ≤ every 2%, saves result, sets status finished/error, honors `run==False` → stopped). `start_worker(conn)` — changefeed on `KalshiBacktests` pending + boot drain (mirror `backtest_engine._changefeed_worker`/`_load_initial_queue`), small ThreadPool.
+- [ ] **Step 1: Write failing test** for `run_job` with fakes: a pending job dict + fake provider/model → asserts result saved, status→finished, progress reaches 100; a job with `run=False` mid-flight → status stopped.
+- [ ] **Step 2-4:** FAIL → implement → PASS. (Changefeed/threadpool tested only via `run_job`; the loop is integration.)
+- [ ] **Step 5: Commit** `feat(kalshi): in-process backtest worker (changefeed + drain + stop)`.
+
+### Task 12: FastAPI endpoints + startup hook
+**Files:**
+- Modify: `backend/api/main.py` (routes + `KalshiBacktestBody` model + start worker at startup) — locate the existing Kalshi routes and add alongside.
+- Test: `backend/tests/api/test_kalshi_backtest_endpoints.py` (TestClient, worker disabled / job left pending)
+
+**Interfaces:**
+- Produces routes (spec §7): `POST /brokerages/{bid}/kalshi/backtests`, `GET /brokerages/{bid}/kalshi/backtests`, `GET /kalshi/backtests/{id}/status`, `GET /kalshi/backtests/{id}/results`, `POST /kalshi/backtests/{id}/stop`, `DELETE /kalshi/backtests/{id}`. Body validated by `KalshiBacktestBody`.
+- [ ] **Step 1: Write failing test:** POST creates a pending row (assert 200 + id + row in a fake/real test DB); GET status returns it; stop sets run=False; DELETE removes. Use the existing test-app fixture pattern (find how other endpoint tests build the TestClient + auth + conn dependency override).
+- [ ] **Step 2-4:** FAIL → implement (thin handlers calling Task 10 writers; enqueue only — worker runs async) → PASS.
+- [ ] **Step 5: Commit** `feat(api): kalshi backtest endpoints + worker startup`.
+
+---
+
+## Phase D — Web UI (`frontend/`)
+
+### Task 13: API calls + backtest list/section on Kalshi instance detail
+**Files:**
+- Modify: `frontend/src/views/KalshiInstanceDetailView.vue` (add Backtest section + "New backtest" button in header action group; list past backtests; poll running)
+- (Reuse inline `fetch` + `authHeaders()` idiom.)
+
+**Interfaces:**
+- Consumes endpoints from Task 12. Poll `GET /kalshi/backtests/{id}/status` every 3s while status∈{pending,running} (pattern: `BacktestsView.vue:140-161`), render progress bar (`BacktestsView.vue:385-410`).
+- [ ] **Step 1:** Add data + methods: `loadBacktests()`, `pollRunning()`, `openCreateBacktest()`, `stopBacktest(id)`, `openResults(id)`.
+- [ ] **Step 2:** Add template: a "Backtests" card section (list rows: name, date range, status pill, progress bar, P&L, actions) + header button.
+- [ ] **Step 3:** Manual check: `cd frontend && npm run build` passes; dev server renders the section (empty state ok).
+- [ ] **Step 4: Commit** `feat(web): kalshi backtest list + section on instance detail`.
+
+### Task 14: Create-backtest modal (leagues + tuning + dates)
+**Files:**
+- Create: `frontend/src/components/kalshi/KalshiBacktestModal.vue` (adapt `KalshiCreateInstanceModal.vue`)
+**Interfaces:**
+- Reuse league multi-select (`LEAGUES`/`toggleLeague`), numeric tuning grid + `InfoTip`, native `<input type=date>` range, bankroll. Prefill from the instance config (`GET /instances/{id}/kalshi/detail`). Submit `POST /brokerages/{bid}/kalshi/backtests` then show it in the list / open results.
+- [ ] **Step 1:** Build the modal from a copy of `KalshiCreateInstanceModal.vue`, swap the "create instance" submit for the backtest body ({leagues, start_date, end_date, bankroll_cents, config}); remove live-only fields; add date range.
+- [ ] **Step 2:** Wire open/close from Task 13's button; on submit, refresh list.
+- [ ] **Step 3:** `npm run build` passes.
+- [ ] **Step 4: Commit** `feat(web): kalshi backtest create modal (leagues/tuning/date range)`.
+
+### Task 15: Results view (equity curve + tables)
+**Files:**
+- Create: `frontend/src/views/KalshiBacktestResultView.vue`; route in `frontend/src/router/index.js` (`/kalshi/backtests/:id`)
+**Interfaces:**
+- `GET /kalshi/backtests/{id}/results` → render: summary stat cards (pnl, roi, win rate, clv, api_calls_used, cache_hits), equity curve via `KalshiPortfolioChart.vue` (feed `equity_curve`), trade `<table>`, calibration `<table>`, per-league `<table>`. Poll status until finished.
+- [ ] **Step 1:** Build view; reuse `KalshiPortfolioChart`.
+- [ ] **Step 2:** Route + navigation from the list row.
+- [ ] **Step 3:** `npm run build` passes.
+- [ ] **Step 4: Commit** `feat(web): kalshi backtest results view (equity, trades, calibration)`.
+
+---
+
+## Phase E — Mobile UI (`mobile/`)
+
+### Task 16: Repo methods + providers
+**Files:**
+- Modify: `mobile/lib/features/kalshi/data/kalshi_repository.dart`
+**Interfaces:**
+- Produces: `createBacktest(bid, body) -> id`, `listBacktests(bid)`, `backtestStatus(id)`, `backtestResults(id)`, `stopBacktest(id)` + `FutureProvider.autoDispose.family` providers (mirror existing kalshi getters).
+- [ ] **Step 1-2:** Add methods + providers (existing Dio idiom). `flutter analyze` clean.
+- [ ] **Step 3: Commit** `feat(mobile): kalshi backtest repository methods + providers`.
+
+### Task 17: Create sheet + list section
+**Files:**
+- Create: `mobile/lib/features/kalshi/presentation/kalshi_backtest_sheet.dart` (mirror `KalshiInstanceSheet`)
+- Modify: `mobile/lib/features/kalshi/presentation/kalshi_instance_detail_screen.dart` (Backtests section + AppBar action → open sheet)
+**Interfaces:**
+- Sheet collects leagues (chips), tuning `_field` numerics, date text fields, bankroll → `createBacktest`. List section shows past backtests with `StatusPill` + `LinearProgressIndicator`, tap → results screen.
+- [ ] **Step 1-2:** Build sheet + section. `flutter analyze` clean.
+- [ ] **Step 3: Commit** `feat(mobile): kalshi backtest create sheet + list section`.
+
+### Task 18: Results screen
+**Files:**
+- Create: `mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart`; route in `mobile/lib/core/router/router.dart` (`/kalshi/backtests/:id` on `_rootKey`)
+**Interfaces:**
+- Render summary `StatTile` grid, equity `ScrubbableAreaChart` (from `core/charts/`), trades `DataTable`, calibration + per-league. Poll status via `Timer.periodic` until finished.
+- [ ] **Step 1-2:** Build screen + route. `flutter analyze` clean.
+- [ ] **Step 3: Commit** `feat(mobile): kalshi backtest results screen`.
+
+---
+
+## Phase F — Integration, bug sweep, verify
+
+### Task 19: End-to-end smoke against the live DB (Tailscale up)
+- [ ] Run one real backtest for a small WC date window via the API (worker on), confirm: fixtures resolved, candles+odds fetched & CACHED (`api_calls>0`, `cache_hits==0` first run), a SECOND identical run has `api_calls==0`/`cache_hits>0`, results populate (pnl/equity/trades/calibration). Record numbers.
+- [ ] Verify OddsPapi budget guard: with budget near limit, extra fixtures are skipped + logged, not silently dropped.
+
+### Task 20: Parallel bug sweep + full suite
+- [ ] Dispatch parallel review agents (correctness of pricing reuse, cache correctness/immutability, budget-guard, ticker matching, API/worker lifecycle, UI wiring). Fix confirmed findings.
+- [ ] `pytest backend/tests/kalshi backend/tests/api -q` green; `cd frontend && npm run build`; `cd mobile && flutter analyze` (pre-existing infos only).
+- [ ] `npx gitnexus analyze` to refresh the index; `git` clean; open PR.
+
+---
+
+## Self-Review (against spec)
+
+**Coverage:** §2 sources → Tasks 0,1,2; §5 tables → Task 3/10; §5 caching rule → Task 3 (+T19 proof); §6 replay → Tasks 5-9; §7 endpoints → Task 12; §4.1 worker → Task 11; §8 web → Tasks 13-15; §9 mobile → Tasks 16-18; §10 testing → per-task + T19/T20; §11 risks (budget/ticker/lookahead/schema/restart) → Tasks 2-4,11,0. **No gaps.**
+
+**Placeholders:** none — UI tasks reference exact reusable components + endpoints; backend tasks carry test code and signatures. UI tasks give interfaces + files rather than full component source (skilled-dev + identified components); acceptable for this layer.
+
+**Type consistency:** `BacktestDataProvider` methods, `BacktestConfig`, `SizedBet`, `Trade`, `BacktestResult`, `run_backtest`, `evaluate`, `settle`, `aggregate`, `build_model_fn`, doc builders — names used consistently across Tasks 3–12.

--- a/docs/superpowers/plans/2026-07-01-kalshi-backtest.md
+++ b/docs/superpowers/plans/2026-07-01-kalshi-backtest.md
@@ -41,13 +41,18 @@
 
 ## Phase A — Backend data layer
 
-### Task 1: Kalshi historical candlesticks client method
+### Task 1: Kalshi candlesticks client method (CONFIRMED live shape)
 **Files:**
-- Modify: `backend/kalshi/client.py` (add method to the client class)
+- Modify: `backend/kalshi/client.py` (module-level pure helpers + client method)
 - Test: `backend/tests/kalshi/test_client_candlesticks.py`
 
+**CONFIRMED via live probe (2026-07-01) — build to THIS, not the docs:**
+- Endpoint is PUBLIC (no auth). Host **`https://external-api.kalshi.com`** (NOT `api.elections.kalshi.com` — that 403s via CloudFront). Path `/trade-api/v2/series/{series}/markets/{ticker}/candlesticks`. Series = the ticker prefix before the first `-` (e.g. `KXWCGAME`). Requires a browser-ish `User-Agent` header. Query: `start_ts,end_ts` (unix s), `period_interval` ∈ {1,60,1440}.
+- WC2026 markets are AFTER the `/historical/cutoff` (2026-05-02), so they live on THIS regular endpoint, not `/historical/...`.
+- Real candle shape: `{end_period_ts:int, yes_ask:{open_dollars,high_dollars,low_dollars,close_dollars}, yes_bid:{...}, price:{close_dollars,...} or {} , volume_fp, open_interest_fp}`. Prices are **dollar strings** (`"0.8100"` = 81¢).
+
 **Interfaces:**
-- Produces: `KalshiClient.get_historical_candlesticks(ticker: str, start_ts: int, end_ts: int, period_interval: int = 60) -> list[dict]` returning a list of candlestick dicts each with keys `end_period_ts:int, yes_bid:dict, yes_ask:dict, price:dict, volume, open_interest`. Also a pure helper `parse_candlesticks(payload: dict) -> list[dict]` and `yes_ask_close_at(candles: list[dict], ts: int) -> int|None` (last candle with `end_period_ts <= ts`, returns `yes_ask['close']` in cents).
+- Produces: `parse_candlesticks(payload) -> list[dict]`; `yes_ask_close_at(candles, ts) -> int|None` (last candle with `end_period_ts <= ts`; returns `round(float(yes_ask.close_dollars)*100)` cents, None if absent/no book); `KalshiClient.get_candlesticks(ticker, start_ts, end_ts, period_interval=60) -> list[dict]` (public GET to external-api host with UA; derives series from ticker; returns `parse_candlesticks`).
 
 - [ ] **Step 1: Write failing test** for the pure helpers (no network):
 
@@ -56,55 +61,78 @@
 from kalshi.client import parse_candlesticks, yes_ask_close_at
 
 RAW = {"candlesticks": [
-    {"end_period_ts": 1000, "yes_bid": {"close": 40}, "yes_ask": {"close": 44}, "price": {"close": 42}, "volume": "5", "open_interest": "10"},
-    {"end_period_ts": 2000, "yes_bid": {"close": 46}, "yes_ask": {"close": 50}, "price": {"close": 48}, "volume": "3", "open_interest": "12"},
+    {"end_period_ts": 1000, "yes_bid": {"close_dollars": "0.40"}, "yes_ask": {"close_dollars": "0.44"}, "price": {}, "volume_fp": "5.00", "open_interest_fp": "10.00"},
+    {"end_period_ts": 2000, "yes_bid": {"close_dollars": "0.46"}, "yes_ask": {"close_dollars": "0.50"}, "price": {"close_dollars": "0.48"}, "volume_fp": "3.00", "open_interest_fp": "12.00"},
 ]}
 
 def test_parse_candlesticks_extracts_rows():
     rows = parse_candlesticks(RAW)
     assert len(rows) == 2 and rows[0]["end_period_ts"] == 1000
 
-def test_yes_ask_close_at_returns_last_on_or_before():
+def test_yes_ask_close_at_returns_cents_of_last_on_or_before():
     rows = parse_candlesticks(RAW)
-    assert yes_ask_close_at(rows, 1500) == 44   # last <= 1500 is the 1000 candle
+    assert yes_ask_close_at(rows, 1500) == 44   # 0.44 dollars -> 44c, last <= 1500
     assert yes_ask_close_at(rows, 2500) == 50
     assert yes_ask_close_at(rows, 500) is None   # nothing before
+
+def test_yes_ask_close_at_handles_missing_book():
+    assert yes_ask_close_at([{"end_period_ts": 1, "yes_ask": {}}], 5) is None
 
 def test_parse_candlesticks_empty_is_safe():
     assert parse_candlesticks({}) == []
 ```
 
 - [ ] **Step 2:** Run `pytest backend/tests/kalshi/test_client_candlesticks.py -v` → FAIL (import error).
-- [ ] **Step 3: Implement** pure helpers + the fetch method in `client.py`:
+- [ ] **Step 3: Implement** module-level helpers + the fetch method:
 
 ```python
 def parse_candlesticks(payload: dict) -> list[dict]:
     return list((payload or {}).get("candlesticks") or [])
 
-def yes_ask_close_at(candles: list[dict], ts: int):
+def yes_ask_close_at(candles, ts):
     best = None
     for c in candles:
-        if int(c.get("end_period_ts", 0)) <= ts:
+        if int(c.get("end_period_ts", 0)) <= int(ts):
             best = c
         else:
             break
-    if best is None:
+    cd = ((best or {}).get("yes_ask") or {}).get("close_dollars")
+    if cd is None:
         return None
-    return int((best.get("yes_ask") or {}).get("close")) if (best.get("yes_ask") or {}).get("close") is not None else None
+    try:
+        return int(round(float(cd) * 100))
+    except (TypeError, ValueError):
+        return None
 ```
-Add to the client class (mirror existing request style in `client.py`; historical endpoint is unauthenticated — plain GET):
+Client method (public endpoint — plain GET to external-api host, browser UA, no signing):
 ```python
-def get_historical_candlesticks(self, ticker, start_ts, end_ts, period_interval=60):
-    url = f"{self.base_url}/historical/markets/{ticker}/candlesticks"
+CANDLE_HOST = "https://external-api.kalshi.com/trade-api/v2"
+_CANDLE_UA = {"User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/126", "Accept": "application/json"}
+
+def get_candlesticks(self, ticker, start_ts, end_ts, period_interval=60):
+    series = str(ticker).split("-", 1)[0]
+    url = f"{CANDLE_HOST}/series/{series}/markets/{ticker}/candlesticks"
     params = {"start_ts": int(start_ts), "end_ts": int(end_ts), "period_interval": int(period_interval)}
-    resp = self._session.get(url, params=params, timeout=20)
+    resp = self._session.request("GET", url, headers=_CANDLE_UA, params=params, timeout=20)
     resp.raise_for_status()
-    return parse_candlesticks(resp.json() if resp.content else {})
+    return parse_candlesticks(resp.json() if getattr(resp, "content", None) else {})
 ```
-(Confirm `self.base_url`/`self._session` names against the existing client; adapt.)
 
 - [ ] **Step 4:** Run tests → PASS.
-- [ ] **Step 5: Commit** `feat(kalshi): historical candlesticks client method + pure price helpers`.
+- [ ] **Step 5: Commit** `feat(kalshi): public candlesticks client method + dollar-string price helpers`.
+
+### Task 1b: Kalshi settled-markets results (free score source)
+**Files:**
+- Modify: `backend/kalshi/client.py`
+- Test: `backend/tests/kalshi/test_client_settled.py`
+
+**CONFIRMED:** `GET https://external-api.kalshi.com/trade-api/v2/markets?series_ticker=KXWCGAME&status=settled&limit=..` is PUBLIC and returns `{markets:[{ticker, result:"yes"|"no", close_time, ...}]}`. Each side-ticker's `result` gives the outcome — a FREE final-score source (no OddsPapi needed).
+
+**Interfaces:**
+- Produces: `KalshiClient.list_settled_markets(series, limit=1000) -> list[dict]` (public GET, paginates via `cursor`); pure `result_side_from_markets(markets, fixture_prefix) -> "home"|"draw"|"away"|None` mapping the yes-resolved side ticker (…-TIE→draw, else the team-code side) to home/away using the fixture's ordered team codes.
+- [ ] **Step 1: Write failing test** for `result_side_from_markets`: given markets for `KXWCGAME-26JUN30MEXECU-*` where `-MEX` result yes and `-TIE`/`-ECU` result no, and fixture home=MEX away=ECU → returns "home"; if `-TIE` yes → "draw"; missing → None.
+- [ ] **Step 2-4:** FAIL → implement (reuse `data/ticker_names.py` to map side codes) → PASS.
+- [ ] **Step 5: Commit** `feat(kalshi): public settled-markets list + result resolver (free scores)`.
 
 ### Task 2: OddsPapi fixtures + historical-odds methods
 **Files:**
@@ -129,7 +157,7 @@ def get_historical_candlesticks(self, ticker, start_ts, end_ts, period_interval=
 **Interfaces:**
 - Produces: `class BacktestDataProvider` with:
   - `fixtures(leagues, start_date, end_date) -> list[Fixture]`
-  - `final_score(fx) -> str|None` (`home|draw|away`, None if unsettled)
+  - `final_score(fx) -> str|None` (`home|draw|away`, None if unsettled) — **PRIMARY source: Kalshi settled markets (Task 1b), free/public; OddsPapi fixture result only as fallback.** OddsPapi is used only for the sharp odds line.
   - `candles(ticker) -> list[dict]`
   - `sharp_odds(fx) -> list[dict]`  (snapshots)
   - `kalshi_tickers(fx) -> dict[str,str]` (side→ticker)

--- a/docs/superpowers/specs/2026-07-01-kalshi-backtest-design.md
+++ b/docs/superpowers/specs/2026-07-01-kalshi-backtest-design.md
@@ -1,0 +1,208 @@
+# Kalshi Soccer Backtest — Design Spec
+
+**Date:** 2026-07-01
+**Branch:** `feat/kalshi-backtest`
+**Status:** Approved for implementation
+
+## 1. Goal
+
+Add a backtesting feature to the Kalshi soccer bot, surfaced on both **web** and **mobile**,
+mirroring the UX of the existing IntelliStock stock backtests: the user picks **leagues**,
+**tuning settings**, and a **date range**, runs it, watches progress, and sees results
+(P&L, equity curve, trade list, calibration). The replay drives the **same pure functions
+the live Kalshi engine uses**, so it genuinely tests the real strategy and becomes the
+validation harness for later strategy fixes.
+
+## 2. Why this is possible now (data sources)
+
+Historical data for a faithful replay is obtainable, essentially free:
+
+| Data | Source | Access |
+|---|---|---|
+| Kalshi price history | `GET /historical/markets/{ticker}/candlesticks` | **Public, no auth**. 1m/60m/1440m OHLC + yes/no bid-ask + volume. Params: `start_ts`,`end_ts`,`period_interval`. |
+| Historical sharp odds (Pinnacle) | **OddsPapi** `/v4/historical-odds` | Free tier (~250 req/mo). Full timestamped price history per fixture. Covers 2026 World Cup. |
+| Fixtures + final scores | OddsPapi `/v4/fixtures` (fallback: Kalshi settlement / final candlestick) | Free tier. |
+
+The repo already has `OddsPapiClient` (`backend/kalshi/ingest_odds.py`) with a budget guard
+(`should_scan`, `fixtures_per_day_budget`, `bump_scan_budget` in `db.py`) — currently dead
+code. It gets wired for the first time here.
+
+**Prerequisite:** a free OddsPapi API key (no credit card), stored on the backtest/instance
+config like the existing `odds_api_key` (new field `oddspapi_api_key`).
+
+**Known caveat:** national-team Elo is current-only (no as-of-date), so *model-only* metrics
+carry mild look-ahead and are labeled "indicative". *Strategy* P&L is sound because fair value
+anchors to the real historical sharp line.
+
+## 3. Scope (v1) — YAGNI boundaries
+
+- **Pre-match only.** No in-play/live replay.
+- **A small set of pre-kickoff decision snapshots** per fixture (default: T−3h; configurable
+  list), not the full tick path. One entry per fixture per side.
+- Exposes the **existing** config knobs (edge_threshold, no_sharp_edge_threshold,
+  kelly_fraction, order_size_min/max, max_open_exposure_frac, per_bet_cap_frac,
+  sharp_weight, devig_method, min/max price, draw_min_edge, bankroll, leagues). New
+  strategy fixes (devig-Kalshi-book, per-fixture lock, calibration) are **out of scope here**
+  but will be automatically backtestable once added, because the replay reuses engine functions.
+- **Lightweight in-process background runner** — NOT the heavy Docker-per-backtest machinery
+  the stock backtests use (per-fixture pre-match replay is cheap). Same polled-progress UX.
+
+## 4. Architecture
+
+```
+Web/Mobile create form ──POST──▶ KalshiBacktests row (status=pending)
+                                        │ (in-process worker, changefeed/drain)
+                                        ▼
+                          backend/kalshi/backtest.py :: run_backtest(cfg)
+                              │  resolve fixtures (OddsPapi, CACHED)
+                              │  per fixture: score (CACHED), Kalshi candles (CACHED),
+                              │               sharp odds (CACHED), model probs
+                              │  evaluate() → REUSE fusion/edge/candidates/risk/planner
+                              │  settle() → REUSE reconcile
+                              │  write throttled progress → KalshiBacktests.progress
+                              ▼
+                      KalshiBacktestResults row (equity curve, trades, calibration)
+                                        ▲
+Web/Mobile results ◀──GET /status,/results (poll)──┘
+```
+
+### 4.1 Backend modules
+- `backend/kalshi/backtest.py` — **new**. Orchestrates the replay. Pure core
+  (`run_backtest(cfg, data_provider, progress_cb) -> BacktestResult`) so it unit-tests
+  without live APIs (data_provider injected/faked). No DB or HTTP inside the core.
+- `backend/kalshi/backtest_data.py` — **new**. `BacktestDataProvider`: fetch-or-cache layer
+  for fixtures, scores, Kalshi candlesticks, OddsPapi odds. Owns the cache tables and the
+  OddsPapi budget guard. This is where "cache everything, only fetch new" lives.
+- `backend/kalshi/client.py` — **extend** with `get_historical_candlesticks(ticker, start_ts,
+  end_ts, period_interval)` (public endpoint; ~15 lines).
+- `backend/kalshi/ingest_odds.py` — **extend** `OddsPapiClient` with `list_fixtures(sport_id,
+  date_from, date_to)`, `historical_odds(fixture_id, books)`, and normalized parsers. Confirm
+  real response schema during Phase 0 (a probe call) and map into the `parse_three_way` shape.
+- API endpoints — **extend** the FastAPI Kalshi surface (alongside existing
+  `/brokerages/{bid}/kalshi/...` routes).
+- Background worker — **new** `kalshi_backtest_worker` started at app startup: watches
+  `KalshiBacktests` for `pending` (changefeed, like `backtest_engine._changefeed_worker`),
+  drains on boot, runs each in a small ThreadPool, honors a `run=false` stop flag.
+
+### 4.2 Reused engine functions (the point)
+`intelligence.fusion.build_market_probs`/`fuse`, `edge.compute_edge`,
+`strategy.candidates.generate_candidates`, `risk.RiskCaps` + `capital.planner.allocate`,
+`reconcile.reconcile_position`/`aggregate_positions`, `fair_value` + `devig` (sharp line),
+`quant`/`intelligence.pricing` (model probs), `instance_config.risk_caps_from_config`.
+
+## 5. Data model (RethinkDB tables)
+
+**Job/queue + status:** `KalshiBacktests` (pk `id`)
+```
+id, brokerage_id, instance_id?, name, status(pending|running|finished|error|stopped),
+progress(0..100), run(bool, stop flag), config{...tuning...}, leagues[], start_date, end_date,
+bankroll_cents, created_at, started_at, finished_at, error,
+summary{ pnl_cents, roi, n_bets, n_fixtures, win_rate, clv_avg, api_calls_used, cache_hits }
+```
+
+**Heavy results:** `KalshiBacktestResults` (pk `id` = backtest id)
+```
+id, equity_curve[ {ts, cum_pnl_cents, bankroll_cents} ],
+trades[ {fixture_key, league, home, away, ts, side, entry_cents, size, model_prob,
+         sharp_prob, fused_fair, edge, outcome, realized_pnl_cents, clv} ],
+calibration[ {bucket_lo, bucket_hi, predicted, actual, n} ],
+per_league[ {league, n, pnl_cents, roi, clv_avg} ], logs[]
+```
+
+**Immutable historical caches (shared across ALL backtests):**
+- `KalshiHistCandles` (pk `"{ticker}|{interval}"`) → `{ticker, interval, candles[], cached_at}`
+- `KalshiHistOdds` (pk `"{fixture_key}|{book}"`) → `{fixture_key, book, snapshots[{ts,home,draw,away}], cached_at}`
+- `KalshiHistFixtures` (pk `fixture_key`) → `{fixture_key, league, home, away, kickoff_ts,
+  home_score, away_score, result(home|draw|away), settled(bool), kalshi_tickers{side:ticker}, cached_at}`
+
+**Caching rule:** on a cache hit return stored data (0 API calls). Only fetch on miss, or when
+a fixture row exists but `settled=false` (re-fetch score/odds until the match has settled). Once
+`settled=true`, the row and its candles/odds are immutable and never re-fetched. OddsPapi fetches
+pass through the budget guard; skips are logged, never silent (mirrors `ingest_odds` docstring).
+
+## 6. Replay algorithm (`run_backtest`)
+
+```
+fixtures = data.fixtures(leagues, start, end)          # cached
+for i, fx in enumerate(fixtures):
+    score = data.final_score(fx)                       # cached; skip if not settled
+    if score is None: continue
+    tickers = data.kalshi_tickers(fx)                  # resolve via discovery+normalize+ticker_names
+    candles = data.candles(tickers)                    # public, cached
+    oddseries = data.sharp_odds(fx)                    # OddsPapi, cached
+    model = model_probs(fx, as_of=fx.kickoff_ts)       # elo/dixon-coles (nat-elo caveat)
+    for snap_ts in cfg.decision_snapshots(fx):         # default [kickoff - 3h]
+        kalshi_ask = price_at(candles, snap_ts)        # yes_ask per side at snap
+        sharp = devig(sharp_at(oddseries, snap_ts))    # reuse fair_value/devig
+        cands = evaluate(cfg_caps, model, sharp, kalshi_ask)  # reuse fusion→edge→candidates→planner
+        for c in cands:                                 # sized bets
+            trade = settle(c, score)                    # reuse reconcile → realized_pnl, clv
+            record(trade)
+        if cands: break                                 # one decision snapshot per fixture (v1)
+    progress_cb((i+1)/len(fixtures))
+return aggregate(trades)  # equity curve (by kickoff order), roi, win_rate, clv, calibration, per-league
+```
+
+Determinism: fixtures processed in kickoff order; no wall-clock/random in the core.
+
+## 7. API endpoints (mirror stock backtest shapes)
+
+- `POST /brokerages/{bid}/kalshi/backtests` — body `KalshiBacktestBody{ name?, instance_id?,
+  leagues[], start_date, end_date, bankroll_cents, config{...} }` → `{id}`. Inserts pending row.
+- `GET  /brokerages/{bid}/kalshi/backtests` — list (summary rows).
+- `GET  /kalshi/backtests/{id}/status` — `{status, progress, summary, error}` (poll target).
+- `GET  /kalshi/backtests/{id}/results` — full `KalshiBacktestResults`.
+- `POST /kalshi/backtests/{id}/stop` — set `run=false`.
+- `DELETE /kalshi/backtests/{id}` — delete job + results.
+
+## 8. Web UI (`frontend/`)
+
+- Add a **Backtest** section + "New backtest" button on `KalshiInstanceDetailView.vue` header
+  (next to Edit). New route `/kalshi/instances/:id/backtest` optional.
+- **Create modal**: reuse `KalshiCreateInstanceModal.vue` building blocks — leagues multi-select
+  (`LEAGUES`/`toggleLeague`), numeric tuning grid + `InfoTip`, native `<input type=date>` range,
+  bankroll. Prefill from the instance's current config.
+- **Results view**: equity curve via `KalshiPortfolioChart.vue` (area); trade table + calibration
+  table hand-rolled; summary stat cards; poll `GET /kalshi/backtests/{id}/status` every 3s for the
+  progress bar (pattern from `BacktestsView.vue`). List section shows past backtests.
+- API via the existing inline `fetch` + `authHeaders()` idiom.
+
+## 9. Mobile UI (`mobile/`)
+
+- **`KalshiBacktestSheet`** mirroring `KalshiInstanceSheet` (leagues chips, `_field` numerics,
+  date text fields, risk presets) opened via `showModalBottomSheet` from the Kalshi instance
+  detail AppBar.
+- **Results**: reuse `core/charts/ScrubbableAreaChart` (equity), `StatTile` grid, `DataTable`
+  trades, `LinearProgressIndicator` progress, `GlassCard`/`StatusPill`/`EmptyState`.
+- Repo methods on `KalshiRepository` (`POST .../kalshi/backtests`, status, results) +
+  `FutureProvider.autoDispose.family` providers + `Timer.periodic` polling (existing idioms).
+- A backtests list section on the Kalshi instance detail screen.
+
+## 10. Testing
+
+- **Unit (pytest, no network):** `run_backtest` core against a faked `BacktestDataProvider`
+  (deterministic fixtures/candles/odds/scores) — asserts bet selection, sizing, settlement,
+  aggregation, per-fixture single-entry, edge/no-sharp gating. Cache layer: hit returns stored,
+  miss fetches once, `settled=false` re-fetches, budget-guard skip. New client methods:
+  candlestick param/URL construction + response parsing; OddsPapi fixtures/historical parsing.
+- **Integration (opt-in, real keys):** one small real fetch each (Kalshi candlesticks public +
+  OddsPapi historical) behind an env-gated marker, to confirm live response schemas.
+- **Web/mobile:** existing test patterns for the new components where present; `flutter analyze`
+  clean (pre-existing infos only); web build passes.
+
+## 11. Risks / mitigations
+
+- **OddsPapi 250/mo budget** → aggressive immutable caching (re-runs = 0 calls); budget guard
+  refuses to overspend and logs skips; surface `api_calls_used`/`cache_hits` in the summary.
+- **Fixture↔Kalshi ticker mapping** may miss on name variants → reuse `normalize`/`ticker_names`
+  crosswalk + fuzzy match (as `odds_api.match_event` already does); unmatched fixtures are logged
+  and skipped, never guessed.
+- **National-Elo look-ahead** → label model-only metrics "indicative"; headline P&L uses the
+  sharp-anchored path.
+- **OddsPapi response schema unknown** → Phase 0 probe call confirms and maps it before building on it.
+- **Server restart mid-run** → boot drains `pending`/`running`-orphaned rows (re-queue or mark stopped).
+
+## 12. Out of scope (future)
+In-play replay; full tick-path replay; the P1/P3 strategy fixes themselves (devig-Kalshi-book,
+per-fixture lock, calibration) — added later and validated *with* this harness; paid historical
+tiers; leagues beyond what OddsPapi + Kalshi + a score source jointly cover.

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -88,6 +88,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/kalshi/instances/:id/backtest',
+    name: 'kalshi-backtest',
+    component: () => import('../views/KalshiBacktestView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/strategies',
     name: 'strategies',
     component: () => import('../views/StrategiesView.vue'),

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -1,0 +1,376 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import VueApexCharts from 'vue3-apexcharts'
+import { getToken } from '../utils/auth.js'
+
+const API_BASE = import.meta.env.DEV ? '/api' : (import.meta.env.VITE_API_URL || '/api')
+function authHeaders() {
+  return { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` }
+}
+
+const route = useRoute()
+const router = useRouter()
+const instanceId = route.params.id
+
+const LEAGUES = [
+  'World Cup', 'World Cup Qualifiers', 'Champions League', 'Europa League',
+  'EPL', 'EFL Championship', 'Serie A', 'Serie B', 'La Liga', 'La Liga 2',
+  'Bundesliga', '2. Bundesliga', 'Ligue 1', 'Ligue 2', 'Eredivisie',
+  'Primeira Liga', 'MLS', 'Brasileirão',
+]
+
+const brokerageId = ref('')
+const loadErr = ref('')
+
+// --- create form ---
+const name = ref('')
+const leagues = ref(['World Cup'])
+const startDate = ref('')
+const endDate = ref('')
+const bankroll = ref(54)          // dollars
+const edgePct = ref(3)            // %
+const noSharpPct = ref(8)         // %
+const kelly = ref(0.2)
+const orderMin = ref(5)           // $
+const orderMax = ref(10)          // $
+const sharpWeight = ref(85)       // %
+const oddspapiKey = ref('')
+const submitting = ref(false)
+const submitErr = ref('')
+
+function toggleLeague(l) {
+  const i = leagues.value.indexOf(l)
+  if (i >= 0) leagues.value.splice(i, 1)
+  else leagues.value.push(l)
+}
+
+async function loadInstance() {
+  try {
+    const res = await fetch(`${API_BASE}/instances/${instanceId}/kalshi/detail`, { headers: authHeaders() })
+    if (!res.ok) throw new Error(`detail ${res.status}`)
+    const d = await res.json()
+    brokerageId.value = d.brokerage_id
+    const c = d.config || {}
+    if (c.edge_threshold != null) edgePct.value = Math.round(c.edge_threshold * 1000) / 10
+    if (c.no_sharp_edge_threshold != null) noSharpPct.value = Math.round(c.no_sharp_edge_threshold * 1000) / 10
+    if (c.kelly_fraction != null) kelly.value = c.kelly_fraction
+    if (c.order_size_min_cents != null) orderMin.value = Math.round(c.order_size_min_cents) / 100
+    if (c.order_size_max_cents != null) orderMax.value = Math.round(c.order_size_max_cents) / 100
+    if (c.sharp_weight != null) sharpWeight.value = Math.round(c.sharp_weight * 100)
+    if (c.bankroll_cents != null) bankroll.value = Math.round(c.bankroll_cents / 100)
+    if (Array.isArray(c.leagues) && c.leagues.length) leagues.value = [...c.leagues]
+    if (c.oddspapi_api_key) oddspapiKey.value = c.oddspapi_api_key
+  } catch (e) {
+    loadErr.value = "Couldn't load the instance config."
+  }
+}
+
+async function submit() {
+  submitErr.value = ''
+  if (!startDate.value || !endDate.value) { submitErr.value = 'Pick a start and end date.'; return }
+  if (startDate.value > endDate.value) { submitErr.value = 'Start date must be on/before end date.'; return }
+  if (!leagues.value.length) { submitErr.value = 'Select at least one league.'; return }
+  submitting.value = true
+  try {
+    const body = {
+      name: name.value || `Backtest ${startDate.value}..${endDate.value}`,
+      instance_id: instanceId,
+      leagues: leagues.value,
+      start_date: startDate.value,
+      end_date: endDate.value,
+      bankroll_dollars: Number(bankroll.value) || 0,
+      config: {
+        edge_threshold: Number(edgePct.value) / 100,
+        no_sharp_edge_threshold: Number(noSharpPct.value) / 100,
+        kelly_fraction: Number(kelly.value),
+        order_size_min_dollars: Number(orderMin.value) || 0,
+        order_size_max_dollars: Number(orderMax.value) || 0,
+        sharp_weight: Number(sharpWeight.value) / 100,
+        oddspapi_api_key: oddspapiKey.value || undefined,
+      },
+    }
+    const res = await fetch(`${API_BASE}/brokerages/${brokerageId.value}/kalshi/backtests`, {
+      method: 'POST', headers: authHeaders(), body: JSON.stringify(body),
+    })
+    if (!res.ok) throw new Error(`create ${res.status}`)
+    const d = await res.json()
+    await loadBacktests()
+    openResults(d.id)
+  } catch (e) {
+    submitErr.value = 'Failed to start the backtest.'
+  } finally {
+    submitting.value = false
+  }
+}
+
+// --- list + polling ---
+const backtests = ref([])
+let pollTimer = null
+
+async function loadBacktests() {
+  if (!brokerageId.value) return
+  try {
+    const res = await fetch(`${API_BASE}/brokerages/${brokerageId.value}/kalshi/backtests`, { headers: authHeaders() })
+    if (!res.ok) return
+    const d = await res.json()
+    backtests.value = d.backtests || []
+  } catch (e) { /* ignore transient */ }
+}
+
+function anyRunning() {
+  return backtests.value.some((b) => b.status === 'pending' || b.status === 'running')
+}
+
+async function tick() {
+  await loadBacktests()
+  if (selected.value && (selected.value.status === 'pending' || selected.value.status === 'running')) {
+    await refreshResults(selected.value.id)
+  }
+}
+
+async function stopBacktest(id) {
+  await fetch(`${API_BASE}/kalshi/backtests/${id}/stop`, { method: 'POST', headers: authHeaders() })
+  await loadBacktests()
+}
+async function delBacktest(id) {
+  if (!confirm('Delete this backtest?')) return
+  await fetch(`${API_BASE}/kalshi/backtests/${id}`, { method: 'DELETE', headers: authHeaders() })
+  if (selected.value && selected.value.id === id) selected.value = null
+  await loadBacktests()
+}
+
+// --- results ---
+const selected = ref(null)     // status row
+const result = ref(null)       // heavy result
+
+async function refreshResults(id) {
+  try {
+    const res = await fetch(`${API_BASE}/kalshi/backtests/${id}/results`, { headers: authHeaders() })
+    if (!res.ok) return
+    const d = await res.json()
+    selected.value = { ...(selected.value || {}), id, status: d.status, summary: d.summary || {} }
+    result.value = d.result || null
+  } catch (e) { /* ignore */ }
+}
+function openResults(id) {
+  selected.value = { id, status: 'pending', summary: {} }
+  result.value = null
+  refreshResults(id)
+}
+
+const equitySeries = computed(() => {
+  const ec = (result.value && result.value.equity_curve) || []
+  return [{ name: 'Cumulative P&L ($)', data: ec.map((p) => [Number(p.ts) * 1000, (p.cum_pnl_cents || 0) / 100]) }]
+})
+const equityOpts = {
+  chart: { type: 'area', toolbar: { show: false }, animations: { enabled: false } },
+  dataLabels: { enabled: false },
+  stroke: { curve: 'straight', width: 2 },
+  xaxis: { type: 'datetime', labels: { style: { colors: '#94a3b8' } } },
+  yaxis: { labels: { style: { colors: '#94a3b8' }, formatter: (v) => `$${Math.round(v)}` } },
+  colors: ['#22d3ee'], grid: { borderColor: '#1e293b' }, tooltip: { theme: 'dark' },
+}
+
+function fmtPct(v) { return v == null ? '—' : `${(v * 100).toFixed(1)}%` }
+function fmtMoney(c) { return c == null ? '—' : `$${(c / 100).toFixed(2)}` }
+function statusColor(s) {
+  return s === 'finished' ? 'text-emerald-400' : s === 'error' ? 'text-rose-400'
+    : s === 'stopped' ? 'text-slate-400' : 'text-amber-400'
+}
+
+onMounted(async () => {
+  await loadInstance()
+  await loadBacktests()
+  pollTimer = setInterval(tick, 3000)
+})
+onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
+</script>
+
+<template>
+  <main class="max-w-6xl mx-auto px-4 py-6 space-y-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <button @click="router.push(`/kalshi/instances/${instanceId}`)" class="text-sm text-slate-400 hover:text-slate-200">← Back to instance</button>
+        <h1 class="text-xl font-semibold text-slate-100 mt-1">Backtest</h1>
+      </div>
+    </div>
+    <p v-if="loadErr" class="text-sm text-amber-400">{{ loadErr }}</p>
+
+    <!-- Create form -->
+    <section class="bg-surface border border-border-subtle rounded-xl p-4 space-y-4">
+      <h2 class="text-sm font-semibold text-slate-200">New backtest</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label class="block">
+          <span class="text-xs text-slate-400">Name</span>
+          <input v-model="name" type="text" placeholder="e.g. WC group stage" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">Bankroll ($)</span>
+          <input v-model.number="bankroll" type="number" min="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">Start date</span>
+          <input v-model="startDate" type="date" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">End date</span>
+          <input v-model="endDate" type="date" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+        </label>
+      </div>
+
+      <div>
+        <span class="text-xs text-slate-400">Leagues</span>
+        <div class="flex flex-wrap gap-2 mt-1">
+          <button v-for="l in LEAGUES" :key="l" type="button" @click="toggleLeague(l)"
+                  class="px-2.5 py-1 rounded-full text-xs border transition-colors"
+                  :class="leagues.includes(l) ? 'bg-primary/20 border-primary text-primary' : 'border-border-subtle text-slate-400 hover:text-slate-200'">
+            {{ l }}
+          </button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <label class="block"><span class="text-xs text-slate-400">Edge bar (%)</span>
+          <input v-model.number="edgePct" type="number" step="0.5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">No-sharp bar (%)</span>
+          <input v-model.number="noSharpPct" type="number" step="0.5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Kelly fraction</span>
+          <input v-model.number="kelly" type="number" step="0.05" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Order min ($)</span>
+          <input v-model.number="orderMin" type="number" step="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Order max ($)</span>
+          <input v-model.number="orderMax" type="number" step="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Sharp weight (%)</span>
+          <input v-model.number="sharpWeight" type="number" step="5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+      </div>
+
+      <label class="block">
+        <span class="text-xs text-slate-400">OddsPapi API key <span class="text-slate-500">(for the sharp line — free tier; leave blank for model-only)</span></span>
+        <input v-model="oddspapiKey" type="text" placeholder="oddspapi apiKey" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+      </label>
+
+      <div class="flex items-center gap-3">
+        <button @click="submit" :disabled="submitting || !brokerageId"
+                class="px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium disabled:opacity-50">
+          {{ submitting ? 'Starting…' : 'Run backtest' }}
+        </button>
+        <span v-if="submitErr" class="text-sm text-rose-400">{{ submitErr }}</span>
+      </div>
+    </section>
+
+    <!-- Past backtests -->
+    <section class="bg-surface border border-border-subtle rounded-xl p-4">
+      <h2 class="text-sm font-semibold text-slate-200 mb-3">Backtests</h2>
+      <div v-if="!backtests.length" class="text-sm text-slate-500">No backtests yet.</div>
+      <table v-else class="w-full text-sm">
+        <thead><tr class="text-left text-slate-500 text-xs">
+          <th class="py-1">Name</th><th>Range</th><th>Status</th><th>P&L</th><th></th>
+        </tr></thead>
+        <tbody>
+          <tr v-for="b in backtests" :key="b.id" class="border-t border-border-subtle/50">
+            <td class="py-2 text-slate-200">{{ b.name || b.id.slice(0, 8) }}</td>
+            <td class="text-slate-400">{{ b.start_date }} → {{ b.end_date }}</td>
+            <td>
+              <span :class="statusColor(b.status)">{{ b.status }}</span>
+              <span v-if="b.status === 'running' || b.status === 'pending'" class="text-slate-500"> {{ Math.round(b.progress || 0) }}%</span>
+            </td>
+            <td :class="(b.summary && b.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">
+              {{ b.summary ? fmtMoney(b.summary.pnl_cents) : '—' }}
+            </td>
+            <td class="text-right">
+              <button @click="openResults(b.id)" class="text-xs text-primary hover:underline mr-2">View</button>
+              <button v-if="b.status === 'running' || b.status === 'pending'" @click="stopBacktest(b.id)" class="text-xs text-amber-400 hover:underline mr-2">Stop</button>
+              <button @click="delBacktest(b.id)" class="text-xs text-slate-500 hover:text-rose-400">Delete</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- Results -->
+    <section v-if="selected" class="bg-surface border border-border-subtle rounded-xl p-4 space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-semibold text-slate-200">Results</h2>
+        <span :class="statusColor(selected.status)" class="text-xs">{{ selected.status }}</span>
+      </div>
+
+      <div v-if="selected.summary" class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div class="bg-surface border border-border-subtle rounded-lg p-3">
+          <div class="text-xs text-slate-500">Total P&L</div>
+          <div class="text-lg font-semibold" :class="(selected.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(selected.summary.pnl_cents) }}</div>
+        </div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3">
+          <div class="text-xs text-slate-500">ROI</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.roi) }}</div>
+        </div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3">
+          <div class="text-xs text-slate-500">Bets · Win rate</div><div class="text-lg font-semibold text-slate-100">{{ selected.summary.n_bets ?? '—' }} · {{ fmtPct(selected.summary.win_rate) }}</div>
+        </div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3">
+          <div class="text-xs text-slate-500">Avg CLV · API/cache</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.clv_avg) }} · {{ selected.summary.api_calls ?? 0 }}/{{ selected.summary.cache_hits ?? 0 }}</div>
+        </div>
+      </div>
+
+      <div v-if="result && result.equity_curve && result.equity_curve.length">
+        <VueApexCharts type="area" height="260" :options="equityOpts" :series="equitySeries" />
+      </div>
+
+      <div v-if="result && result.trades && result.trades.length" class="overflow-x-auto">
+        <h3 class="text-xs font-semibold text-slate-400 mb-2">Trades ({{ result.trades.length }})</h3>
+        <table class="w-full text-xs">
+          <thead><tr class="text-left text-slate-500">
+            <th class="py-1">Ticker</th><th>Side</th><th>Entry</th><th>Size</th><th>Model</th><th>Sharp</th><th>Edge</th><th>Outcome</th><th>P&L</th><th>CLV</th>
+          </tr></thead>
+          <tbody>
+            <tr v-for="(t, i) in result.trades" :key="i" class="border-t border-border-subtle/40">
+              <td class="py-1 text-slate-300">{{ t.market_ticker }}</td>
+              <td class="text-slate-400">{{ t.side }}</td>
+              <td class="text-slate-400">{{ t.entry_cents }}¢</td>
+              <td class="text-slate-400">{{ t.size }}</td>
+              <td class="text-slate-400">{{ t.model_prob != null ? t.model_prob.toFixed(2) : '—' }}</td>
+              <td class="text-slate-400">{{ t.sharp_prob != null ? t.sharp_prob.toFixed(2) : '—' }}</td>
+              <td class="text-slate-400">{{ (t.edge * 100).toFixed(1) }}%</td>
+              <td class="text-slate-400">{{ t.outcome }}</td>
+              <td :class="(t.realized_pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(t.realized_pnl_cents) }}</td>
+              <td class="text-slate-400">{{ t.clv != null ? (t.clv * 100).toFixed(1) + '%' : '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="result && result.per_league && Object.keys(result.per_league).length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h3 class="text-xs font-semibold text-slate-400 mb-2">By league</h3>
+          <table class="w-full text-xs">
+            <thead><tr class="text-left text-slate-500"><th>League</th><th>Bets</th><th>P&L</th><th>ROI</th></tr></thead>
+            <tbody>
+              <tr v-for="(v, k) in result.per_league" :key="k" class="border-t border-border-subtle/40">
+                <td class="py-1 text-slate-300">{{ k }}</td><td class="text-slate-400">{{ v.n }}</td>
+                <td :class="(v.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(v.pnl_cents) }}</td>
+                <td class="text-slate-400">{{ fmtPct(v.roi) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="result.calibration && result.calibration.length">
+          <h3 class="text-xs font-semibold text-slate-400 mb-2">Calibration</h3>
+          <table class="w-full text-xs">
+            <thead><tr class="text-left text-slate-500"><th>Bucket</th><th>Predicted</th><th>Actual</th><th>n</th></tr></thead>
+            <tbody>
+              <tr v-for="(c, i) in result.calibration" :key="i" class="border-t border-border-subtle/40">
+                <td class="py-1 text-slate-400">{{ (c.bucket_lo * 100).toFixed(0) }}–{{ (c.bucket_hi * 100).toFixed(0) }}%</td>
+                <td class="text-slate-400">{{ (c.predicted * 100).toFixed(0) }}%</td>
+                <td class="text-slate-400">{{ (c.actual * 100).toFixed(0) }}%</td>
+                <td class="text-slate-400">{{ c.n }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <p v-if="result && (!result.trades || !result.trades.length) && selected.status === 'finished'" class="text-sm text-slate-500">
+        No bets were placed under these settings over this range.
+      </p>
+    </section>
+  </main>
+</template>

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -160,14 +160,15 @@ function openResults(id) {
 }
 
 const equitySeries = computed(() => {
+  // equity_curve is a bare list of cumulative-P&L cents, ordered by bet.
   const ec = (result.value && result.value.equity_curve) || []
-  return [{ name: 'Cumulative P&L ($)', data: ec.map((p) => [Number(p.ts) * 1000, (p.cum_pnl_cents || 0) / 100]) }]
+  return [{ name: 'Cumulative P&L ($)', data: ec.map((v, i) => [i + 1, (v || 0) / 100]) }]
 })
 const equityOpts = {
   chart: { type: 'area', toolbar: { show: false }, animations: { enabled: false } },
   dataLabels: { enabled: false },
   stroke: { curve: 'straight', width: 2 },
-  xaxis: { type: 'datetime', labels: { style: { colors: '#94a3b8' } } },
+  xaxis: { type: 'numeric', title: { text: 'Bet #', style: { color: '#64748b' } }, labels: { style: { colors: '#94a3b8' } } },
   yaxis: { labels: { style: { colors: '#94a3b8' }, formatter: (v) => `$${Math.round(v)}` } },
   colors: ['#22d3ee'], grid: { borderColor: '#1e293b' }, tooltip: { theme: 'dark' },
 }
@@ -342,12 +343,12 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
         <div>
           <h3 class="text-xs font-semibold text-slate-400 mb-2">By league</h3>
           <table class="w-full text-xs">
-            <thead><tr class="text-left text-slate-500"><th>League</th><th>Bets</th><th>P&L</th><th>ROI</th></tr></thead>
+            <thead><tr class="text-left text-slate-500"><th>League</th><th>Bets</th><th>P&L</th><th>Win%</th></tr></thead>
             <tbody>
               <tr v-for="(v, k) in result.per_league" :key="k" class="border-t border-border-subtle/40">
-                <td class="py-1 text-slate-300">{{ k }}</td><td class="text-slate-400">{{ v.n }}</td>
+                <td class="py-1 text-slate-300">{{ k }}</td><td class="text-slate-400">{{ v.n_bets }}</td>
                 <td :class="(v.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(v.pnl_cents) }}</td>
-                <td class="text-slate-400">{{ fmtPct(v.roi) }}</td>
+                <td class="text-slate-400">{{ fmtPct(v.win_rate) }}</td>
               </tr>
             </tbody>
           </table>
@@ -358,9 +359,9 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
             <thead><tr class="text-left text-slate-500"><th>Bucket</th><th>Predicted</th><th>Actual</th><th>n</th></tr></thead>
             <tbody>
               <tr v-for="(c, i) in result.calibration" :key="i" class="border-t border-border-subtle/40">
-                <td class="py-1 text-slate-400">{{ (c.bucket_lo * 100).toFixed(0) }}–{{ (c.bucket_hi * 100).toFixed(0) }}%</td>
-                <td class="text-slate-400">{{ (c.predicted * 100).toFixed(0) }}%</td>
-                <td class="text-slate-400">{{ (c.actual * 100).toFixed(0) }}%</td>
+                <td class="py-1 text-slate-400">{{ (c.bucket[0] * 100).toFixed(0) }}–{{ (c.bucket[1] * 100).toFixed(0) }}%</td>
+                <td class="text-slate-400">{{ (c.predicted_avg * 100).toFixed(0) }}%</td>
+                <td class="text-slate-400">{{ (c.actual_rate * 100).toFixed(0) }}%</td>
                 <td class="text-slate-400">{{ c.n }}</td>
               </tr>
             </tbody>

--- a/frontend/src/views/KalshiInstanceDetailView.vue
+++ b/frontend/src/views/KalshiInstanceDetailView.vue
@@ -325,6 +325,10 @@ onUnmounted(() => {
                     :class="running ? 'border border-amber-500/40 text-amber-400 hover:bg-amber-500/10' : 'bg-primary text-background-dark hover:brightness-110'">
               <span class="material-symbols-outlined text-[18px]">{{ running ? 'pause' : 'play_arrow' }}</span>{{ running ? 'Stop' : 'Start' }}
             </button>
+            <router-link :to="`/kalshi/instances/${id}/backtest`"
+                    class="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border-subtle text-slate-300 text-sm font-semibold hover:text-slate-100 hover:border-primary/50 transition-all">
+              <span class="material-symbols-outlined text-[18px]">science</span> Backtest
+            </router-link>
             <button @click="showEdit = true" :disabled="busy"
                     class="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border-subtle text-slate-300 text-sm font-semibold hover:text-slate-100 hover:border-primary/50 transition-all disabled:opacity-50">
               <span class="material-symbols-outlined text-[18px]">tune</span> Edit

--- a/mobile/lib/core/router/router.dart
+++ b/mobile/lib/core/router/router.dart
@@ -22,6 +22,7 @@ import '../../features/agent_runs/presentation/agent_runs_screen.dart';
 import '../../features/nexus/presentation/nexus_screen.dart';
 import '../../features/kalshi/presentation/kalshi_screen.dart';
 import '../../features/kalshi/presentation/kalshi_instance_detail_screen.dart';
+import '../../features/kalshi/presentation/kalshi_backtest_screen.dart';
 import '../../features/models/presentation/models_screen.dart';
 import '../../features/token_usage/presentation/token_usage_screen.dart';
 import '../../features/settings/presentation/settings_screen.dart';
@@ -120,6 +121,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: '/kalshi/instances/:id',
         parentNavigatorKey: _rootKey,
         builder: (_, s) => KalshiInstanceDetailScreen(instanceId: s.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/kalshi/instances/:id/backtest',
+        parentNavigatorKey: _rootKey,
+        builder: (_, s) => KalshiBacktestScreen(instanceId: s.pathParameters['id']!),
       ),
       // Detail / fullscreen routes pushed over the shell.
       GoRoute(

--- a/mobile/lib/features/kalshi/data/kalshi_repository.dart
+++ b/mobile/lib/features/kalshi/data/kalshi_repository.dart
@@ -171,6 +171,31 @@ class KalshiRepository {
 
   Future<void> deleteInstance(String id) =>
       _client.delete('/instances/$id', query: {'force': true});
+
+  // --- backtests ---
+  Future<String> createBacktest(String bid, Map<String, dynamic> body) async {
+    final d = await _client.post<Map<String, dynamic>>(
+        '/brokerages/$bid/kalshi/backtests', body: body);
+    return (d['id'] ?? '').toString();
+  }
+
+  Future<List<Map<String, dynamic>>> listBacktests(String bid) async {
+    final d = await _client.get<Map<String, dynamic>>('/brokerages/$bid/kalshi/backtests');
+    final list = (d['backtests'] ?? []) as List? ?? [];
+    return list.whereType<Map<String, dynamic>>().toList();
+  }
+
+  Future<Map<String, dynamic>> backtestStatus(String id) =>
+      _client.get<Map<String, dynamic>>('/kalshi/backtests/$id/status');
+
+  Future<Map<String, dynamic>> backtestResults(String id) =>
+      _client.get<Map<String, dynamic>>('/kalshi/backtests/$id/results');
+
+  Future<void> stopBacktest(String id) =>
+      _client.post('/kalshi/backtests/$id/stop');
+
+  Future<void> deleteBacktest(String id) =>
+      _client.delete('/kalshi/backtests/$id');
 }
 
 final kalshiRepositoryProvider = Provider<KalshiRepository>(

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
@@ -290,11 +290,11 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     final res = _result;
     final ec = (res?['equity_curve'] ?? []) as List? ?? [];
     final trades = (res?['trades'] ?? []) as List? ?? [];
+    // equity_curve is a bare list of cumulative-P&L cents, ordered by bet.
     final ts = <DateTime>[], vals = <double>[];
-    for (final p in ec) {
-      final m = p as Map;
-      ts.add(DateTime.fromMillisecondsSinceEpoch(((m['ts'] ?? 0) as num).toInt() * 1000));
-      vals.add(((m['cum_pnl_cents'] ?? 0) as num) / 100);
+    for (var i = 0; i < ec.length; i++) {
+      ts.add(DateTime.fromMillisecondsSinceEpoch(i * 3600000));
+      vals.add(((ec[i] ?? 0) as num) / 100);
     }
     return _card('Results', [
       Wrap(spacing: 10, runSpacing: 10, children: [
@@ -307,7 +307,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
       ]),
       const SizedBox(height: 12),
       if (vals.length > 1)
-        ScrubbableAreaChart(timestamps: ts, values: vals, lineColor: AppColors.chartLine, height: 200, baseline: 0),
+        ScrubbableAreaChart(timestamps: ts, values: vals, lineColor: AppColors.chartLine, height: 200, baseline: 0, indexed: true),
       if (trades.isNotEmpty) ...[
         const SizedBox(height: 12),
         Text('Trades (${trades.length})', style: const TextStyle(color: AppColors.textMuted, fontSize: 12, fontWeight: FontWeight.w600)),

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
@@ -1,0 +1,345 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/charts/scrubbable_area_chart.dart';
+import '../../../core/theme/app_colors.dart';
+import '../data/kalshi_repository.dart';
+
+const _kLeagues = [
+  'World Cup', 'World Cup Qualifiers', 'Champions League', 'Europa League',
+  'EPL', 'EFL Championship', 'Serie A', 'Serie B', 'La Liga', 'La Liga 2',
+  'Bundesliga', '2. Bundesliga', 'Ligue 1', 'Ligue 2', 'Eredivisie',
+  'Primeira Liga', 'MLS', 'Brasileirão',
+];
+
+class KalshiBacktestScreen extends ConsumerStatefulWidget {
+  const KalshiBacktestScreen({super.key, required this.instanceId});
+  final String instanceId;
+
+  @override
+  ConsumerState<KalshiBacktestScreen> createState() => _KalshiBacktestScreenState();
+}
+
+class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
+  String _bid = '';
+  final _name = TextEditingController();
+  final _oddsKey = TextEditingController();
+  List<String> _leagues = ['World Cup'];
+  DateTime? _start, _end;
+  double _bankroll = 54, _edgePct = 3, _noSharpPct = 8, _kelly = 0.2,
+      _orderMin = 5, _orderMax = 10, _sharpWeight = 85;
+
+  bool _submitting = false;
+  String? _err;
+  List<Map<String, dynamic>> _backtests = [];
+  Map<String, dynamic>? _selected; // status row
+  Map<String, dynamic>? _result;
+  Timer? _timer;
+
+  KalshiRepository get _repo => ref.read(kalshiRepositoryProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _timer = Timer.periodic(const Duration(seconds: 3), (_) => _tick());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _name.dispose();
+    _oddsKey.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final d = await _repo.instanceDetail(widget.instanceId);
+      final c = (d['config'] ?? {}) as Map<String, dynamic>;
+      setState(() {
+        _bid = (d['brokerage_id'] ?? '').toString();
+        if (c['edge_threshold'] != null) _edgePct = (c['edge_threshold'] as num) * 100;
+        if (c['no_sharp_edge_threshold'] != null) _noSharpPct = (c['no_sharp_edge_threshold'] as num) * 100;
+        if (c['kelly_fraction'] != null) _kelly = (c['kelly_fraction'] as num).toDouble();
+        if (c['order_size_min_cents'] != null) _orderMin = (c['order_size_min_cents'] as num) / 100;
+        if (c['order_size_max_cents'] != null) _orderMax = (c['order_size_max_cents'] as num) / 100;
+        if (c['sharp_weight'] != null) _sharpWeight = (c['sharp_weight'] as num) * 100;
+        if (c['bankroll_cents'] != null) _bankroll = (c['bankroll_cents'] as num) / 100;
+        if (c['leagues'] is List && (c['leagues'] as List).isNotEmpty) {
+          _leagues = (c['leagues'] as List).map((e) => e.toString()).toList();
+        }
+        if (c['oddspapi_api_key'] != null) _oddsKey.text = c['oddspapi_api_key'].toString();
+      });
+      await _loadBacktests();
+    } catch (_) {
+      setState(() => _err = "Couldn't load the instance config.");
+    }
+  }
+
+  Future<void> _loadBacktests() async {
+    if (_bid.isEmpty) return;
+    try {
+      final list = await _repo.listBacktests(_bid);
+      if (mounted) setState(() => _backtests = list);
+    } catch (_) {/* transient */}
+  }
+
+  Future<void> _tick() async {
+    await _loadBacktests();
+    final sel = _selected;
+    if (sel != null && (sel['status'] == 'pending' || sel['status'] == 'running')) {
+      await _openResults(sel['id'].toString());
+    }
+  }
+
+  String _fmtDate(DateTime? d) =>
+      d == null ? '' : '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  Future<void> _pick(bool isStart) async {
+    final now = DateTime.now();
+    final d = await showDatePicker(
+      context: context,
+      initialDate: (isStart ? _start : _end) ?? now,
+      firstDate: DateTime(2024), lastDate: DateTime(now.year + 1),
+    );
+    if (d != null) setState(() => isStart ? _start = d : _end = d);
+  }
+
+  Future<void> _submit() async {
+    setState(() => _err = null);
+    if (_start == null || _end == null) return setState(() => _err = 'Pick a start and end date.');
+    if (_fmtDate(_start).compareTo(_fmtDate(_end)) > 0) return setState(() => _err = 'Start must be on/before end.');
+    if (_leagues.isEmpty) return setState(() => _err = 'Select at least one league.');
+    setState(() => _submitting = true);
+    try {
+      final body = {
+        'name': _name.text.isEmpty ? 'Backtest ${_fmtDate(_start)}..${_fmtDate(_end)}' : _name.text,
+        'instance_id': widget.instanceId,
+        'leagues': _leagues,
+        'start_date': _fmtDate(_start),
+        'end_date': _fmtDate(_end),
+        'bankroll_dollars': _bankroll,
+        'config': {
+          'edge_threshold': _edgePct / 100,
+          'no_sharp_edge_threshold': _noSharpPct / 100,
+          'kelly_fraction': _kelly,
+          'order_size_min_dollars': _orderMin,
+          'order_size_max_dollars': _orderMax,
+          'sharp_weight': _sharpWeight / 100,
+          if (_oddsKey.text.isNotEmpty) 'oddspapi_api_key': _oddsKey.text,
+        },
+      };
+      final id = await _repo.createBacktest(_bid, body);
+      await _loadBacktests();
+      await _openResults(id);
+    } catch (_) {
+      setState(() => _err = 'Failed to start the backtest.');
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  Future<void> _openResults(String id) async {
+    try {
+      final d = await _repo.backtestResults(id);
+      if (!mounted) return;
+      setState(() {
+        _selected = {'id': id, 'status': d['status'], 'summary': d['summary'] ?? {}};
+        _result = d['result'] as Map<String, dynamic>?;
+      });
+    } catch (_) {/* ignore */}
+  }
+
+  String _money(dynamic cents) =>
+      cents == null ? '—' : '\$${((cents as num) / 100).toStringAsFixed(2)}';
+  String _pct(dynamic v) => v == null ? '—' : '${((v as num) * 100).toStringAsFixed(1)}%';
+  Color _statusColor(String? s) => s == 'finished'
+      ? AppColors.success
+      : s == 'error' ? AppColors.danger : s == 'stopped' ? AppColors.textDim : AppColors.warning;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.canvas,
+      appBar: AppBar(title: const Text('Backtest'), backgroundColor: AppColors.canvas),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (_err != null) Padding(padding: const EdgeInsets.only(bottom: 8), child: Text(_err!, style: const TextStyle(color: AppColors.warning))),
+          _card('New backtest', [
+            _field('Name', _name),
+            const SizedBox(height: 8),
+            Row(children: [
+              Expanded(child: _dateBtn('Start', _start, () => _pick(true))),
+              const SizedBox(width: 8),
+              Expanded(child: _dateBtn('End', _end, () => _pick(false))),
+            ]),
+            const SizedBox(height: 10),
+            const Text('Leagues', style: TextStyle(color: AppColors.textMuted, fontSize: 12)),
+            Wrap(spacing: 6, runSpacing: 6, children: [
+              for (final l in _kLeagues)
+                FilterChip(
+                  label: Text(l, style: const TextStyle(fontSize: 11)),
+                  selected: _leagues.contains(l),
+                  onSelected: (v) => setState(() => v ? _leagues.add(l) : _leagues.remove(l)),
+                  selectedColor: AppColors.primary.withValues(alpha: 0.25),
+                  backgroundColor: AppColors.surface,
+                ),
+            ]),
+            const SizedBox(height: 10),
+            Wrap(spacing: 10, runSpacing: 10, children: [
+              _num('Bankroll (\$)', _bankroll, (v) => _bankroll = v),
+              _num('Edge bar (%)', _edgePct, (v) => _edgePct = v),
+              _num('No-sharp (%)', _noSharpPct, (v) => _noSharpPct = v),
+              _num('Kelly', _kelly, (v) => _kelly = v),
+              _num('Order min (\$)', _orderMin, (v) => _orderMin = v),
+              _num('Order max (\$)', _orderMax, (v) => _orderMax = v),
+              _num('Sharp wt (%)', _sharpWeight, (v) => _sharpWeight = v),
+            ]),
+            const SizedBox(height: 8),
+            _field('OddsPapi API key (sharp line; blank = model-only)', _oddsKey),
+            const SizedBox(height: 12),
+            SizedBox(width: double.infinity, child: ElevatedButton(
+              onPressed: _submitting || _bid.isEmpty ? null : _submit,
+              style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary, foregroundColor: AppColors.onPrimary),
+              child: Text(_submitting ? 'Starting…' : 'Run backtest'),
+            )),
+          ]),
+          const SizedBox(height: 16),
+          _card('Backtests', [
+            if (_backtests.isEmpty)
+              const Text('No backtests yet.', style: TextStyle(color: AppColors.textDim))
+            else
+              for (final b in _backtests) _btRow(b),
+          ]),
+          if (_selected != null) ...[
+            const SizedBox(height: 16),
+            _resultsCard(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _card(String title, List<Widget> children) => Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(color: AppColors.surface, borderRadius: BorderRadius.circular(14), border: Border.all(color: AppColors.border)),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(title, style: const TextStyle(color: AppColors.textHi, fontWeight: FontWeight.w600, fontSize: 14)),
+          const SizedBox(height: 10),
+          ...children,
+        ]),
+      );
+
+  Widget _field(String label, TextEditingController c) => TextField(
+        controller: c,
+        style: const TextStyle(color: AppColors.textHi, fontSize: 13),
+        decoration: InputDecoration(labelText: label, labelStyle: const TextStyle(color: AppColors.textMuted, fontSize: 12), isDense: true,
+          enabledBorder: OutlineInputBorder(borderSide: const BorderSide(color: AppColors.border), borderRadius: BorderRadius.circular(8))),
+      );
+
+  Widget _dateBtn(String label, DateTime? d, VoidCallback onTap) => OutlinedButton(
+        onPressed: onTap,
+        style: OutlinedButton.styleFrom(side: const BorderSide(color: AppColors.border), foregroundColor: AppColors.textMd),
+        child: Text(d == null ? label : _fmtDate(d), style: const TextStyle(fontSize: 12)),
+      );
+
+  Widget _num(String label, double value, ValueChanged<double> onChanged) => SizedBox(
+        width: 110,
+        child: TextFormField(
+          initialValue: value == value.roundToDouble() ? value.toInt().toString() : value.toString(),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          style: const TextStyle(color: AppColors.textHi, fontSize: 13),
+          decoration: InputDecoration(labelText: label, labelStyle: const TextStyle(color: AppColors.textMuted, fontSize: 11), isDense: true,
+            enabledBorder: OutlineInputBorder(borderSide: const BorderSide(color: AppColors.border), borderRadius: BorderRadius.circular(8))),
+          onChanged: (t) => onChanged(double.tryParse(t) ?? value),
+        ),
+      );
+
+  Widget _btRow(Map<String, dynamic> b) {
+    final status = b['status']?.toString();
+    final summary = (b['summary'] ?? {}) as Map;
+    final pnl = summary['pnl_cents'];
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(children: [
+        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text((b['name'] ?? b['id'].toString().substring(0, 8)).toString(), style: const TextStyle(color: AppColors.textMd, fontSize: 13)),
+          Text('${b['start_date']} → ${b['end_date']}', style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+        ])),
+        Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
+          Text(status == 'running' || status == 'pending' ? '$status ${(b['progress'] ?? 0).round()}%' : (status ?? ''),
+              style: TextStyle(color: _statusColor(status), fontSize: 12)),
+          Text(pnl == null ? '—' : _money(pnl),
+              style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 12)),
+        ]),
+        const SizedBox(width: 6),
+        IconButton(icon: const Icon(Icons.visibility_outlined, size: 18, color: AppColors.primary), onPressed: () => _openResults(b['id'].toString())),
+        if (status == 'running' || status == 'pending')
+          IconButton(icon: const Icon(Icons.stop_circle_outlined, size: 18, color: AppColors.warning), onPressed: () async { await _repo.stopBacktest(b['id'].toString()); await _loadBacktests(); }),
+        IconButton(icon: const Icon(Icons.delete_outline, size: 18, color: AppColors.textDim), onPressed: () async { await _repo.deleteBacktest(b['id'].toString()); await _loadBacktests(); }),
+      ]),
+    );
+  }
+
+  Widget _resultsCard() {
+    final sel = _selected!;
+    final summary = (sel['summary'] ?? {}) as Map;
+    final res = _result;
+    final ec = (res?['equity_curve'] ?? []) as List? ?? [];
+    final trades = (res?['trades'] ?? []) as List? ?? [];
+    final ts = <DateTime>[], vals = <double>[];
+    for (final p in ec) {
+      final m = p as Map;
+      ts.add(DateTime.fromMillisecondsSinceEpoch(((m['ts'] ?? 0) as num).toInt() * 1000));
+      vals.add(((m['cum_pnl_cents'] ?? 0) as num) / 100);
+    }
+    return _card('Results', [
+      Wrap(spacing: 10, runSpacing: 10, children: [
+        _stat('Total P&L', _money(summary['pnl_cents']), (summary['pnl_cents'] ?? 0) >= 0 ? AppColors.success : AppColors.danger),
+        _stat('ROI', _pct(summary['roi']), AppColors.textHi),
+        _stat('Bets', '${summary['n_bets'] ?? '—'}', AppColors.textHi),
+        _stat('Win rate', _pct(summary['win_rate']), AppColors.textHi),
+        _stat('Avg CLV', _pct(summary['clv_avg']), AppColors.textHi),
+        _stat('API/cache', '${summary['api_calls'] ?? 0}/${summary['cache_hits'] ?? 0}', AppColors.textMuted),
+      ]),
+      const SizedBox(height: 12),
+      if (vals.length > 1)
+        ScrubbableAreaChart(timestamps: ts, values: vals, lineColor: AppColors.chartLine, height: 200, baseline: 0),
+      if (trades.isNotEmpty) ...[
+        const SizedBox(height: 12),
+        Text('Trades (${trades.length})', style: const TextStyle(color: AppColors.textMuted, fontSize: 12, fontWeight: FontWeight.w600)),
+        for (final t in trades.take(60)) _tradeRow(t as Map),
+      ],
+      if (res != null && trades.isEmpty && sel['status'] == 'finished')
+        const Padding(padding: EdgeInsets.only(top: 8), child: Text('No bets were placed under these settings over this range.', style: TextStyle(color: AppColors.textDim, fontSize: 12))),
+    ]);
+  }
+
+  Widget _stat(String label, String value, Color color) => Container(
+        width: 104,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(color: AppColors.canvas, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(label, style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+          Text(value, style: TextStyle(color: color, fontSize: 15, fontWeight: FontWeight.w600)),
+        ]),
+      );
+
+  Widget _tradeRow(Map t) {
+    final pnl = t['realized_pnl_cents'];
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(children: [
+        Expanded(child: Text('${t['market_ticker']}', style: const TextStyle(color: AppColors.textMd, fontSize: 11), overflow: TextOverflow.ellipsis)),
+        Text('${t['side']} · ${t['entry_cents']}¢ ×${t['size']}', style: const TextStyle(color: AppColors.textMuted, fontSize: 11)),
+        const SizedBox(width: 8),
+        Text('${t['outcome']}', style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+        const SizedBox(width: 8),
+        Text(_money(pnl), style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 11)),
+      ]),
+    );
+  }
+}

--- a/mobile/lib/features/kalshi/presentation/kalshi_instance_detail_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_instance_detail_screen.dart
@@ -177,6 +177,11 @@ class _State extends ConsumerState<KalshiInstanceDetailScreen> {
                   ),
                 ),
                 IconButton(
+                  onPressed: () => context.push('/kalshi/instances/${widget.instanceId}/backtest'),
+                  icon: Icon(Icons.science_outlined, color: AppColors.warning),
+                  tooltip: 'Backtest',
+                ),
+                IconButton(
                   onPressed: _busy ? null : () => _editInstance(detail),
                   icon: Icon(Icons.tune, color: AppColors.primary),
                   tooltip: 'Edit config',


### PR DESCRIPTION
## What

Adds a **backtest** feature to the Kalshi soccer bot, on both **web** and **mobile**, mirroring the stock-backtest UX (pick leagues + tuning + date range → run → results). The replay drives the **same pure functions the live bot uses** (`fusion`/`edge`/`candidates`/`risk`/`planner`/`reconcile`), so it genuinely tests the real strategy.

## How the data works (all free)
- **Kalshi prices** — public `external-api.kalshi.com/.../series/{s}/markets/{ticker}/candlesticks` (no auth)
- **Final results** — free from Kalshi settled markets (`result: yes|no` per side)
- **Sharp line** — OddsPapi `/v4/historical-odds` (Pinnacle, free tier); wires up the previously-dead `OddsPapiClient`
- **Caching (required):** immutable historical data is cached in RethinkDB; re-running a backtest over the same fixtures costs **0 API calls** (proven in the live smoke).

## Structure
- Backend: `kalshi/backtest.py` (config/evaluate/settle/aggregate/run_backtest/model_fn), `kalshi/backtest_data.py` (fetch-or-cache provider), `kalshi/backtest_worker.py` (in-process changefeed worker), client candlestick/settled-market methods, 6 FastAPI endpoints, 5 cache/job tables.
- Web: `KalshiBacktestView.vue` (create form + list + results: equity chart, trades, calibration, per-league) + route + nav button.
- Mobile: `kalshi_backtest_screen.dart` (form, leagues chips, date pickers, tuning, results w/ equity chart + stat tiles + trades) + repo methods + route + nav.

## Verification
- **Live end-to-end smoke on real Kalshi data**: replayed the June-30 WC slate — correct results, P&L computed, and caching proven (2nd run = 0 API calls). Caught + fixed a real bug (unbounded candle range → Kalshi 400).
- **412** kalshi/backtest tests pass; `npm run build` clean; `flutter analyze` clean (new files).

## Notes / follow-ups
- **Prerequisite:** a free OddsPapi API key (entered in the form) for the sharp line + fixture discovery. Without it the engine runs model-only, but the UI has no fixture source — a Kalshi-settled-markets fixture fallback is a possible follow-up.
- National-team Elo is current-only → model-only calibration metrics are *indicative*; strategy P&L anchors to the real historical sharp line.
- Pre-existing repo notes surfaced during review (unrelated): ~100× fee discrepancy between `reconcile._fee_cents` and `fees.fee_cents_for_order` (settle uses `reconcile`, the live grading path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)