### PR TITLE
feat(kalshi): backtest full settings + LLM analyst + saved OddsPapi key

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4347,6 +4347,12 @@ def api_kalshi_create_backtest(brokerage_id: str, body: KalshiBacktestBody, conn
             for k in ("oddspapi_api_key", "odds_api_key"):
                 if not cfg.get(k) and icfg.get(k):
                     cfg[k] = icfg.get(k)
+            # Persist a newly-entered OddsPapi key onto the instance so it's saved
+            # once and prefilled on subsequent backtests (deep-merged into config).
+            new_key = cfg.get("oddspapi_api_key")
+            if new_key and new_key != icfg.get("oddspapi_api_key"):
+                _r_auth.db("IntelliStock").table("Instances").get(str(body.instance_id)).update(
+                    {"kalshi_config": {"oddspapi_api_key": new_key}}).run(conn)
         except Exception:
             pass
     jid = str(_uuid.uuid4())

--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -64,6 +64,9 @@ class BacktestConfig:
     devig_method: str
     decision_offsets_sec: tuple = (-3 * 3600,)
     fee_rate: float = DEFAULT_FEE_RATE
+    model: str = ""              # analyst LLM model id (Models table); "" = none
+    analyst_max_calls: int = 10  # cap on LLM analyst calls (cost control)
+    use_llm: bool = False        # whether the replay runs the LLM analyst
 
 
 def config_from_body(body: dict) -> BacktestConfig:
@@ -110,6 +113,9 @@ def config_from_body(body: dict) -> BacktestConfig:
         devig_method=devig_method,
         decision_offsets_sec=decision_offsets_sec,
         fee_rate=float(body.get("fee_rate", DEFAULT_FEE_RATE)),
+        model=str(body.get("model") or ""),
+        analyst_max_calls=int(body.get("analyst_max_calls", 10) or 10),
+        use_llm=bool(body.get("use_llm", False)),
     )
 
 
@@ -137,7 +143,7 @@ class SizedBet:
 
 
 def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
-             kalshi_asks: dict, fixture: dict) -> list["SizedBet"]:
+             kalshi_asks: dict, fixture: dict, llm_adjustments: dict = None) -> list["SizedBet"]:
     """Replicate the live pre-match decision path for ONE fixture:
     fuse model+sharp probs -> generate edge-gated candidates -> size via the
     quarter-Kelly/order-size-range planner. `model_probs`/`sharp_probs` are
@@ -171,12 +177,15 @@ def evaluate(cfg: BacktestConfig, model_probs: dict, sharp_probs: dict,
     sharp_probs = sharp_probs or {}
     model_probs = model_probs or {}
     kalshi_asks = kalshi_asks or {}
+    llm_adjustments = llm_adjustments or {}
 
     base = {}
     for side in set(model_probs) | set(sharp_probs):
         sharp_v = sharp_probs.get(side)
         model_v = model_probs.get(side, sharp_v if sharp_v is not None else 0.0)
-        base[side] = fuse(sharp=sharp_v, model=model_v, llm_adjustment=0.0, w_sharp=cfg.sharp_weight, llm_cap=0.05)
+        base[side] = fuse(sharp=sharp_v, model=model_v,
+                          llm_adjustment=float(llm_adjustments.get(side, 0.0) or 0.0),
+                          w_sharp=cfg.sharp_weight, llm_cap=0.05)
     fused = {"winner": renormalize_group(base) if base else {}}
     sharp_by_type = {"winner": dict(sharp_probs)} if sharp_probs else {}
 
@@ -408,7 +417,7 @@ def _sharp_probs_at(oddseries: list[dict], snap_ts: int, devig_method: str) -> d
     return {"home": p[0], "draw": p[1], "away": p[2]}
 
 
-def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None) -> BacktestResult:
+def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_fn=None) -> BacktestResult:
     """Replay `data`'s fixture history through `evaluate`/`settle`/`aggregate`,
     in kickoff order, one decision snapshot per fixture.
 
@@ -479,9 +488,15 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None) -> Backt
                     log.info("run_backtest: skipping fixture_id=%s reason=no_candle_data", fixture_id)
                 else:
                     model_probs = model_fn(fx) or {}
+                    llm_adj = {}
+                    if analyst_fn is not None:
+                        try:
+                            llm_adj = analyst_fn(fx, model_probs, sharp_probs) or {}
+                        except Exception:
+                            llm_adj = {}   # analyst failure -> no-op (statistical model only)
                     fx_for_eval = dict(fx)
                     fx_for_eval["market_tickers"] = tickers
-                    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fx_for_eval)
+                    bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fx_for_eval, llm_adj)
                     for bet in bets:
                         trades.append(settle(bet, result, cfg.fee_rate))
 

