### PR TITLE
fix(kalshi): sharp-odds failure no longer crashes backtest; surface errors; OddsPapi /v4

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4396,6 +4396,7 @@ def api_kalshi_backtest_results(backtest_id: str, conn=Depends(conn_dependency),
     if not row:
         raise HTTPException(status_code=404, detail="backtest not found")
     return {"status": row.get("status"), "summary": row.get("summary") or {},
+            "error": row.get("error"),
             "result": kdb.get_backtest_result(conn, backtest_id)}
 
 

--- a/backend/kalshi/backtest_data.py
+++ b/backend/kalshi/backtest_data.py
@@ -283,7 +283,16 @@ class BacktestDataProvider:
                 "BacktestDataProvider.sharp_odds: OddsPapi budget exhausted, "
                 "skipping fixture_id=%s (returning cached-or-empty)", fixture_id)
             return []
-        rows = self.oddspapi_client.historical_odds(fixture_id)
+        # The sharp line is OPTIONAL — any OddsPapi failure (bad key, 404, network)
+        # must degrade to model-only, never crash the backtest.
+        try:
+            rows = self.oddspapi_client.historical_odds(fixture_id)
+        except Exception as e:
+            self.log.warning(
+                "BacktestDataProvider.sharp_odds: OddsPapi failed for fixture_id=%s "
+                "(%s) — trading model-only", fixture_id, e)
+            self._table_put("KalshiHistOdds", {"id": fixture_id, "snapshots": []}, "id")
+            return []
         self.api_calls += 1
         self._budget_bumper()
         self._table_put("KalshiHistOdds", {"id": fixture_id, "snapshots": rows}, "id")

--- a/backend/kalshi/backtest_worker.py
+++ b/backend/kalshi/backtest_worker.py
@@ -82,6 +82,12 @@ def run_job(job, *, conn, provider, model_fn, store=_db, stop_check=None,
         return "stopped"
     except Exception as e:  # pragma: no cover - defensive; unit-tested via run_fn raising
         log.exception("backtest %s failed", jid)
+        # Save the error as a viewable log so the results screen shows WHAT failed
+        # instead of an empty "No logs recorded."
+        try:
+            store.save_backtest_result(conn, jid, {"logs": [f"ERROR: {e}"], "summary": {}})
+        except Exception:
+            pass
         store.update_backtest_progress(conn, jid, status="error", error=str(e),
                                        finished_at=_iso_now())
         return "error"

--- a/backend/kalshi/ingest_odds.py
+++ b/backend/kalshi/ingest_odds.py
@@ -154,13 +154,14 @@ class OddsPapiClient:
 
     def list_fixtures(self, sport_id: int, date_from: str, date_to: str) -> list[dict]:
         """Fixtures for a sport in a date window, normalized (parsed)."""
-        raw = self.fetch_raw("/fixtures", {
-            "sport_id": sport_id, "date_from": date_from, "date_to": date_to,
+        raw = self.fetch_raw("/v4/fixtures", {
+            "sportId": sport_id, "from": date_from, "to": date_to,
         })
         return parse_fixtures(raw)
 
     def historical_odds(self, fixture_id, books: tuple[str, ...] = ("pinnacle",)) -> list[dict]:
         """Historical odds snapshots for a fixture, normalized (parsed) for the
         first available book in `books` priority order."""
-        raw = self.fetch_raw("/historical-odds", {"fixture_id": fixture_id})
+        raw = self.fetch_raw("/v4/historical-odds",
+                             {"fixtureId": fixture_id, "bookmakers": ",".join(books)})
         return parse_hist_odds(raw, books=books)

--- a/backend/tests/test_kalshi_ingest_odds_methods.py
+++ b/backend/tests/test_kalshi_ingest_odds_methods.py
@@ -128,10 +128,10 @@ def test_list_fixtures_calls_fetch_raw_with_expected_params():
     out = client.list_fixtures(sport_id=1, date_from="2026-07-01", date_to="2026-07-02")
     method, url, params = sess.last_call
     assert method == "GET"
-    assert url.endswith("/fixtures")
-    assert params["sport_id"] == 1
-    assert params["date_from"] == "2026-07-01"
-    assert params["date_to"] == "2026-07-02"
+    assert url.endswith("/v4/fixtures")
+    assert params["sportId"] == 1
+    assert params["from"] == "2026-07-01"
+    assert params["to"] == "2026-07-02"
     assert params["apiKey"] == "KEY"
     assert out[0]["fixture_id"] == "9"
 
@@ -143,7 +143,7 @@ def test_historical_odds_calls_fetch_raw_with_expected_params():
     out = client.historical_odds(fixture_id=9, books=("pinnacle",))
     method, url, params = sess.last_call
     assert method == "GET"
-    assert url.endswith("/historical-odds")
-    assert params["fixture_id"] == 9
+    assert url.endswith("/v4/historical-odds")
+    assert params["fixtureId"] == 9
     assert params["apiKey"] == "KEY"
     assert out == [{"ts": 100, "home": 2.0, "draw": 3.5, "away": 4.0}]

--- a/frontend/src/views/KalshiBacktestResultView.vue
+++ b/frontend/src/views/KalshiBacktestResultView.vue
@@ -22,7 +22,7 @@ async function load() {
     const res = await fetch(`${API_BASE}/kalshi/backtests/${id}/results`, { headers: authHeaders() })
     if (!res.ok) return
     const d = await res.json()
-    status.value = { status: d.status, summary: d.summary || {} }
+    status.value = { status: d.status, summary: d.summary || {}, error: d.error }
     result.value = d.result || null
     if (!selectedDay.value && dayKeys.value.length) selectedDay.value = dayKeys.value[dayKeys.value.length - 1]
   } catch (e) { /* ignore */ }
@@ -89,6 +89,10 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer) })
         <h1 class="text-xl font-semibold text-slate-100">Backtest <span class="font-mono text-slate-400 text-base">{{ id.slice(0, 8) }}</span></h1>
         <span v-if="status" :class="statusColor(status.status)" class="text-sm">{{ status.status }}</span>
       </div>
+    </div>
+
+    <div v-if="status && status.error" class="bg-rose-500/10 border border-rose-500/40 rounded-lg p-3 text-sm text-rose-300">
+      <span class="font-semibold">Error:</span> {{ status.error }}
     </div>
 
     <!-- Summary hero -->


### PR DESCRIPTION
## The bug you hit ("error / No logs recorded")
A backtest errored with `404 .../historical-odds` and showed no logs. Cause: `sharp_odds()` let an OddsPapi HTTP error propagate and **crash the whole run** — the sharp line is optional and must degrade to model-only.

## Fixes
- `sharp_odds()` now catches ANY OddsPapi failure → model-only (never crashes).
- On error, `run_job` saves the message as a viewable **log**; `/results` returns `error`; the web result screen shows an **error banner** (no more empty "No logs recorded").
- `OddsPapiClient` uses the correct **`/v4`** endpoints + documented params (`sportId/from/to`, `fixtureId/bookmakers`).

## About your OddsPapi key
Tested live across every auth method: sent correctly (`apiKey` query param), OddsPapi returns **`401 INVALID_API_KEY`**. Your `6fec…` string is your **The-Odds-API** key — OddsPapi is a different company. Get a free key at **oddspapi.io**. Until then the backtest runs **model-only** (fixtures/prices/results all come from Kalshi, free).

## Verify
120 backtest/ingest tests pass; web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)