### PR TITLE
feat(kalshi): backtest results screen + run logs/decision log; fix OddsPapi 403 + de-hardcode

### DIFF
--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -439,20 +439,44 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_
     single call when there are zero fixtures). Returns `aggregate()`'s result
     with `data.api_calls`/`data.cache_hits` surfaced into `result.summary`.
     """
+    logs: list = []
+    decision_log: list = []
+
+    def _log(msg):
+        logs.append(msg)
+        log.info("run_backtest: %s", msg)
+
     fixtures = list(data.fixtures(cfg.leagues, cfg.start_date, cfg.end_date))
     fixtures.sort(key=lambda fx: fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)
+    _log(f"discovered {len(fixtures)} fixture(s) for leagues={cfg.leagues} "
+         f"{cfg.start_date}..{cfg.end_date}")
+    if not fixtures:
+        _log("no fixtures found — check the OddsPapi key/coverage for these "
+             "leagues+dates, or that markets exist on Kalshi for this range.")
+    counts = {"unsettled": 0, "unmatched": 0, "no_candle_data": 0, "no_bet": 0, "bet": 0}
 
     trades: list[Trade] = []
     n = len(fixtures)
     for i, fx in enumerate(fixtures):
         fixture_id = fx.get("fixture_id", "")
+        label = (f"{fx.get('home')} vs {fx.get('away')}"
+                 if fx.get("home") else fixture_id)
+        rec = {"fixture_id": fixture_id, "label": label,
+               "kickoff_ts": int(fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)}
         result = data.final_score(fx)
         if result is None:
-            log.info("run_backtest: skipping fixture_id=%s reason=unsettled", fixture_id)
+            counts["unsettled"] += 1
+            rec.update({"decision": "skipped", "reason": "unsettled"})
+            _log(f"skip {label}: not settled yet")
+            decision_log.append(rec)
         else:
+            rec["result"] = result
             tickers = data.kalshi_tickers(fx)
             if not tickers:
-                log.info("run_backtest: skipping fixture_id=%s reason=unmatched", fixture_id)
+                counts["unmatched"] += 1
+                rec.update({"decision": "skipped", "reason": "unmatched"})
+                _log(f"skip {label}: no Kalshi market matched this fixture")
+                decision_log.append(rec)
             else:
                 kickoff_ts = int(fx.get("kickoff_ts", fx.get("kickoff", 0)) or 0)
                 # Bound the candlestick window around kickoff. Kalshi's endpoint
@@ -485,7 +509,10 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_
                         break
 
                 if not kalshi_asks:
-                    log.info("run_backtest: skipping fixture_id=%s reason=no_candle_data", fixture_id)
+                    counts["no_candle_data"] += 1
+                    rec.update({"decision": "skipped", "reason": "no_candle_data"})
+                    _log(f"skip {label}: no Kalshi price at the decision snapshot")
+                    decision_log.append(rec)
                 else:
                     model_probs = model_fn(fx) or {}
                     llm_adj = {}
@@ -497,17 +524,43 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_
                     fx_for_eval = dict(fx)
                     fx_for_eval["market_tickers"] = tickers
                     bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fx_for_eval, llm_adj)
-                    for bet in bets:
-                        trades.append(settle(bet, result, cfg.fee_rate))
+                    rec.update({"model_prob": {k: round(v, 4) for k, v in model_probs.items()},
+                                "sharp_prob": {k: round(v, 4) for k, v in sharp_probs.items()},
+                                "asks": kalshi_asks, "has_sharp": bool(sharp_probs)})
+                    if bets:
+                        counts["bet"] += 1
+                        settled = [settle(b, result, cfg.fee_rate) for b in bets]
+                        trades.extend(settled)
+                        rec.update({"decision": "placed", "bets": [
+                            {"side": b.side, "entry_cents": b.entry_cents, "size": b.size,
+                             "edge": round(b.edge, 4), "fused_fair": round(b.fused_fair, 4),
+                             "outcome": s.outcome, "pnl_cents": s.realized_pnl_cents}
+                            for b, s in zip(bets, settled)]})
+                        _log(f"BET {label}: {len(bets)} side(s), "
+                             f"pnl {sum(s.realized_pnl_cents for s in settled)}c")
+                    else:
+                        counts["no_bet"] += 1
+                        rec.update({"decision": "no_bet", "reason": "no side cleared the edge bar"})
+                        _log(f"no bet {label}: no side cleared the edge bar "
+                             f"(sharp={'yes' if sharp_probs else 'no'})")
+                    decision_log.append(rec)
 
         if progress_cb is not None:
             progress_cb((i + 1) / n if n else 1.0)
+
+    _log(f"done: {counts['bet']} bet · {counts['no_bet']} no-edge · "
+         f"{counts['unsettled']} unsettled · {counts['unmatched']} unmatched · "
+         f"{counts['no_candle_data']} no-price · api_calls={getattr(data, 'api_calls', 0)} "
+         f"cache_hits={getattr(data, 'cache_hits', 0)}")
 
     out = aggregate(trades, cfg.bankroll_cents)
     out.summary = {
         "api_calls": getattr(data, "api_calls", 0),
         "cache_hits": getattr(data, "cache_hits", 0),
+        "n_fixtures": n, **counts,
     }
+    out.logs = logs
+    out.decision_log = decision_log
     return out
 
 

--- a/backend/kalshi/backtest_data.py
+++ b/backend/kalshi/backtest_data.py
@@ -36,10 +36,13 @@ log = logging.getLogger(__name__)
 _DEFAULT_SOCCER_SERIES = ("KXWCGAME",)
 _DEFAULT_MARKET_STATUSES = ("open", "settled")
 
-# OddsPapi sport_id is unconfirmed (Phase 0 note in ingest_odds.py); soccer
-# defaults to 1 and is easy to extend per-league once the real catalog is known.
-_SPORT_ID_BY_LEAGUE = {"world cup": 1}
-_DEFAULT_SPORT_ID = 1
+# OddsPapi uses a single sport id for ALL soccer (docs: sportId=10); leagues are
+# distinguished by tournament name in the results, NOT by sport id. So every
+# league resolves to the soccer id — league-agnostic, no per-league hardcoding.
+# (A per-tournament name filter is a follow-up once a live key confirms the field.)
+_SOCCER_SPORT_ID = 10
+_SPORT_ID_BY_LEAGUE: dict = {}
+_DEFAULT_SPORT_ID = _SOCCER_SPORT_ID
 
 
 def _fx_get(fx: Any, key: str, default: Any = None) -> Any:
@@ -148,25 +151,36 @@ class BacktestDataProvider:
         out: list[dict] = []
         if self.oddspapi_client is None:
             return out
-        for league in leagues or []:
+        # All soccer leagues share one OddsPapi sport id, so fetch once per unique
+        # sport id (not per league) — league-agnostic and budget-frugal. Fixtures
+        # are deduped by id; each is tagged with its own tournament when the feed
+        # provides one, else the requested league(s).
+        want = list(leagues or [])
+        sport_ids = sorted({_SPORT_ID_BY_LEAGUE.get((lg or "").strip().lower(), _DEFAULT_SPORT_ID)
+                            for lg in (want or [""])})
+        seen: set = set()
+        for sport_id in sport_ids:
             if not self._oddspapi_allowed(1):
                 self.log.warning(
                     "BacktestDataProvider.fixtures: OddsPapi budget exhausted, "
-                    "skipping league=%s %s..%s", league, start_date, end_date)
+                    "skipping sport_id=%s %s..%s", sport_id, start_date, end_date)
                 continue
-            sport_id = _SPORT_ID_BY_LEAGUE.get((league or "").strip().lower(), _DEFAULT_SPORT_ID)
             try:
                 rows = self.oddspapi_client.list_fixtures(sport_id, start_date, end_date)
             except Exception:
-                self.log.warning("BacktestDataProvider.fixtures: list_fixtures failed for league=%s", league)
+                self.log.warning("BacktestDataProvider.fixtures: list_fixtures failed for sport_id=%s", sport_id)
                 continue
             self.api_calls += 1
             self._budget_bumper()
             for r in rows:
+                fid = r.get("fixture_id")
+                if fid in seen:
+                    continue
+                seen.add(fid)
                 out.append({
-                    "fixture_id": r.get("fixture_id"),
+                    "fixture_id": fid,
                     "sport": "soccer",
-                    "league": league,
+                    "league": r.get("league") or r.get("tournament") or (want[0] if want else ""),
                     "home": normalize_team(r.get("home", "")),
                     "away": normalize_team(r.get("away", "")),
                     "kickoff_ts": r.get("kickoff_ts"),

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -476,6 +476,8 @@ def backtest_result_doc(id, result) -> dict:
         "calibration": list(g("calibration", []) or []),
         "trades": [_as_plain(t) for t in (g("trades", []) or [])],
         "summary": dict(g("summary", {}) or {}),
+        "logs": list(g("logs", []) or []),
+        "decision_log": list(g("decision_log", []) or []),
     }
 
 

--- a/backend/kalshi/ingest_odds.py
+++ b/backend/kalshi/ingest_odds.py
@@ -136,10 +136,19 @@ class OddsPapiClient:
             session = requests.Session()
         self._session = session
 
+    # OddsPapi sits behind Cloudflare, which 403s (error 1010) requests without a
+    # browser-like User-Agent. Send one so the API is reachable at all.
+    _HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+                      "(KHTML, like Gecko) Chrome/126 Safari/537.36",
+        "Accept": "application/json",
+    }
+
     def fetch_raw(self, path: str, params: dict | None = None) -> dict:
         p = dict(params or {})
         p["apiKey"] = self.api_key  # query param, not a header
-        resp = self._session.request("GET", f"{self.base_url}{path}", params=p, timeout=20.0)
+        resp = self._session.request("GET", f"{self.base_url}{path}", params=p,
+                                     headers=self._HEADERS, timeout=20.0)
         resp.raise_for_status()
         return resp.json() if resp.content else {}
 

--- a/backend/tests/test_kalshi_ingest_odds_methods.py
+++ b/backend/tests/test_kalshi_ingest_odds_methods.py
@@ -114,8 +114,9 @@ class FakeSession:
         self._payload = payload
         self.last_call = None
 
-    def request(self, method, url, params=None, timeout=None):
+    def request(self, method, url, params=None, timeout=None, headers=None):
         self.last_call = (method, url, params)
+        self.last_headers = headers
         return FakeResp(self._payload)
 
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -94,6 +94,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/kalshi/backtests/:id',
+    name: 'kalshi-backtest-result',
+    component: () => import('../views/KalshiBacktestResultView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/strategies',
     name: 'strategies',
     component: () => import('../views/StrategiesView.vue'),

--- a/frontend/src/views/KalshiBacktestResultView.vue
+++ b/frontend/src/views/KalshiBacktestResultView.vue
@@ -1,0 +1,192 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import VueApexCharts from 'vue3-apexcharts'
+import { getToken } from '../utils/auth.js'
+
+const API_BASE = import.meta.env.DEV ? '/api' : (import.meta.env.VITE_API_URL || '/api')
+function authHeaders() { return { Authorization: `Bearer ${getToken()}` } }
+
+const route = useRoute()
+const router = useRouter()
+const id = route.params.id
+
+const status = ref(null)
+const result = ref(null)
+const tab = ref('trades')  // trades | decisions | logs
+const selectedDay = ref(null)
+let pollTimer = null
+
+async function load() {
+  try {
+    const res = await fetch(`${API_BASE}/kalshi/backtests/${id}/results`, { headers: authHeaders() })
+    if (!res.ok) return
+    const d = await res.json()
+    status.value = { status: d.status, summary: d.summary || {} }
+    result.value = d.result || null
+    if (!selectedDay.value && dayKeys.value.length) selectedDay.value = dayKeys.value[dayKeys.value.length - 1]
+  } catch (e) { /* ignore */ }
+}
+
+// --- trades grouped by kickoff day ---
+function dayOf(ts) {
+  if (!ts) return 'unknown'
+  const d = new Date(Number(ts) * 1000)
+  return d.toISOString().slice(0, 10)
+}
+const trades = computed(() => (result.value && result.value.trades) || [])
+const tradesByDay = computed(() => {
+  const m = {}
+  for (const t of trades.value) (m[dayOf(t.kickoff)] ||= []).push(t)
+  return m
+})
+const dayKeys = computed(() => Object.keys(tradesByDay.value).sort())
+const selectedTrades = computed(() => (selectedDay.value && tradesByDay.value[selectedDay.value]) || [])
+
+// --- equity chart: one point per trade, x = kickoff date ---
+const equitySeries = computed(() => {
+  const ec = (result.value && result.value.equity_curve) || []
+  return [{ name: 'Cumulative P&L ($)', data: trades.value.map((t, i) => ({ x: Number(t.kickoff) * 1000 || (i + 1), y: (ec[i] || 0) / 100, day: dayOf(t.kickoff) })) }]
+})
+const equityOpts = computed(() => ({
+  chart: { type: 'area', toolbar: { show: false }, animations: { enabled: false },
+    events: {
+      dataPointSelection: (e, ctx, cfg) => pickIdx(cfg.dataPointIndex),
+      markerClick: (e, ctx, { dataPointIndex }) => pickIdx(dataPointIndex),
+    } },
+  dataLabels: { enabled: false },
+  stroke: { curve: 'straight', width: 2 },
+  markers: { size: 4, strokeColors: '#0f172a', hover: { size: 6 } },
+  xaxis: { type: 'datetime', labels: { style: { colors: '#94a3b8' } } },
+  yaxis: { labels: { style: { colors: '#94a3b8' }, formatter: (v) => `$${Math.round(v)}` } },
+  colors: ['#22d3ee'], grid: { borderColor: '#1e293b' },
+  tooltip: { theme: 'dark', x: { format: 'MMM dd' } },
+}))
+function pickIdx(i) {
+  const t = trades.value[i]
+  if (t) { selectedDay.value = dayOf(t.kickoff); tab.value = 'trades' }
+}
+
+function fmtPct(v) { return v == null ? '—' : `${(v * 100).toFixed(1)}%` }
+function fmtMoney(c) { return c == null ? '—' : `$${(c / 100).toFixed(2)}` }
+const s = computed(() => (status.value && status.value.summary) || {})
+function statusColor(st) { return st === 'finished' ? 'text-emerald-400' : st === 'error' ? 'text-rose-400' : st === 'stopped' ? 'text-slate-400' : 'text-amber-400' }
+
+onMounted(async () => {
+  await load()
+  pollTimer = setInterval(() => {
+    if (status.value && (status.value.status === 'pending' || status.value.status === 'running')) load()
+  }, 3000)
+})
+onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
+</script>
+
+<template>
+  <main class="max-w-6xl mx-auto px-4 py-6 space-y-6">
+    <div>
+      <button @click="router.back()" class="text-sm text-slate-400 hover:text-slate-200">← Back</button>
+      <div class="flex items-center gap-3 mt-1">
+        <h1 class="text-xl font-semibold text-slate-100">Backtest <span class="font-mono text-slate-400 text-base">{{ id.slice(0, 8) }}</span></h1>
+        <span v-if="status" :class="statusColor(status.status)" class="text-sm">{{ status.status }}</span>
+      </div>
+    </div>
+
+    <!-- Summary hero -->
+    <section class="bg-surface border border-border-subtle rounded-xl p-4">
+      <div class="grid grid-cols-2 md:grid-cols-6 gap-3">
+        <div><div class="text-xs text-slate-500">Total P&L</div><div class="text-lg font-semibold" :class="(s.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(s.pnl_cents) }}</div></div>
+        <div><div class="text-xs text-slate-500">ROI</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(s.roi) }}</div></div>
+        <div><div class="text-xs text-slate-500">Bets</div><div class="text-lg font-semibold text-slate-100">{{ s.n_bets ?? '—' }}</div></div>
+        <div><div class="text-xs text-slate-500">Win rate</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(s.win_rate) }}</div></div>
+        <div><div class="text-xs text-slate-500">Avg CLV</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(s.clv_avg) }}</div></div>
+        <div><div class="text-xs text-slate-500">API / cache</div><div class="text-lg font-semibold text-slate-100">{{ s.api_calls ?? 0 }} / {{ s.cache_hits ?? 0 }}</div></div>
+      </div>
+      <div class="mt-3 pt-3 border-t border-border-subtle/50 text-xs text-slate-500 flex flex-wrap gap-x-4 gap-y-1">
+        <span>Fixtures: <span class="text-slate-300">{{ s.n_fixtures ?? 0 }}</span></span>
+        <span>Bet: <span class="text-emerald-400">{{ s.bet ?? 0 }}</span></span>
+        <span>No-edge: <span class="text-slate-300">{{ s.no_bet ?? 0 }}</span></span>
+        <span>Unsettled: <span class="text-slate-300">{{ s.unsettled ?? 0 }}</span></span>
+        <span>Unmatched: <span class="text-amber-400">{{ s.unmatched ?? 0 }}</span></span>
+        <span>No-price: <span class="text-slate-300">{{ s.no_candle_data ?? 0 }}</span></span>
+      </div>
+    </section>
+
+    <!-- Scrubbable equity chart -->
+    <section v-if="trades.length" class="bg-surface border border-border-subtle rounded-xl p-4">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="text-sm font-semibold text-slate-200">Equity — click a point to see that day's trades</h2>
+        <span v-if="selectedDay" class="text-xs text-primary">{{ selectedDay }} · {{ selectedTrades.length }} trade(s)</span>
+      </div>
+      <VueApexCharts type="area" height="280" :options="equityOpts" :series="equitySeries" />
+      <!-- day chips -->
+      <div class="flex flex-wrap gap-2 mt-3">
+        <button v-for="d in dayKeys" :key="d" @click="selectedDay = d; tab = 'trades'"
+                class="px-2.5 py-1 rounded-full text-xs border transition-colors"
+                :class="selectedDay === d ? 'bg-primary/20 border-primary text-primary' : 'border-border-subtle text-slate-400 hover:text-slate-200'">
+          {{ d }} · {{ tradesByDay[d].length }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Tabs -->
+    <section class="bg-surface border border-border-subtle rounded-xl p-4">
+      <div class="flex gap-4 border-b border-border-subtle/50 mb-3">
+        <button v-for="t in ['trades', 'decisions', 'logs']" :key="t" @click="tab = t"
+                class="pb-2 text-sm capitalize" :class="tab === t ? 'text-primary border-b-2 border-primary' : 'text-slate-400 hover:text-slate-200'">
+          {{ t === 'decisions' ? 'Decision log' : t }}
+        </button>
+      </div>
+
+      <!-- Trades (cards for the selected day) -->
+      <div v-if="tab === 'trades'">
+        <div v-if="!selectedTrades.length" class="text-sm text-slate-500">
+          {{ trades.length ? 'Pick a day above to see its trades.' : 'No bets were placed under these settings over this range.' }}
+        </div>
+        <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div v-for="(t, i) in selectedTrades" :key="i" class="bg-surface border border-border-subtle rounded-lg p-3">
+            <div class="flex items-center justify-between">
+              <div class="text-sm text-slate-200 font-mono">{{ t.market_ticker }}</div>
+              <div class="text-sm font-semibold" :class="(t.realized_pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(t.realized_pnl_cents) }}</div>
+            </div>
+            <div class="text-xs text-slate-400 mt-1">
+              <span v-if="t.league" class="mr-1 text-slate-500">{{ t.league }}</span>
+              side <span class="text-slate-200">{{ t.side }}</span> · entry {{ t.entry_cents }}¢ × {{ t.size }}
+            </div>
+            <!-- flags / badges -->
+            <div class="flex flex-wrap gap-1.5 mt-2">
+              <span class="px-1.5 py-0.5 rounded text-[10px] bg-slate-700/50 text-slate-300">edge {{ (t.edge * 100).toFixed(1) }}%</span>
+              <span class="px-1.5 py-0.5 rounded text-[10px]" :class="t.sharp_prob != null ? 'bg-sky-500/20 text-sky-300' : 'bg-amber-500/20 text-amber-300'">{{ t.sharp_prob != null ? 'sharp' : 'model-only' }}</span>
+              <span v-if="t.model_prob != null" class="px-1.5 py-0.5 rounded text-[10px] bg-slate-700/50 text-slate-300">model {{ t.model_prob.toFixed(2) }}</span>
+              <span v-if="t.sharp_prob != null" class="px-1.5 py-0.5 rounded text-[10px] bg-slate-700/50 text-slate-300">sharp {{ t.sharp_prob.toFixed(2) }}</span>
+              <span class="px-1.5 py-0.5 rounded text-[10px]" :class="t.outcome === 'win' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-300'">{{ t.outcome }}</span>
+              <span v-if="t.clv != null" class="px-1.5 py-0.5 rounded text-[10px] bg-slate-700/50 text-slate-300">CLV {{ (t.clv * 100).toFixed(1) }}%</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Decision log -->
+      <div v-else-if="tab === 'decisions'" class="overflow-x-auto">
+        <table class="w-full text-xs">
+          <thead><tr class="text-left text-slate-500"><th class="py-1">Fixture</th><th>Decision</th><th>Reason</th><th>Model</th><th>Sharp</th></tr></thead>
+          <tbody>
+            <tr v-for="(d, i) in (result && result.decision_log) || []" :key="i" class="border-t border-border-subtle/40">
+              <td class="py-1 text-slate-300">{{ d.label }}</td>
+              <td><span :class="d.decision === 'placed' ? 'text-emerald-400' : d.decision === 'no_bet' ? 'text-slate-300' : 'text-amber-400'">{{ d.decision }}</span></td>
+              <td class="text-slate-500">{{ d.reason || (d.bets ? d.bets.length + ' side(s)' : '') }}</td>
+              <td class="text-slate-400">{{ d.model_prob ? Object.entries(d.model_prob).map(([k, v]) => k[0] + ':' + v.toFixed(2)).join(' ') : '—' }}</td>
+              <td class="text-slate-400">{{ d.sharp_prob && Object.keys(d.sharp_prob).length ? Object.entries(d.sharp_prob).map(([k, v]) => k[0] + ':' + v.toFixed(2)).join(' ') : '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-if="!(result && result.decision_log && result.decision_log.length)" class="text-sm text-slate-500">No decision log recorded.</p>
+      </div>
+
+      <!-- Logs -->
+      <div v-else class="bg-black/40 rounded-lg p-3 font-mono text-[11px] text-slate-300 max-h-96 overflow-y-auto whitespace-pre-wrap">
+        <div v-for="(line, i) in (result && result.logs) || []" :key="i">{{ line }}</div>
+        <p v-if="!(result && result.logs && result.logs.length)" class="text-slate-500">No logs recorded.</p>
+      </div>
+    </section>
+  </main>
+</template>

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -356,7 +356,17 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
           <tr v-for="b in backtests" :key="b.id" class="border-t border-border-subtle/50">
             <td class="py-2 text-slate-300 font-mono text-xs">{{ b.id.slice(0, 8) }}</td>
             <td class="text-slate-400">{{ b.start_date }} → {{ b.end_date }}</td>
-            <td><span :class="statusColor(b.status)">{{ b.status }}</span><span v-if="b.status === 'running' || b.status === 'pending'" class="text-slate-500"> {{ Math.round(b.progress || 0) }}%</span></td>
+            <td>
+              <div class="flex items-center gap-2">
+                <span :class="statusColor(b.status)">{{ b.status }}</span>
+                <template v-if="b.status === 'running' || b.status === 'pending'">
+                  <div class="w-16 h-1.5 rounded-full bg-slate-700/60 overflow-hidden">
+                    <div class="h-full bg-amber-400 rounded-full transition-all" :style="{ width: Math.max(3, Math.round(b.progress || 0)) + '%' }"></div>
+                  </div>
+                  <span class="text-slate-500 text-[11px]">{{ Math.round(b.progress || 0) }}%</span>
+                </template>
+              </div>
+            </td>
             <td :class="(b.summary && b.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ b.summary ? fmtMoney(b.summary.pnl_cents) : '—' }}</td>
             <td class="text-right">
               <button @click="openResults(b.id)" class="text-xs text-primary hover:underline mr-2">View</button>

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -187,9 +187,6 @@ async function loadBacktests() {
 
 async function tick() {
   await loadBacktests()
-  if (selected.value && (selected.value.status === 'pending' || selected.value.status === 'running')) {
-    await refreshResults(selected.value.id)
-  }
 }
 
 async function stopBacktest(id) {
@@ -217,9 +214,7 @@ async function refreshResults(id) {
   } catch (e) { /* ignore */ }
 }
 function openResults(id) {
-  selected.value = { id, status: 'pending', summary: {} }
-  result.value = null
-  refreshResults(id)
+  router.push(`/kalshi/backtests/${id}`)
 }
 
 const equitySeries = computed(() => {
@@ -378,70 +373,5 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
       </table>
     </section>
 
-    <!-- Results -->
-    <section v-if="selected" class="bg-surface border border-border-subtle rounded-xl p-4 space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-semibold text-slate-200">Results</h2>
-        <span :class="statusColor(selected.status)" class="text-xs">{{ selected.status }}</span>
-      </div>
-      <div v-if="selected.summary" class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Total P&L</div><div class="text-lg font-semibold" :class="(selected.summary.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(selected.summary.pnl_cents) }}</div></div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">ROI</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.roi) }}</div></div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Bets · Win rate</div><div class="text-lg font-semibold text-slate-100">{{ selected.summary.n_bets ?? '—' }} · {{ fmtPct(selected.summary.win_rate) }}</div></div>
-        <div class="bg-surface border border-border-subtle rounded-lg p-3"><div class="text-xs text-slate-500">Avg CLV · API/cache</div><div class="text-lg font-semibold text-slate-100">{{ fmtPct(selected.summary.clv_avg) }} · {{ selected.summary.api_calls ?? 0 }}/{{ selected.summary.cache_hits ?? 0 }}</div></div>
-      </div>
-      <div v-if="result && result.equity_curve && result.equity_curve.length">
-        <VueApexCharts type="area" height="260" :options="equityOpts" :series="equitySeries" />
-      </div>
-      <div v-if="result && result.trades && result.trades.length" class="overflow-x-auto">
-        <h3 class="text-xs font-semibold text-slate-400 mb-2">Trades ({{ result.trades.length }})</h3>
-        <table class="w-full text-xs">
-          <thead><tr class="text-left text-slate-500"><th class="py-1">Ticker</th><th>Side</th><th>Entry</th><th>Size</th><th>Model</th><th>Sharp</th><th>Edge</th><th>Outcome</th><th>P&L</th><th>CLV</th></tr></thead>
-          <tbody>
-            <tr v-for="(t, i) in result.trades" :key="i" class="border-t border-border-subtle/40">
-              <td class="py-1 text-slate-300">{{ t.market_ticker }}</td><td class="text-slate-400">{{ t.side }}</td>
-              <td class="text-slate-400">{{ t.entry_cents }}¢</td><td class="text-slate-400">{{ t.size }}</td>
-              <td class="text-slate-400">{{ t.model_prob != null ? t.model_prob.toFixed(2) : '—' }}</td>
-              <td class="text-slate-400">{{ t.sharp_prob != null ? t.sharp_prob.toFixed(2) : '—' }}</td>
-              <td class="text-slate-400">{{ (t.edge * 100).toFixed(1) }}%</td><td class="text-slate-400">{{ t.outcome }}</td>
-              <td :class="(t.realized_pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(t.realized_pnl_cents) }}</td>
-              <td class="text-slate-400">{{ t.clv != null ? (t.clv * 100).toFixed(1) + '%' : '—' }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div v-if="result && result.per_league && Object.keys(result.per_league).length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <h3 class="text-xs font-semibold text-slate-400 mb-2">By league</h3>
-          <table class="w-full text-xs">
-            <thead><tr class="text-left text-slate-500"><th>League</th><th>Bets</th><th>P&L</th><th>Win%</th></tr></thead>
-            <tbody>
-              <tr v-for="(v, k) in result.per_league" :key="k" class="border-t border-border-subtle/40">
-                <td class="py-1 text-slate-300">{{ k }}</td><td class="text-slate-400">{{ v.n_bets }}</td>
-                <td :class="(v.pnl_cents >= 0) ? 'text-emerald-400' : 'text-rose-400'">{{ fmtMoney(v.pnl_cents) }}</td>
-                <td class="text-slate-400">{{ fmtPct(v.win_rate) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div v-if="result.calibration && result.calibration.length">
-          <h3 class="text-xs font-semibold text-slate-400 mb-2">Calibration</h3>
-          <table class="w-full text-xs">
-            <thead><tr class="text-left text-slate-500"><th>Bucket</th><th>Predicted</th><th>Actual</th><th>n</th></tr></thead>
-            <tbody>
-              <tr v-for="(c, i) in result.calibration" :key="i" class="border-t border-border-subtle/40">
-                <td class="py-1 text-slate-400">{{ (c.bucket[0] * 100).toFixed(0) }}–{{ (c.bucket[1] * 100).toFixed(0) }}%</td>
-                <td class="text-slate-400">{{ (c.predicted_avg * 100).toFixed(0) }}%</td>
-                <td class="text-slate-400">{{ (c.actual_rate * 100).toFixed(0) }}%</td>
-                <td class="text-slate-400">{{ c.n }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <p v-if="result && (!result.trades || !result.trades.length) && selected.status === 'finished'" class="text-sm text-slate-500">
-        No bets were placed under these settings over this range.
-      </p>
-    </section>
   </main>
 </template>

--- a/mobile/lib/core/router/router.dart
+++ b/mobile/lib/core/router/router.dart
@@ -23,6 +23,7 @@ import '../../features/nexus/presentation/nexus_screen.dart';
 import '../../features/kalshi/presentation/kalshi_screen.dart';
 import '../../features/kalshi/presentation/kalshi_instance_detail_screen.dart';
 import '../../features/kalshi/presentation/kalshi_backtest_screen.dart';
+import '../../features/kalshi/presentation/kalshi_backtest_result_screen.dart';
 import '../../features/models/presentation/models_screen.dart';
 import '../../features/token_usage/presentation/token_usage_screen.dart';
 import '../../features/settings/presentation/settings_screen.dart';
@@ -126,6 +127,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: '/kalshi/instances/:id/backtest',
         parentNavigatorKey: _rootKey,
         builder: (_, s) => KalshiBacktestScreen(instanceId: s.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/kalshi/backtests/:id',
+        parentNavigatorKey: _rootKey,
+        builder: (_, s) => KalshiBacktestResultScreen(backtestId: s.pathParameters['id']!),
       ),
       // Detail / fullscreen routes pushed over the shell.
       GoRoute(

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/charts/scrubbable_area_chart.dart';
+import '../../../core/theme/app_colors.dart';
+import '../data/kalshi_repository.dart';
+
+class KalshiBacktestResultScreen extends ConsumerStatefulWidget {
+  const KalshiBacktestResultScreen({super.key, required this.backtestId});
+  final String backtestId;
+
+  @override
+  ConsumerState<KalshiBacktestResultScreen> createState() => _S();
+}
+
+class _S extends ConsumerState<KalshiBacktestResultScreen> {
+  Map<String, dynamic>? _status;
+  Map<String, dynamic>? _result;
+  String _tab = 'trades';
+  String? _selectedDay;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _timer = Timer.periodic(const Duration(seconds: 3), (_) {
+      final st = _status?['status'];
+      if (st == 'pending' || st == 'running') _load();
+    });
+  }
+
+  @override
+  void dispose() { _timer?.cancel(); super.dispose(); }
+
+  Future<void> _load() async {
+    try {
+      final d = await ref.read(kalshiRepositoryProvider).backtestResults(widget.backtestId);
+      if (!mounted) return;
+      setState(() {
+        _status = {'status': d['status'], 'summary': d['summary'] ?? {}};
+        _result = d['result'] as Map<String, dynamic>?;
+        final days = _daysList();
+        if (_selectedDay == null && days.isNotEmpty) _selectedDay = days.last;
+      });
+    } catch (_) {}
+  }
+
+  List<Map> get _trades => ((_result?['trades'] ?? []) as List).cast<Map>();
+  String _dayOf(dynamic ts) {
+    final n = (ts is num) ? ts.toInt() : 0;
+    if (n == 0) return 'unknown';
+    return DateTime.fromMillisecondsSinceEpoch(n * 1000, isUtc: true).toIso8601String().substring(0, 10);
+  }
+  Map<String, List<Map>> _byDay() {
+    final m = <String, List<Map>>{};
+    for (final t in _trades) {
+      (m[_dayOf(t['kickoff'])] ??= []).add(t);
+    }
+    return m;
+  }
+  List<String> _daysList() => _byDay().keys.toList()..sort();
+
+  String _money(dynamic c) => c == null ? '—' : '\$${((c as num) / 100).toStringAsFixed(2)}';
+  String _pct(dynamic v) => v == null ? '—' : '${((v as num) * 100).toStringAsFixed(1)}%';
+  Color _sc(String? st) => st == 'finished' ? AppColors.success : st == 'error' ? AppColors.danger : st == 'stopped' ? AppColors.textDim : AppColors.warning;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = (_status?['summary'] ?? {}) as Map;
+    final ec = ((_result?['equity_curve'] ?? []) as List);
+    final ts = <DateTime>[], vals = <double>[];
+    for (var i = 0; i < ec.length; i++) {
+      final kt = i < _trades.length ? (_trades[i]['kickoff'] as num? ?? 0).toInt() : 0;
+      ts.add(kt > 0 ? DateTime.fromMillisecondsSinceEpoch(kt * 1000) : DateTime.fromMillisecondsSinceEpoch(i * 3600000));
+      vals.add(((ec[i] ?? 0) as num) / 100);
+    }
+    return Scaffold(
+      backgroundColor: AppColors.canvas,
+      appBar: AppBar(
+        backgroundColor: AppColors.canvas,
+        title: Row(children: [
+          const Text('Backtest '),
+          Text(widget.backtestId.substring(0, 8), style: const TextStyle(fontFamily: 'monospace', fontSize: 14, color: AppColors.textMuted)),
+          const SizedBox(width: 8),
+          if (_status != null) Text(_status!['status']?.toString() ?? '', style: TextStyle(color: _sc(_status!['status']?.toString()), fontSize: 13)),
+        ]),
+      ),
+      body: ListView(padding: const EdgeInsets.all(16), children: [
+        _summary(s),
+        if (vals.length > 1) ...[
+          const SizedBox(height: 16),
+          _card('Equity — scrub to see that day\'s trades', [
+            if (_selectedDay != null)
+              Padding(padding: const EdgeInsets.only(bottom: 6), child: Text('$_selectedDay · ${(_byDay()[_selectedDay] ?? []).length} trade(s)', style: const TextStyle(color: AppColors.primary, fontSize: 12))),
+            ScrubbableAreaChart(
+              timestamps: ts, values: vals, lineColor: AppColors.chartLine, height: 200, baseline: 0, indexed: true,
+              onScrub: (i) {
+                if (i != null && i < _trades.length) setState(() => _selectedDay = _dayOf(_trades[i]['kickoff']));
+              },
+            ),
+            const SizedBox(height: 8),
+            Wrap(spacing: 6, runSpacing: 6, children: [
+              for (final d in _daysList())
+                GestureDetector(onTap: () => setState(() => _selectedDay = d), child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(borderRadius: BorderRadius.circular(20), color: _selectedDay == d ? AppColors.primary.withValues(alpha: 0.2) : AppColors.surface, border: Border.all(color: _selectedDay == d ? AppColors.primary : AppColors.border)),
+                  child: Text('$d · ${_byDay()[d]!.length}', style: TextStyle(fontSize: 11, color: _selectedDay == d ? AppColors.primary : AppColors.textMuted)))),
+            ]),
+          ]),
+        ],
+        const SizedBox(height: 16),
+        _tabs(),
+      ]),
+    );
+  }
+
+  Widget _summary(Map s) => _card('Summary', [
+        Wrap(spacing: 10, runSpacing: 10, children: [
+          _stat('Total P&L', _money(s['pnl_cents']), (s['pnl_cents'] ?? 0) >= 0 ? AppColors.success : AppColors.danger),
+          _stat('ROI', _pct(s['roi']), AppColors.textHi),
+          _stat('Bets', '${s['n_bets'] ?? '—'}', AppColors.textHi),
+          _stat('Win rate', _pct(s['win_rate']), AppColors.textHi),
+          _stat('Avg CLV', _pct(s['clv_avg']), AppColors.textHi),
+          _stat('API/cache', '${s['api_calls'] ?? 0}/${s['cache_hits'] ?? 0}', AppColors.textMuted),
+        ]),
+        const SizedBox(height: 8),
+        Text('Fixtures ${s['n_fixtures'] ?? 0} · bet ${s['bet'] ?? 0} · no-edge ${s['no_bet'] ?? 0} · unsettled ${s['unsettled'] ?? 0} · unmatched ${s['unmatched'] ?? 0} · no-price ${s['no_candle_data'] ?? 0}',
+            style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+      ]);
+
+  Widget _tabs() {
+    final decisions = ((_result?['decision_log'] ?? []) as List).cast<Map>();
+    final logs = ((_result?['logs'] ?? []) as List);
+    final dayTrades = (_byDay()[_selectedDay] ?? []);
+    return _card('', [
+      Row(children: [
+        for (final t in ['trades', 'decisions', 'logs'])
+          Padding(padding: const EdgeInsets.only(right: 16), child: GestureDetector(
+            onTap: () => setState(() => _tab = t),
+            child: Text(t == 'decisions' ? 'Decision log' : t[0].toUpperCase() + t.substring(1),
+                style: TextStyle(fontSize: 13, color: _tab == t ? AppColors.primary : AppColors.textMuted, fontWeight: _tab == t ? FontWeight.w600 : FontWeight.w400)))),
+      ]),
+      const SizedBox(height: 10),
+      if (_tab == 'trades')
+        if (dayTrades.isEmpty)
+          Text(_trades.isEmpty ? 'No bets were placed under these settings.' : 'Scrub or pick a day to see its trades.', style: const TextStyle(color: AppColors.textDim, fontSize: 12))
+        else
+          for (final t in dayTrades) _tradeCard(t)
+      else if (_tab == 'decisions')
+        if (decisions.isEmpty)
+          const Text('No decision log recorded.', style: TextStyle(color: AppColors.textDim, fontSize: 12))
+        else
+          for (final d in decisions) _decisionRow(d)
+      else
+        Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.4), borderRadius: BorderRadius.circular(8)),
+          child: logs.isEmpty
+              ? const Text('No logs recorded.', style: TextStyle(color: AppColors.textDim, fontSize: 11))
+              : Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                  for (final l in logs) Text(l.toString(), style: const TextStyle(fontFamily: 'monospace', fontSize: 10.5, color: AppColors.textMd)),
+                ]),
+        ),
+    ]);
+  }
+
+  Widget _tradeCard(Map t) {
+    final pnl = t['realized_pnl_cents'];
+    final hasSharp = t['sharp_prob'] != null;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(color: AppColors.canvas, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Row(children: [
+          Expanded(child: Text('${t['market_ticker']}', style: const TextStyle(color: AppColors.textMd, fontSize: 12), overflow: TextOverflow.ellipsis)),
+          Text(_money(pnl), style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 13, fontWeight: FontWeight.w600)),
+        ]),
+        Text('${t['league'] ?? ''} · side ${t['side']} · entry ${t['entry_cents']}¢ × ${t['size']}', style: const TextStyle(color: AppColors.textMuted, fontSize: 11)),
+        const SizedBox(height: 6),
+        Wrap(spacing: 6, runSpacing: 4, children: [
+          _badge('edge ${((t['edge'] ?? 0) * 100).toStringAsFixed(1)}%', AppColors.textMuted),
+          _badge(hasSharp ? 'sharp' : 'model-only', hasSharp ? AppColors.info : AppColors.warning),
+          if (t['model_prob'] != null) _badge('model ${(t['model_prob'] as num).toStringAsFixed(2)}', AppColors.textMuted),
+          _badge('${t['outcome']}', t['outcome'] == 'win' ? AppColors.success : AppColors.danger),
+        ]),
+      ]),
+    );
+  }
+
+  Widget _decisionRow(Map d) {
+    final dec = d['decision']?.toString() ?? '';
+    final col = dec == 'placed' ? AppColors.success : dec == 'no_bet' ? AppColors.textMd : AppColors.warning;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(children: [
+        Expanded(child: Text(d['label']?.toString() ?? '', style: const TextStyle(color: AppColors.textMd, fontSize: 12))),
+        Text(dec, style: TextStyle(color: col, fontSize: 12)),
+        const SizedBox(width: 8),
+        Expanded(child: Text(d['reason']?.toString() ?? '', style: const TextStyle(color: AppColors.textDim, fontSize: 11), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis)),
+      ]),
+    );
+  }
+
+  Widget _badge(String text, Color color) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(color: color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(4)),
+        child: Text(text, style: TextStyle(color: color, fontSize: 10)));
+
+  Widget _card(String title, List<Widget> children) => Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(color: AppColors.surface, borderRadius: BorderRadius.circular(14), border: Border.all(color: AppColors.border)),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          if (title.isNotEmpty) ...[Text(title, style: const TextStyle(color: AppColors.textHi, fontWeight: FontWeight.w600, fontSize: 14)), const SizedBox(height: 10)],
+          ...children,
+        ]));
+
+  Widget _stat(String label, String value, Color color) => Container(
+        width: 104, padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(color: AppColors.canvas, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(label, style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+          Text(value, style: TextStyle(color: color, fontSize: 15, fontWeight: FontWeight.w600)),
+        ]));
+}

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-import '../../../core/charts/scrubbable_area_chart.dart';
 import '../../../core/theme/app_colors.dart';
 import '../data/kalshi_repository.dart';
 
@@ -45,8 +45,6 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
   bool _submitting = false;
   String? _err;
   List<Map<String, dynamic>> _backtests = [];
-  Map<String, dynamic>? _selected;
-  Map<String, dynamic>? _result;
   Timer? _timer;
 
   KalshiRepository get _repo => ref.read(kalshiRepositoryProvider);
@@ -122,11 +120,9 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
 
   Future<void> _tick() async {
     await _loadBacktests();
-    final sel = _selected;
-    if (sel != null && (sel['status'] == 'pending' || sel['status'] == 'running')) {
-      await _openResults(sel['id'].toString());
-    }
   }
+
+  void _openResults(String id) => context.push('/kalshi/backtests/$id');
 
   String _fmtDate(DateTime? d) => d == null ? '' : '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
@@ -173,7 +169,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
       };
       final id = await _repo.createBacktest(_bid, body);
       await _loadBacktests();
-      await _openResults(id);
+      if (mounted) _openResults(id);
     } catch (_) {
       setState(() => _err = 'Failed to start the backtest.');
     } finally {
@@ -181,19 +177,7 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     }
   }
 
-  Future<void> _openResults(String id) async {
-    try {
-      final d = await _repo.backtestResults(id);
-      if (!mounted) return;
-      setState(() {
-        _selected = {'id': id, 'status': d['status'], 'summary': d['summary'] ?? {}};
-        _result = d['result'] as Map<String, dynamic>?;
-      });
-    } catch (_) {}
-  }
-
   String _money(dynamic cents) => cents == null ? '—' : '\$${((cents as num) / 100).toStringAsFixed(2)}';
-  String _pct(dynamic v) => v == null ? '—' : '${((v as num) * 100).toStringAsFixed(1)}%';
   Color _statusColor(String? s) => s == 'finished' ? AppColors.success : s == 'error' ? AppColors.danger : s == 'stopped' ? AppColors.textDim : AppColors.warning;
 
   @override
@@ -286,7 +270,6 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
             else
               for (final b in _backtests) _btRow(b),
           ]),
-          if (_selected != null) ...[const SizedBox(height: 16), _resultsCard()],
         ],
       ),
     );
@@ -348,59 +331,4 @@ class _KalshiBacktestScreenState extends ConsumerState<KalshiBacktestScreen> {
     );
   }
 
-  Widget _resultsCard() {
-    final sel = _selected!;
-    final summary = (sel['summary'] ?? {}) as Map;
-    final res = _result;
-    final ec = (res?['equity_curve'] ?? []) as List? ?? [];
-    final trades = (res?['trades'] ?? []) as List? ?? [];
-    final ts = <DateTime>[], vals = <double>[];
-    for (var i = 0; i < ec.length; i++) {
-      ts.add(DateTime.fromMillisecondsSinceEpoch(i * 3600000));
-      vals.add(((ec[i] ?? 0) as num) / 100);
-    }
-    return _card('Results', [
-      Wrap(spacing: 10, runSpacing: 10, children: [
-        _stat('Total P&L', _money(summary['pnl_cents']), (summary['pnl_cents'] ?? 0) >= 0 ? AppColors.success : AppColors.danger),
-        _stat('ROI', _pct(summary['roi']), AppColors.textHi),
-        _stat('Bets', '${summary['n_bets'] ?? '—'}', AppColors.textHi),
-        _stat('Win rate', _pct(summary['win_rate']), AppColors.textHi),
-        _stat('Avg CLV', _pct(summary['clv_avg']), AppColors.textHi),
-        _stat('API/cache', '${summary['api_calls'] ?? 0}/${summary['cache_hits'] ?? 0}', AppColors.textMuted),
-      ]),
-      const SizedBox(height: 12),
-      if (vals.length > 1)
-        ScrubbableAreaChart(timestamps: ts, values: vals, lineColor: AppColors.chartLine, height: 200, baseline: 0, indexed: true),
-      if (trades.isNotEmpty) ...[
-        const SizedBox(height: 12),
-        Text('Trades (${trades.length})', style: const TextStyle(color: AppColors.textMuted, fontSize: 12, fontWeight: FontWeight.w600)),
-        for (final t in trades.take(60)) _tradeRow(t as Map),
-      ],
-      if (res != null && trades.isEmpty && sel['status'] == 'finished')
-        const Padding(padding: EdgeInsets.only(top: 8), child: Text('No bets were placed under these settings over this range.', style: TextStyle(color: AppColors.textDim, fontSize: 12))),
-    ]);
-  }
-
-  Widget _stat(String label, String value, Color color) => Container(
-        width: 104, padding: const EdgeInsets.all(10),
-        decoration: BoxDecoration(color: AppColors.canvas, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text(label, style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
-          Text(value, style: TextStyle(color: color, fontSize: 15, fontWeight: FontWeight.w600)),
-        ]));
-
-  Widget _tradeRow(Map t) {
-    final pnl = t['realized_pnl_cents'];
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(children: [
-        Expanded(child: Text('${t['market_ticker']}', style: const TextStyle(color: AppColors.textMd, fontSize: 11), overflow: TextOverflow.ellipsis)),
-        Text('${t['side']} · ${t['entry_cents']}¢ ×${t['size']}', style: const TextStyle(color: AppColors.textMuted, fontSize: 11)),
-        const SizedBox(width: 8),
-        Text('${t['outcome']}', style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
-        const SizedBox(width: 8),
-        Text(_money(pnl), style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 11)),
-      ]),
-    );
-  }
 }


### PR DESCRIPTION
Follow-ups from testing the Kalshi backtest.

## Fixes
- **OddsPapi Cloudflare 403 (error 1010)** — the client now sends a browser User-Agent, so the API is reachable. (Note: a valid OddsPapi key is still required — a The-Odds-API key returns `INVALID_API_KEY`.)
- **Run logs + decision log** — `run_backtest` now records human-readable logs and a per-fixture decision log (skip reasons: unsettled/unmatched/no-price, model+sharp probs, edge, bet outcome) plus fixture/skip counts in the summary. Explains a 0-trade run at a glance.
- **Pending status UI** — no more cramped `pending0%`; a proper progress bar.

## New results screen (web + mobile)
Instance-style dedicated view at `/kalshi/backtests/:id`:
- **Scrubbable equity chart** — click/scrub a point to see that day's trades.
- **Trade cards** with badges (edge, sharp/model-only, model prob, outcome, CLV).
- **Decision log** tab + **Logs** tab (saved run logs) + fixture/skip counts.
- List "View" navigates here (inline results removed).

## De-hardcoding (works for all leagues)
- Removed hardcoded World-Cup team→flag emoji maps.
- Removed WC-only sport-id (`{world cup:1}`): all soccer leagues use one OddsPapi soccer id; fixtures fetched once per unique sport id, deduped, and tagged by their own tournament. Forward-compatible for any league.

## Verify
- 119 backtest/ingest tests pass; `npm run build` clean; `flutter analyze` clean (new files; only pre-existing infos remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)