--- a/backend/kalshi/backtest_worker.py
+++ b/backend/kalshi/backtest_worker.py
@@ -31,7 +31,7 @@ class _Stopped(Exception):
 
 
 def run_job(job, *, conn, provider, model_fn, store=_db, stop_check=None,
-            run_fn=_run_backtest) -> str:
+            run_fn=_run_backtest, analyst_fn=None) -> str:
     """Run one backtest job to completion, writing status/progress/result via
     `store`. Returns the terminal status ('finished' | 'stopped' | 'error').
 
@@ -61,7 +61,7 @@ def run_job(job, *, conn, provider, model_fn, store=_db, stop_check=None,
                 last[0] = frac
                 store.update_backtest_progress(conn, jid, progress=round(frac * 100, 2))
 
-        result = run_fn(cfg, provider, model_fn, progress_cb=progress_cb)
+        result = run_fn(cfg, provider, model_fn, progress_cb=progress_cb, analyst_fn=analyst_fn)
 
         store.save_backtest_result(conn, jid, result)
         summary = dict(getattr(result, "summary", {}) or {})
@@ -135,12 +135,50 @@ def _build_job_context(job, conn):  # pragma: no cover - integration
     except Exception:
         elo = {}
     model_fn = build_model_fn(nat_elo, elo)
-    return provider, model_fn
+    analyst_fn = _build_analyst_fn(cfg, conn)
+    return provider, model_fn, analyst_fn
+
+
+def _build_analyst_fn(cfg, conn):  # pragma: no cover - integration
+    """Build the LLM analyst closure for a backtest, or None. Uses the configured
+    Models-table model; news is intentionally empty (a past fixture has no
+    time-faithful news feed), so the analyst adjusts on the feature bundle only.
+    Any failure degrades to None -> the replay runs on the statistical model."""
+    if not cfg.get("use_llm") or not cfg.get("model"):
+        return None
+    try:
+        model_doc = _db._r.db(_db.DB_NAME).table("Models").get(cfg["model"]).run(conn)
+    except Exception:
+        model_doc = None
+    if not model_doc:
+        return None
+    try:
+        from kalshi.intelligence.analyst_panel import analyze, make_llm_call
+    except Exception:
+        return None
+    llm_call = make_llm_call(model_doc)
+    if llm_call is None:
+        return None
+
+    def analyst_fn(fx, model_probs, sharp_probs):
+        markets = list((model_probs or {}).keys()) or ["home", "draw", "away"]
+        features = {
+            "home": fx.get("home"), "away": fx.get("away"),
+            "league": fx.get("league"), "model_probs": model_probs,
+            "home_elo": fx.get("home_elo"), "away_elo": fx.get("away_elo"),
+            "home_xg": fx.get("home_xg"), "away_xg": fx.get("away_xg"),
+        }
+        try:
+            return analyze(features, markets, news="", llm_call=llm_call).get("adjustments", {})
+        except Exception:
+            return {}
+
+    return analyst_fn
 
 
 def _run_job_production(job, conn):  # pragma: no cover - integration
-    provider, model_fn = _build_job_context(job, conn)
-    return run_job(job, conn=conn, provider=provider, model_fn=model_fn)
+    provider, model_fn, analyst_fn = _build_job_context(job, conn)
+    return run_job(job, conn=conn, provider=provider, model_fn=model_fn, analyst_fn=analyst_fn)
 
 
 def start_worker(conn_factory, *, max_workers: int = 2):  # pragma: no cover - integration

--- a/backend/kalshi/instance_config.py
+++ b/backend/kalshi/instance_config.py
@@ -123,6 +123,9 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         "stop_loss_frac": float(raw.get("stop_loss_frac", 0.35)),
         # Sharp-odds anchor (de-vig'd bookmaker odds -> fair value -> edge vs Kalshi).
         "odds_api_key": str(raw.get("odds_api_key") or "").strip(),
+        # OddsPapi key (historical sharp line for backtests). Persisted so it's
+        # entered once and reused across backtests.
+        "oddspapi_api_key": str(raw.get("oddspapi_api_key") or "").strip(),
         "sharp_weight": min(1.0, max(0.0, float(raw.get("sharp_weight", 0.85)))),
         "devig_method": (str(raw.get("devig_method") or "power").lower()
                          if str(raw.get("devig_method") or "power").lower()

--- a/backend/tests/test_kalshi_backtest_llm.py
+++ b/backend/tests/test_kalshi_backtest_llm.py
@@ -1,0 +1,61 @@
+"""LLM analyst plumbing: llm_adjustments shift the fused prob (evaluate) and
+run_backtest calls the injected analyst_fn."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi.backtest import config_from_body, evaluate, run_backtest
+
+
+def _cfg():
+    return config_from_body({
+        "leagues": ["World Cup"], "start_date": "2026-06-29", "end_date": "2026-07-01",
+        "bankroll_cents": 10000, "edge_threshold": 0.02, "no_sharp_edge_threshold": 0.0,
+        "order_size_min_cents": 500, "order_size_max_cents": 1000, "kelly_fraction": 0.2,
+        "min_price_cents": 1, "max_price_cents": 99,
+    })
+
+
+def test_positive_llm_adjustment_raises_home_fused_fair_and_still_bets():
+    cfg = _cfg()
+    fx = {"fixture_id": "F", "league": "World Cup", "market_tickers": {"home": "F-H"}}
+    mp = {"home": 0.50, "draw": 0.30, "away": 0.20}
+    asks = {"home": 40}
+    b0 = evaluate(cfg, mp, {}, asks, fx, {})
+    b1 = evaluate(cfg, mp, {}, asks, fx, {"home": 0.10})   # clamped to llm_cap 0.05
+    assert b0 and b1
+    assert b1[0].fused_fair > b0[0].fused_fair
+
+
+class _Provider:
+    """Minimal fake: one settled, bettable fixture."""
+    def __init__(self):
+        self.api_calls = 0
+        self.cache_hits = 0
+    def fixtures(self, leagues, s, e):
+        return [{"fixture_id": "F", "league": "World Cup", "kickoff_ts": 20_000}]
+    def final_score(self, fx):
+        return "home"
+    def kalshi_tickers(self, fx):
+        return {"home": "F-H", "draw": "F-T", "away": "F-A"}
+    def candles(self, ticker, start_ts=0, end_ts=4102444800):
+        # a single hourly candle before the decision snapshot (kickoff-3h)
+        asks = {"F-H": "0.40", "F-T": "0.30", "F-A": "0.30"}
+        return [{"end_period_ts": 100, "yes_ask": {"close_dollars": asks.get(ticker, "0.50")}}]
+    def sharp_odds(self, fx):
+        return []
+
+
+def test_run_backtest_invokes_analyst_fn():
+    cfg = _cfg()
+    calls = []
+
+    def analyst_fn(fx, model_probs, sharp_probs):
+        calls.append((fx.get("fixture_id"), dict(model_probs)))
+        return {"home": 0.05}
+
+    def model_fn(fx):
+        return {"home": 0.50, "draw": 0.30, "away": 0.20}
+
+    res = run_backtest(cfg, _Provider(), model_fn, analyst_fn=analyst_fn)
+    assert calls and calls[0][0] == "F"
+    assert res.n_bets >= 1

--- a/backend/tests/test_kalshi_backtest_worker.py
+++ b/backend/tests/test_kalshi_backtest_worker.py
@@ -36,7 +36,7 @@ def test_run_job_finished_saves_result_and_summary():
     store = FakeStore()
     job = {"id": "b1", "config": {"leagues": ["World Cup"], "bankroll_cents": 5400}}
 
-    def fake_run(cfg, provider, model_fn, progress_cb=None):
+    def fake_run(cfg, provider, model_fn, progress_cb=None, analyst_fn=None):
         progress_cb(0.5); progress_cb(1.0)
         return _result()
 
@@ -54,7 +54,7 @@ def test_run_job_stopped_when_run_flag_cleared():
     store = FakeStore(run_flag=False)   # stop_check() -> True on first progress
     job = {"id": "b2", "config": {}}
 
-    def fake_run(cfg, provider, model_fn, progress_cb=None):
+    def fake_run(cfg, provider, model_fn, progress_cb=None, analyst_fn=None):
         progress_cb(0.1)   # should raise _Stopped inside
         return _result()   # never reached
 
@@ -69,7 +69,7 @@ def test_run_job_error_records_message():
     store = FakeStore()
     job = {"id": "b3", "config": {}}
 
-    def fake_run(cfg, provider, model_fn, progress_cb=None):
+    def fake_run(cfg, provider, model_fn, progress_cb=None, analyst_fn=None):
         raise ValueError("boom")
 
     status = run_job(job, conn=None, provider=object(), model_fn=object(),

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -20,29 +20,74 @@ const LEAGUES = [
   'Primeira Liga', 'MLS', 'Brasileirão',
 ]
 
+// Risk presets tune every config value (mirrors instance creation).
+const RISK_PRESETS = {
+  low: { label: 'Low', edgePct: 5, kelly: 0.10, maxContracts: 25, exposurePct: 10, leagueCapPct: 12, usagePct: 40, dailyLossPct: 5, orderMin: 1, orderMax: 3 },
+  medium: { label: 'Medium', edgePct: 4, kelly: 0.125, maxContracts: 50, exposurePct: 15, leagueCapPct: 25, usagePct: 50, dailyLossPct: 8, orderMin: 2, orderMax: 5 },
+  high: { label: 'High', edgePct: 3, kelly: 0.15, maxContracts: 75, exposurePct: 25, leagueCapPct: 30, usagePct: 60, dailyLossPct: 10, orderMin: 5, orderMax: 10 },
+  max: { label: 'Max', edgePct: 2, kelly: 0.20, maxContracts: 100, exposurePct: 40, leagueCapPct: 40, usagePct: 70, dailyLossPct: 15, orderMin: 8, orderMax: 15 },
+}
+const PRESET_DESC = {
+  low: 'Conservative — fewer, higher-conviction bets at small size.',
+  medium: 'Balanced edge, size, and exposure.',
+  high: 'More +EV spots at larger size; higher variance.',
+  max: 'Aggressive — most +EV spots at largest size. Highest variance.',
+}
+
 const brokerageId = ref('')
 const loadErr = ref('')
 
-// --- create form ---
-const name = ref('')
+// --- form state ---
+const tier = ref('max')
 const leagues = ref(['World Cup'])
 const startDate = ref('')
 const endDate = ref('')
-const bankroll = ref(54)          // dollars
-const edgePct = ref(3)            // %
-const noSharpPct = ref(8)         // %
+const bankroll = ref(54)
+const edgePct = ref(2)
+const noSharpPct = ref(3)
 const kelly = ref(0.2)
-const orderMin = ref(5)           // $
-const orderMax = ref(10)          // $
-const sharpWeight = ref(85)       // %
+const maxContracts = ref(100)
+const exposurePct = ref(40)
+const leagueCapPct = ref(40)
+const usagePct = ref(70)
+const dailyLossPct = ref(15)
+const minPrice = ref(15)
+const maxPrice = ref(90)
+const drawMinEdge = ref(10)
+const orderMin = ref(8)
+const orderMax = ref(15)
+const sharpWeight = ref(85)
 const oddspapiKey = ref('')
+
+// LLM analyst
+const models = ref([])
+const modelId = ref('')
+const useLlm = ref(false)
+const analystMaxCalls = ref(10)
+
 const submitting = ref(false)
 const submitErr = ref('')
 
+function applyPreset(key) {
+  tier.value = key
+  const p = RISK_PRESETS[key]
+  edgePct.value = p.edgePct; kelly.value = p.kelly; maxContracts.value = p.maxContracts
+  exposurePct.value = p.exposurePct; leagueCapPct.value = p.leagueCapPct
+  usagePct.value = p.usagePct; dailyLossPct.value = p.dailyLossPct
+  orderMin.value = p.orderMin; orderMax.value = p.orderMax
+}
 function toggleLeague(l) {
   const i = leagues.value.indexOf(l)
-  if (i >= 0) leagues.value.splice(i, 1)
-  else leagues.value.push(l)
+  if (i >= 0) leagues.value.splice(i, 1); else leagues.value.push(l)
+}
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${API_BASE}/models`, { headers: authHeaders() })
+    if (!res.ok) return
+    const d = await res.json()
+    models.value = (d.models || d || []).filter((m) => m && m.id)
+  } catch (e) { /* ignore */ }
 }
 
 async function loadInstance() {
@@ -52,15 +97,26 @@ async function loadInstance() {
     const d = await res.json()
     brokerageId.value = d.brokerage_id
     const c = d.config || {}
+    if (c.tier) tier.value = c.tier
     if (c.edge_threshold != null) edgePct.value = Math.round(c.edge_threshold * 1000) / 10
     if (c.no_sharp_edge_threshold != null) noSharpPct.value = Math.round(c.no_sharp_edge_threshold * 1000) / 10
     if (c.kelly_fraction != null) kelly.value = c.kelly_fraction
+    if (c.max_contracts_per_market != null) maxContracts.value = c.max_contracts_per_market
+    if (c.max_open_exposure_frac != null) exposurePct.value = Math.round(c.max_open_exposure_frac * 100)
+    if (c.per_league_cap_frac != null) leagueCapPct.value = Math.round(c.per_league_cap_frac * 100)
+    if (c.bankroll_usage_pct != null) usagePct.value = c.bankroll_usage_pct
+    if (c.daily_loss_cap_frac != null) dailyLossPct.value = Math.round(c.daily_loss_cap_frac * 100)
+    if (c.min_price_cents != null) minPrice.value = c.min_price_cents
+    if (c.max_price_cents != null) maxPrice.value = c.max_price_cents
+    if (c.draw_min_edge != null) drawMinEdge.value = Math.round(c.draw_min_edge * 1000) / 10
     if (c.order_size_min_cents != null) orderMin.value = Math.round(c.order_size_min_cents) / 100
     if (c.order_size_max_cents != null) orderMax.value = Math.round(c.order_size_max_cents) / 100
     if (c.sharp_weight != null) sharpWeight.value = Math.round(c.sharp_weight * 100)
     if (c.bankroll_cents != null) bankroll.value = Math.round(c.bankroll_cents / 100)
     if (Array.isArray(c.leagues) && c.leagues.length) leagues.value = [...c.leagues]
     if (c.oddspapi_api_key) oddspapiKey.value = c.oddspapi_api_key
+    if (c.model) { modelId.value = c.model; useLlm.value = true }
+    if (c.analyst_max_calls != null) analystMaxCalls.value = c.analyst_max_calls
   } catch (e) {
     loadErr.value = "Couldn't load the instance config."
   }
@@ -74,20 +130,31 @@ async function submit() {
   submitting.value = true
   try {
     const body = {
-      name: name.value || `Backtest ${startDate.value}..${endDate.value}`,
       instance_id: instanceId,
       leagues: leagues.value,
       start_date: startDate.value,
       end_date: endDate.value,
       bankroll_dollars: Number(bankroll.value) || 0,
       config: {
+        tier: tier.value,
         edge_threshold: Number(edgePct.value) / 100,
         no_sharp_edge_threshold: Number(noSharpPct.value) / 100,
         kelly_fraction: Number(kelly.value),
+        max_contracts_per_market: Number(maxContracts.value),
+        max_open_exposure_frac: Number(exposurePct.value) / 100,
+        per_league_cap_frac: Number(leagueCapPct.value) / 100,
+        bankroll_usage_pct: Number(usagePct.value),
+        daily_loss_cap_frac: Number(dailyLossPct.value) / 100,
+        min_price_cents: Number(minPrice.value),
+        max_price_cents: Number(maxPrice.value),
+        draw_min_edge: Number(drawMinEdge.value) / 100,
         order_size_min_dollars: Number(orderMin.value) || 0,
         order_size_max_dollars: Number(orderMax.value) || 0,
         sharp_weight: Number(sharpWeight.value) / 100,
         oddspapi_api_key: oddspapiKey.value || undefined,
+        model: useLlm.value ? (modelId.value || undefined) : undefined,
+        use_llm: useLlm.value && !!modelId.value,
+        analyst_max_calls: Number(analystMaxCalls.value) || 10,
       },
     }
     const res = await fetch(`${API_BASE}/brokerages/${brokerageId.value}/kalshi/backtests`, {
@@ -115,11 +182,7 @@ async function loadBacktests() {
     if (!res.ok) return
     const d = await res.json()
     backtests.value = d.backtests || []
-  } catch (e) { /* ignore transient */ }
-}
-
-function anyRunning() {
-  return backtests.value.some((b) => b.status === 'pending' || b.status === 'running')
+  } catch (e) { /* ignore */ }
 }
 
 async function tick() {
@@ -141,8 +204,8 @@ async function delBacktest(id) {
 }
 
 // --- results ---
-const selected = ref(null)     // status row
-const result = ref(null)       // heavy result
+const selected = ref(null)
+const result = ref(null)
 
 async function refreshResults(id) {
   try {
@@ -160,7 +223,6 @@ function openResults(id) {
 }
 
 const equitySeries = computed(() => {
-  // equity_curve is a bare list of cumulative-P&L cents, ordered by bet.
   const ec = (result.value && result.value.equity_curve) || []
   return [{ name: 'Cumulative P&L ($)', data: ec.map((v, i) => [i + 1, (v || 0) / 100]) }]
 })
@@ -180,8 +242,10 @@ function statusColor(s) {
     : s === 'stopped' ? 'text-slate-400' : 'text-amber-400'
 }
 
+const inputCls = 'w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100'
+
 onMounted(async () => {
-  await loadInstance()
+  await Promise.all([loadInstance(), loadModels()])
   await loadBacktests()
   pollTimer = setInterval(tick, 3000)
 })
@@ -190,36 +254,57 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
 
 <template>
   <main class="max-w-6xl mx-auto px-4 py-6 space-y-6">
-    <div class="flex items-center justify-between">
-      <div>
-        <button @click="router.push(`/kalshi/instances/${instanceId}`)" class="text-sm text-slate-400 hover:text-slate-200">← Back to instance</button>
-        <h1 class="text-xl font-semibold text-slate-100 mt-1">Backtest</h1>
-      </div>
+    <div>
+      <button @click="router.push(`/kalshi/instances/${instanceId}`)" class="text-sm text-slate-400 hover:text-slate-200">← Back to instance</button>
+      <h1 class="text-xl font-semibold text-slate-100 mt-1">Backtest</h1>
     </div>
     <p v-if="loadErr" class="text-sm text-amber-400">{{ loadErr }}</p>
 
-    <!-- Create form -->
     <section class="bg-surface border border-border-subtle rounded-xl p-4 space-y-4">
       <h2 class="text-sm font-semibold text-slate-200">New backtest</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <label class="block">
-          <span class="text-xs text-slate-400">Name</span>
-          <input v-model="name" type="text" placeholder="e.g. WC group stage" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
-        </label>
-        <label class="block">
-          <span class="text-xs text-slate-400">Bankroll ($)</span>
-          <input v-model.number="bankroll" type="number" min="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
-        </label>
-        <label class="block">
-          <span class="text-xs text-slate-400">Start date</span>
-          <input v-model="startDate" type="date" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
-        </label>
-        <label class="block">
-          <span class="text-xs text-slate-400">End date</span>
-          <input v-model="endDate" type="date" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
-        </label>
+
+      <!-- Risk tolerance preset -->
+      <div>
+        <span class="text-xs text-slate-400">Risk tolerance</span>
+        <div class="flex gap-2 mt-1">
+          <button v-for="(p, k) in RISK_PRESETS" :key="k" type="button" @click="applyPreset(k)"
+                  class="flex-1 px-3 py-2 rounded-lg text-sm border transition-colors"
+                  :class="tier === k ? 'bg-primary/20 border-primary text-primary' : 'border-border-subtle text-slate-400 hover:text-slate-200'">
+            {{ p.label }}
+          </button>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-1">{{ PRESET_DESC[tier] }}</p>
       </div>
 
+      <!-- Analyst LLM model -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label class="block">
+          <span class="text-xs text-slate-400">Analyst LLM model</span>
+          <select v-model="modelId" @change="useLlm = !!modelId" :class="inputCls">
+            <option value="">None (statistical model only)</option>
+            <option v-for="m in models" :key="m.id" :value="m.id">{{ m.name || m.model || m.id }}</option>
+          </select>
+          <label class="flex items-center gap-2 mt-2 text-[11px] text-slate-400">
+            <input type="checkbox" v-model="useLlm" :disabled="!modelId" /> Use LLM analyst in this backtest
+          </label>
+        </label>
+        <div class="grid grid-cols-2 gap-3">
+          <label class="block"><span class="text-xs text-slate-400">Bankroll ($)</span>
+            <input v-model.number="bankroll" type="number" min="1" :class="inputCls" /></label>
+          <label class="block"><span class="text-xs text-slate-400">Bankroll usage (%)</span>
+            <input v-model.number="usagePct" type="number" step="5" :class="inputCls" /></label>
+        </div>
+      </div>
+
+      <!-- Dates -->
+      <div class="grid grid-cols-2 gap-4">
+        <label class="block"><span class="text-xs text-slate-400">Start date</span>
+          <input v-model="startDate" type="date" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">End date</span>
+          <input v-model="endDate" type="date" :class="inputCls" /></label>
+      </div>
+
+      <!-- Leagues -->
       <div>
         <span class="text-xs text-slate-400">Leagues</span>
         <div class="flex flex-wrap gap-2 mt-1">
@@ -231,29 +316,30 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
         </div>
       </div>
 
+      <!-- Tuning grid -->
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-        <label class="block"><span class="text-xs text-slate-400">Edge bar (%)</span>
-          <input v-model.number="edgePct" type="number" step="0.5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
-        <label class="block"><span class="text-xs text-slate-400">No-sharp bar (%)</span>
-          <input v-model.number="noSharpPct" type="number" step="0.5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
-        <label class="block"><span class="text-xs text-slate-400">Kelly fraction</span>
-          <input v-model.number="kelly" type="number" step="0.05" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
-        <label class="block"><span class="text-xs text-slate-400">Order min ($)</span>
-          <input v-model.number="orderMin" type="number" step="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
-        <label class="block"><span class="text-xs text-slate-400">Order max ($)</span>
-          <input v-model.number="orderMax" type="number" step="1" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
-        <label class="block"><span class="text-xs text-slate-400">Sharp weight (%)</span>
-          <input v-model.number="sharpWeight" type="number" step="5" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Edge threshold (%)</span><input v-model.number="edgePct" type="number" step="0.5" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">No-sharp bar (%)</span><input v-model.number="noSharpPct" type="number" step="0.5" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Kelly fraction</span><input v-model.number="kelly" type="number" step="0.05" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Max contracts / market</span><input v-model.number="maxContracts" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Max open exposure (%)</span><input v-model.number="exposurePct" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Per-league cap (%)</span><input v-model.number="leagueCapPct" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Min price (¢)</span><input v-model.number="minPrice" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Max price (¢)</span><input v-model.number="maxPrice" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Draw min edge (%)</span><input v-model.number="drawMinEdge" type="number" step="0.5" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Order min ($)</span><input v-model.number="orderMin" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Order max ($)</span><input v-model.number="orderMax" type="number" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Sharp weight (%)</span><input v-model.number="sharpWeight" type="number" step="5" :class="inputCls" /></label>
+        <label class="block"><span class="text-xs text-slate-400">Daily loss cap (%)</span><input v-model.number="dailyLossPct" type="number" :class="inputCls" /></label>
       </div>
 
       <label class="block">
-        <span class="text-xs text-slate-400">OddsPapi API key <span class="text-slate-500">(for the sharp line — free tier; leave blank for model-only)</span></span>
-        <input v-model="oddspapiKey" type="text" placeholder="oddspapi apiKey" class="w-full mt-1 bg-surface border border-border-subtle rounded-lg px-3 py-2 text-sm text-slate-100" />
+        <span class="text-xs text-slate-400">OddsPapi API key <span class="text-slate-500">(sharp line — free tier; saved for next time; blank = model-only)</span></span>
+        <input v-model="oddspapiKey" type="text" placeholder="oddspapi apiKey" :class="inputCls" />
       </label>
 
       <div class="flex items-center gap-3">
-        <button @click="submit" :disabled="submitting || !brokerageId"
-                class="px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium disabled:opacity-50">
+        <button @click="submit" :disabled="submitting || !brokerageId" class="px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium disabled:opacity-50">
           {{ submitting ? 'Starting…' : 'Run backtest' }}
         </button>
         <span v-if="submitErr" class="text-sm text-rose-400">{{ submitErr }}</span>
@@ -265,20 +351,13 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
       <h2 class="text-sm font-semibold text-slate-200 mb-3">Backtests</h2>
       <div v-if="!backtests.length" class="text-sm text-slate-500">No backtests yet.</div>
       <table v-else class="w-full text-sm">
-        <thead><tr class="text-left text-slate-500 text-xs">
-          <th class="py-1">Name</th><th>Range</th><th>Status</th><th>P&L</th><th></th>
-        </tr></thead>
+        <thead><tr class="text-left text-slate-500 text-xs"><th class="py-1">ID</th><th>Range</th><th>Status</th><th>P&L</th><th></th></tr></thead>
         <tbody>
           <tr v-for="b in backtests" :key="b.id" class="border-t border-border-subtle/50">
-            <td class="py-2 text-slate-200">{{ b.name || b.id.slice(0, 8) }}</td>
+            <td class="py-2 text-slate-300 font-mono text-xs">{{ b.id.slice(0, 8) }}</td>
             <td class="text-slate-400">{{ b.start_date }} → {{ b.end_date }}</td>
-            <td>
-              <span :class="statusColor(b.status)">{{ b.status }}</span>
-              <span v-if="b.status === 'running' || b.status === 'pending'" class="text-slate-500"> {{ Math.round(b.progress || 0) }}%</span>
-            </td>
-            <td :class="(b.summary && b.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">
-              {{ b.summary ? fmtMoney(b.summary.pnl_cents) : '—' }}
-            </td>
+            <td><span :class="statusColor(b.status)">{{ b.status }}</span><span v-if="b.status === 'running' || b.status === 'pending'" class="text-slate-500"> {{ Math.round(b.progress || 0) }}%</span></td>
+            <td :class="(b.summary && b.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ b.summary ? fmtMoney(b.summary.pnl_cents) : '—' }}</td>
             <td class="text-right">
               <button @click="openResults(b.id)" class="text-xs text-primary hover:underline mr-2">View</button>
               <button v-if="b.status === 'running' || b.status === 'pending'" @click="stopBacktest(b.id)" class="text-xs text-amber-400 hover:underline mr-2">Stop</button>
@@ -295,50 +374,32 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
         <h2 class="text-sm font-semibold text-slate-200">Results</h2>
         <span :class="statusColor(selected.status)" class="text-xs">{{ selected.status }}</span>
       </div>
-
       <div v-if="selected.summary" class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <div class="bg-surface border border-border-subtle rounded-lg p-3">
-          <div class="text-xs text-slate-500">Total P&L</div>
-          <div class="text-lg font-semibold" :class="(selected.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(selected.summary.pnl_cents) }}</div>
-        </div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3">
-          <div class="text-xs text-slate-500">ROI</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.roi) }}</div>
-        </div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3">
-          <div class="text-xs text-slate-500">Bets · Win rate</div><div class="text-lg font-semibold text-slate-100">{{ selected.summary.n_bets ?? '—' }} · {{ fmtPct(selected.summary.win_rate) }}</div>
-        </div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3">
-          <div class="text-xs text-slate-500">Avg CLV · API/cache</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.clv_avg) }} · {{ selected.summary.api_calls ?? 0 }}/{{ selected.summary.cache_hits ?? 0 }}</div>
-        </div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Total P&L</div><div class="text-lg font-semibold" :class="(selected.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(selected.summary.pnl_cents) }}</div></div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">ROI</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.roi) }}</div></div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Bets · Win rate</div><div class="text-lg font-semibold text-slate-100">{{ selected.summary.n_bets ?? '—' }} · {{ fmtPct(selected.summary.win_rate) }}</div></div>
+        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Avg CLV · API/cache</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.clv_avg) }} · {{ selected.summary.api_calls ?? 0 }}/{{ selected.summary.cache_hits ?? 0 }}</div></div>
       </div>
-
       <div v-if="result && result.equity_curve && result.equity_curve.length">
         <VueApexCharts type="area" height="260" :options="equityOpts" :series="equitySeries" />
       </div>
-
       <div v-if="result && result.trades && result.trades.length" class="overflow-x-auto">
         <h3 class="text-xs font-semibold text-slate-400 mb-2">Trades ({{ result.trades.length }})</h3>
         <table class="w-full text-xs">
-          <thead><tr class="text-left text-slate-500">
-            <th class="py-1">Ticker</th><th>Side</th><th>Entry</th><th>Size</th><th>Model</th><th>Sharp</th><th>Edge</th><th>Outcome</th><th>P&L</th><th>CLV</th>
-          </tr></thead>
+          <thead><tr class="text-left text-slate-500"><th class="py-1">Ticker</th><th>Side</th><th>Entry</th><th>Size</th><th>Model</th><th>Sharp</th><th>Edge</th><th>Outcome</th><th>P&L</th><th>CLV</th></tr></thead>
           <tbody>
             <tr v-for="(t, i) in result.trades" :key="i" class="border-t border-border-subtle/40">
-              <td class="py-1 text-slate-300">{{ t.market_ticker }}</td>
-              <td class="text-slate-400">{{ t.side }}</td>
-              <td class="text-slate-400">{{ t.entry_cents }}¢</td>
-              <td class="text-slate-400">{{ t.size }}</td>
+              <td class="py-1 text-slate-300">{{ t.market_ticker }}</td><td class="text-slate-400">{{ t.side }}</td>
+              <td class="text-slate-400">{{ t.entry_cents }}¢</td><td class="text-slate-400">{{ t.size }}</td>
               <td class="text-slate-400">{{ t.model_prob != null ? t.model_prob.toFixed(2) : '—' }}</td>
               <td class="text-slate-400">{{ t.sharp_prob != null ? t.sharp_prob.toFixed(2) : '—' }}</td>
-              <td class="text-slate-400">{{ (t.edge * 100).toFixed(1) }}%</td>
-              <td class="text-slate-400">{{ t.outcome }}</td>
+              <td class="text-slate-400">{{ (t.edge * 100).toFixed(1) }}%</td><td class="text-slate-400">{{ t.outcome }}</td>
               <td :class="(t.realized_pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(t.realized_pnl_cents) }}</td>
               <td class="text-slate-400">{{ t.clv != null ? (t.clv * 100).toFixed(1) + '%' : '—' }}</td>
             </tr>
           </tbody>
         </table>
       </div>
-
       <div v-if="result && result.per_league && Object.keys(result.per_league).length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <h3 class="text-xs font-semibold text-slate-400 mb-2">By league</h3>
@@ -368,7 +429,6 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
           </table>
         </div>
       </div>
-
       <p v-if="result && (!result.trades || !result.trades.length) && selected.status === 'finished'" class="text-sm text-slate-500">
         No bets were placed under these settings over this range.
       </p>

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
@@ -13,6 +13,13 @@ const _kLeagues = [
   'Primeira Liga', 'MLS', 'Brasileirão',
 ];
 
+const _kPresets = {
+  'low': {'edge': 5.0, 'kelly': 0.10, 'contracts': 25.0, 'exposure': 10.0, 'leagueCap': 12.0, 'usage': 40.0, 'daily': 5.0, 'omin': 1.0, 'omax': 3.0},
+  'medium': {'edge': 4.0, 'kelly': 0.125, 'contracts': 50.0, 'exposure': 15.0, 'leagueCap': 25.0, 'usage': 50.0, 'daily': 8.0, 'omin': 2.0, 'omax': 5.0},
+  'high': {'edge': 3.0, 'kelly': 0.15, 'contracts': 75.0, 'exposure': 25.0, 'leagueCap': 30.0, 'usage': 60.0, 'daily': 10.0, 'omin': 5.0, 'omax': 10.0},
+  'max': {'edge': 2.0, 'kelly': 0.20, 'contracts': 100.0, 'exposure': 40.0, 'leagueCap': 40.0, 'usage': 70.0, 'daily': 15.0, 'omin': 8.0, 'omax': 15.0},
+};
+
 class KalshiBacktestScreen extends ConsumerStatefulWidget {
   const KalshiBacktestScreen({super.key, required this.instanceId});
   final String instanceId;
@@ -23,17 +30,22 @@ class KalshiBacktestScreen extends ConsumerStatefulWidget {
 
 class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
   String _bid = '';
-  final _name = TextEditingController();
   final _oddsKey = TextEditingController();
+  String _tier = 'max';
   List<String> _leagues = ['World Cup'];
   DateTime? _start, _end;
-  double _bankroll = 54, _edgePct = 3, _noSharpPct = 8, _kelly = 0.2,
-      _orderMin = 5, _orderMax = 10, _sharpWeight = 85;
+  double _bankroll = 54, _edge = 2, _noSharp = 3, _kelly = 0.2, _contracts = 100,
+      _exposure = 40, _leagueCap = 40, _usage = 70, _daily = 15,
+      _minPrice = 15, _maxPrice = 90, _drawMin = 10, _orderMin = 8, _orderMax = 15,
+      _sharpWeight = 85, _analystMaxCalls = 10;
+  List<Map<String, dynamic>> _models = [];
+  String? _modelId;
+  bool _useLlm = false;
 
   bool _submitting = false;
   String? _err;
   List<Map<String, dynamic>> _backtests = [];
-  Map<String, dynamic>? _selected; // status row
+  Map<String, dynamic>? _selected;
   Map<String, dynamic>? _result;
   Timer? _timer;
 
@@ -49,28 +61,50 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
   @override
   void dispose() {
     _timer?.cancel();
-    _name.dispose();
     _oddsKey.dispose();
     super.dispose();
   }
 
+  void _applyPreset(String key) {
+    final p = _kPresets[key]!;
+    setState(() {
+      _tier = key;
+      _edge = p['edge']!; _kelly = p['kelly']!; _contracts = p['contracts']!;
+      _exposure = p['exposure']!; _leagueCap = p['leagueCap']!; _usage = p['usage']!;
+      _daily = p['daily']!; _orderMin = p['omin']!; _orderMax = p['omax']!;
+    });
+  }
+
   Future<void> _load() async {
     try {
-      final d = await _repo.instanceDetail(widget.instanceId);
+      final results = await Future.wait([_repo.instanceDetail(widget.instanceId), _repo.models()]);
+      final d = results[0] as Map<String, dynamic>;
+      _models = (results[1] as List).whereType<Map<String, dynamic>>().toList();
       final c = (d['config'] ?? {}) as Map<String, dynamic>;
       setState(() {
         _bid = (d['brokerage_id'] ?? '').toString();
-        if (c['edge_threshold'] != null) _edgePct = (c['edge_threshold'] as num) * 100;
-        if (c['no_sharp_edge_threshold'] != null) _noSharpPct = (c['no_sharp_edge_threshold'] as num) * 100;
+        if (c['tier'] != null) _tier = c['tier'].toString();
+        if (c['edge_threshold'] != null) _edge = (c['edge_threshold'] as num) * 100;
+        if (c['no_sharp_edge_threshold'] != null) _noSharp = (c['no_sharp_edge_threshold'] as num) * 100;
         if (c['kelly_fraction'] != null) _kelly = (c['kelly_fraction'] as num).toDouble();
+        if (c['max_contracts_per_market'] != null) _contracts = (c['max_contracts_per_market'] as num).toDouble();
+        if (c['max_open_exposure_frac'] != null) _exposure = (c['max_open_exposure_frac'] as num) * 100;
+        if (c['per_league_cap_frac'] != null) _leagueCap = (c['per_league_cap_frac'] as num) * 100;
+        if (c['bankroll_usage_pct'] != null) _usage = (c['bankroll_usage_pct'] as num).toDouble();
+        if (c['daily_loss_cap_frac'] != null) _daily = (c['daily_loss_cap_frac'] as num) * 100;
+        if (c['min_price_cents'] != null) _minPrice = (c['min_price_cents'] as num).toDouble();
+        if (c['max_price_cents'] != null) _maxPrice = (c['max_price_cents'] as num).toDouble();
+        if (c['draw_min_edge'] != null) _drawMin = (c['draw_min_edge'] as num) * 100;
         if (c['order_size_min_cents'] != null) _orderMin = (c['order_size_min_cents'] as num) / 100;
         if (c['order_size_max_cents'] != null) _orderMax = (c['order_size_max_cents'] as num) / 100;
         if (c['sharp_weight'] != null) _sharpWeight = (c['sharp_weight'] as num) * 100;
         if (c['bankroll_cents'] != null) _bankroll = (c['bankroll_cents'] as num) / 100;
+        if (c['analyst_max_calls'] != null) _analystMaxCalls = (c['analyst_max_calls'] as num).toDouble();
         if (c['leagues'] is List && (c['leagues'] as List).isNotEmpty) {
           _leagues = (c['leagues'] as List).map((e) => e.toString()).toList();
         }
         if (c['oddspapi_api_key'] != null) _oddsKey.text = c['oddspapi_api_key'].toString();
+        if (c['model'] != null && c['model'].toString().isNotEmpty) { _modelId = c['model'].toString(); _useLlm = true; }
       });
       await _loadBacktests();
     } catch (_) {
@@ -83,7 +117,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     try {
       final list = await _repo.listBacktests(_bid);
       if (mounted) setState(() => _backtests = list);
-    } catch (_) {/* transient */}
+    } catch (_) {}
   }
 
   Future<void> _tick() async {
@@ -94,16 +128,11 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     }
   }
 
-  String _fmtDate(DateTime? d) =>
-      d == null ? '' : '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  String _fmtDate(DateTime? d) => d == null ? '' : '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
   Future<void> _pick(bool isStart) async {
     final now = DateTime.now();
-    final d = await showDatePicker(
-      context: context,
-      initialDate: (isStart ? _start : _end) ?? now,
-      firstDate: DateTime(2024), lastDate: DateTime(now.year + 1),
-    );
+    final d = await showDatePicker(context: context, initialDate: (isStart ? _start : _end) ?? now, firstDate: DateTime(2024), lastDate: DateTime(now.year + 1));
     if (d != null) setState(() => isStart ? _start = d : _end = d);
   }
 
@@ -115,20 +144,31 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     setState(() => _submitting = true);
     try {
       final body = {
-        'name': _name.text.isEmpty ? 'Backtest ${_fmtDate(_start)}..${_fmtDate(_end)}' : _name.text,
         'instance_id': widget.instanceId,
         'leagues': _leagues,
         'start_date': _fmtDate(_start),
         'end_date': _fmtDate(_end),
         'bankroll_dollars': _bankroll,
         'config': {
-          'edge_threshold': _edgePct / 100,
-          'no_sharp_edge_threshold': _noSharpPct / 100,
+          'tier': _tier,
+          'edge_threshold': _edge / 100,
+          'no_sharp_edge_threshold': _noSharp / 100,
           'kelly_fraction': _kelly,
+          'max_contracts_per_market': _contracts,
+          'max_open_exposure_frac': _exposure / 100,
+          'per_league_cap_frac': _leagueCap / 100,
+          'bankroll_usage_pct': _usage,
+          'daily_loss_cap_frac': _daily / 100,
+          'min_price_cents': _minPrice,
+          'max_price_cents': _maxPrice,
+          'draw_min_edge': _drawMin / 100,
           'order_size_min_dollars': _orderMin,
           'order_size_max_dollars': _orderMax,
           'sharp_weight': _sharpWeight / 100,
           if (_oddsKey.text.isNotEmpty) 'oddspapi_api_key': _oddsKey.text,
+          if (_useLlm && _modelId != null) 'model': _modelId,
+          'use_llm': _useLlm && _modelId != null,
+          'analyst_max_calls': _analystMaxCalls,
         },
       };
       final id = await _repo.createBacktest(_bid, body);
@@ -149,15 +189,12 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
         _selected = {'id': id, 'status': d['status'], 'summary': d['summary'] ?? {}};
         _result = d['result'] as Map<String, dynamic>?;
       });
-    } catch (_) {/* ignore */}
+    } catch (_) {}
   }
 
-  String _money(dynamic cents) =>
-      cents == null ? '—' : '\$${((cents as num) / 100).toStringAsFixed(2)}';
+  String _money(dynamic cents) => cents == null ? '—' : '\$${((cents as num) / 100).toStringAsFixed(2)}';
   String _pct(dynamic v) => v == null ? '—' : '${((v as num) * 100).toStringAsFixed(1)}%';
-  Color _statusColor(String? s) => s == 'finished'
-      ? AppColors.success
-      : s == 'error' ? AppColors.danger : s == 'stopped' ? AppColors.textDim : AppColors.warning;
+  Color _statusColor(String? s) => s == 'finished' ? AppColors.success : s == 'error' ? AppColors.danger : s == 'stopped' ? AppColors.textDim : AppColors.warning;
 
   @override
   Widget build(BuildContext context) {
@@ -169,7 +206,36 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
         children: [
           if (_err != null) Padding(padding: const EdgeInsets.only(bottom: 8), child: Text(_err!, style: const TextStyle(color: AppColors.warning))),
           _card('New backtest', [
-            _field('Name', _name),
+            const Text('Risk tolerance', style: TextStyle(color: AppColors.textMuted, fontSize: 12)),
+            const SizedBox(height: 4),
+            Row(children: [
+              for (final k in _kPresets.keys)
+                Expanded(child: Padding(padding: const EdgeInsets.symmetric(horizontal: 2), child: OutlinedButton(
+                  onPressed: () => _applyPreset(k),
+                  style: OutlinedButton.styleFrom(
+                    backgroundColor: _tier == k ? AppColors.primary.withValues(alpha: 0.2) : null,
+                    side: BorderSide(color: _tier == k ? AppColors.primary : AppColors.border),
+                    foregroundColor: _tier == k ? AppColors.primary : AppColors.textMuted,
+                    padding: const EdgeInsets.symmetric(vertical: 8)),
+                  child: Text(k[0].toUpperCase() + k.substring(1), style: const TextStyle(fontSize: 11))))),
+            ]),
+            const SizedBox(height: 12),
+            const Text('Analyst LLM model', style: TextStyle(color: AppColors.textMuted, fontSize: 12)),
+            DropdownButton<String?>(
+              value: _modelId, isExpanded: true, dropdownColor: AppColors.panel,
+              hint: const Text('None (statistical model only)', style: TextStyle(color: AppColors.textDim, fontSize: 13)),
+              style: const TextStyle(color: AppColors.textHi, fontSize: 13),
+              items: [
+                const DropdownMenuItem(value: null, child: Text('None (statistical model only)')),
+                for (final m in _models)
+                  DropdownMenuItem(value: m['id'].toString(), child: Text((m['name'] ?? m['model'] ?? m['id']).toString(), overflow: TextOverflow.ellipsis)),
+              ],
+              onChanged: (v) => setState(() { _modelId = v; _useLlm = v != null; }),
+            ),
+            Row(children: [
+              Checkbox(value: _useLlm, onChanged: _modelId == null ? null : (v) => setState(() => _useLlm = v ?? false)),
+              const Text('Use LLM analyst in this backtest', style: TextStyle(color: AppColors.textMuted, fontSize: 12)),
+            ]),
             const SizedBox(height: 8),
             Row(children: [
               Expanded(child: _dateBtn('Start', _start, () => _pick(true))),
@@ -185,27 +251,33 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
                   selected: _leagues.contains(l),
                   onSelected: (v) => setState(() => v ? _leagues.add(l) : _leagues.remove(l)),
                   selectedColor: AppColors.primary.withValues(alpha: 0.25),
-                  backgroundColor: AppColors.surface,
-                ),
+                  backgroundColor: AppColors.surface),
             ]),
             const SizedBox(height: 10),
             Wrap(spacing: 10, runSpacing: 10, children: [
               _num('Bankroll (\$)', _bankroll, (v) => _bankroll = v),
-              _num('Edge bar (%)', _edgePct, (v) => _edgePct = v),
-              _num('No-sharp (%)', _noSharpPct, (v) => _noSharpPct = v),
+              _num('Usage (%)', _usage, (v) => _usage = v),
+              _num('Edge (%)', _edge, (v) => _edge = v),
+              _num('No-sharp (%)', _noSharp, (v) => _noSharp = v),
               _num('Kelly', _kelly, (v) => _kelly = v),
+              _num('Max contracts', _contracts, (v) => _contracts = v),
+              _num('Exposure (%)', _exposure, (v) => _exposure = v),
+              _num('League cap (%)', _leagueCap, (v) => _leagueCap = v),
+              _num('Min price (¢)', _minPrice, (v) => _minPrice = v),
+              _num('Max price (¢)', _maxPrice, (v) => _maxPrice = v),
+              _num('Draw min (%)', _drawMin, (v) => _drawMin = v),
               _num('Order min (\$)', _orderMin, (v) => _orderMin = v),
               _num('Order max (\$)', _orderMax, (v) => _orderMax = v),
               _num('Sharp wt (%)', _sharpWeight, (v) => _sharpWeight = v),
+              _num('Daily loss (%)', _daily, (v) => _daily = v),
             ]),
             const SizedBox(height: 8),
-            _field('OddsPapi API key (sharp line; blank = model-only)', _oddsKey),
+            _field('OddsPapi API key (saved; blank = model-only)', _oddsKey),
             const SizedBox(height: 12),
             SizedBox(width: double.infinity, child: ElevatedButton(
               onPressed: _submitting || _bid.isEmpty ? null : _submit,
               style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary, foregroundColor: AppColors.onPrimary),
-              child: Text(_submitting ? 'Starting…' : 'Run backtest'),
-            )),
+              child: Text(_submitting ? 'Starting…' : 'Run backtest'))),
           ]),
           const SizedBox(height: 16),
           _card('Backtests', [
@@ -214,10 +286,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
             else
               for (final b in _backtests) _btRow(b),
           ]),
-          if (_selected != null) ...[
-            const SizedBox(height: 16),
-            _resultsCard(),
-          ],
+          if (_selected != null) ...[const SizedBox(height: 16), _resultsCard()],
         ],
       ),
     );
@@ -234,8 +303,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
       );
 
   Widget _field(String label, TextEditingController c) => TextField(
-        controller: c,
-        style: const TextStyle(color: AppColors.textHi, fontSize: 13),
+        controller: c, style: const TextStyle(color: AppColors.textHi, fontSize: 13),
         decoration: InputDecoration(labelText: label, labelStyle: const TextStyle(color: AppColors.textMuted, fontSize: 12), isDense: true,
           enabledBorder: OutlineInputBorder(borderSide: const BorderSide(color: AppColors.border), borderRadius: BorderRadius.circular(8))),
       );
@@ -243,11 +311,10 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
   Widget _dateBtn(String label, DateTime? d, VoidCallback onTap) => OutlinedButton(
         onPressed: onTap,
         style: OutlinedButton.styleFrom(side: const BorderSide(color: AppColors.border), foregroundColor: AppColors.textMd),
-        child: Text(d == null ? label : _fmtDate(d), style: const TextStyle(fontSize: 12)),
-      );
+        child: Text(d == null ? label : _fmtDate(d), style: const TextStyle(fontSize: 12)));
 
   Widget _num(String label, double value, ValueChanged<double> onChanged) => SizedBox(
-        width: 110,
+        width: 108,
         child: TextFormField(
           initialValue: value == value.roundToDouble() ? value.toInt().toString() : value.toString(),
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
@@ -255,8 +322,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
           decoration: InputDecoration(labelText: label, labelStyle: const TextStyle(color: AppColors.textMuted, fontSize: 11), isDense: true,
             enabledBorder: OutlineInputBorder(borderSide: const BorderSide(color: AppColors.border), borderRadius: BorderRadius.circular(8))),
           onChanged: (t) => onChanged(double.tryParse(t) ?? value),
-        ),
-      );
+        ));
 
   Widget _btRow(Map<String, dynamic> b) {
     final status = b['status']?.toString();
@@ -266,14 +332,12 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
       padding: const EdgeInsets.symmetric(vertical: 6),
       child: Row(children: [
         Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text((b['name'] ?? b['id'].toString().substring(0, 8)).toString(), style: const TextStyle(color: AppColors.textMd, fontSize: 13)),
+          Text(b['id'].toString().substring(0, 8), style: const TextStyle(color: AppColors.textMd, fontSize: 12, fontFamily: 'monospace')),
           Text('${b['start_date']} → ${b['end_date']}', style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
         ])),
         Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
-          Text(status == 'running' || status == 'pending' ? '$status ${(b['progress'] ?? 0).round()}%' : (status ?? ''),
-              style: TextStyle(color: _statusColor(status), fontSize: 12)),
-          Text(pnl == null ? '—' : _money(pnl),
-              style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 12)),
+          Text(status == 'running' || status == 'pending' ? '$status ${(b['progress'] ?? 0).round()}%' : (status ?? ''), style: TextStyle(color: _statusColor(status), fontSize: 12)),
+          Text(pnl == null ? '—' : _money(pnl), style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 12)),
         ]),
         const SizedBox(width: 6),
         IconButton(icon: const Icon(Icons.visibility_outlined, size: 18, color: AppColors.primary), onPressed: () => _openResults(b['id'].toString())),
@@ -290,7 +354,6 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     final res = _result;
     final ec = (res?['equity_curve'] ?? []) as List? ?? [];
     final trades = (res?['trades'] ?? []) as List? ?? [];
-    // equity_curve is a bare list of cumulative-P&L cents, ordered by bet.
     final ts = <DateTime>[], vals = <double>[];
     for (var i = 0; i < ec.length; i++) {
       ts.add(DateTime.fromMillisecondsSinceEpoch(i * 3600000));
@@ -319,14 +382,12 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
   }
 
   Widget _stat(String label, String value, Color color) => Container(
-        width: 104,
-        padding: const EdgeInsets.all(10),
+        width: 104, padding: const EdgeInsets.all(10),
         decoration: BoxDecoration(color: AppColors.canvas, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
         child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
           Text(label, style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
           Text(value, style: TextStyle(color: color, fontSize: 15, fontWeight: FontWeight.w600)),
-        ]),
-      );
+        ]));
 
   Widget _tradeRow(Map t) {
     final pnl = t['realized_pnl_cents'];


### PR DESCRIPTION
Follow-up to the Kalshi backtest feature.

## Changes
- **Full settings parity with instance creation** (web + mobile): risk-tolerance presets (Low/Medium/High/Max) that set defaults, **Analyst LLM model dropdown + use-LLM toggle**, and the complete tuning set (edge, no-sharp bar, kelly, max contracts/market, max open exposure, per-league cap, bankroll usage, daily-loss, price band, draw-min-edge, order size, sharp weight). Prefilled from the instance config.
- **LLM analyst in the replay**: `evaluate()` applies `llm_adjustments`; `run_backtest()` takes an injected `analyst_fn`; the worker builds it from the configured Models-table model. News is intentionally empty (a past fixture has no time-faithful news feed) so the analyst adjusts on the feature bundle only — avoiding look-ahead. Falls back to the statistical model on any failure.
- **OddsPapi key is saved**: a newly-entered key is persisted onto the instance config (and `normalize_config` preserves it), so it prefills next time.
- **No name field** — backtests are identified by an auto short-ID, like regular backtests.

## Verify
- 414 kalshi/backtest tests pass (2 new LLM-plumbing tests); `npm run build` clean; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)