### PR TITLE
fix(kalshi): trade pick label 'Team to win'/'Draw'

### DIFF
--- a/frontend/src/views/KalshiBacktestResultView.vue
+++ b/frontend/src/views/KalshiBacktestResultView.vue
@@ -89,6 +89,12 @@ function pickIdx(i) {
   if (t) { selectedDay.value = dayOf(t.kickoff); tab.value = 'trades' }
 }
 
+function pickLabel(t) {
+  if (t.side === 'draw') return 'Draw'
+  if (t.side === 'home') return `${t.home || 'Home'} to win`
+  if (t.side === 'away') return `${t.away || 'Away'} to win`
+  return t.side
+}
 function fmtPct(v) { return v == null ? '—' : `${(v * 100).toFixed(1)}%` }
 function fmtMoney(c) { return c == null ? '—' : `$${(c / 100).toFixed(2)}` }
 const s = computed(() => (status.value && status.value.summary) || {})
@@ -193,7 +199,7 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer); if (clockTimer)
             </div>
             <div class="text-xs text-slate-400 mt-1">
               <span v-if="t.league" class="mr-1 text-slate-500">{{ t.league }}</span>
-              side <span class="text-slate-200">{{ t.side }}</span> · entry {{ t.entry_cents }}¢ × {{ t.size }}
+              <span class="text-slate-200">{{ pickLabel(t) }}</span> · entry {{ t.entry_cents }}¢ × {{ t.size }}
             </div>
             <!-- flags / badges -->
             <div class="flex flex-wrap gap-1.5 mt-2">

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
@@ -173,6 +173,14 @@ class _S extends ConsumerState<KalshiBacktestResultScreen> {
     ]);
   }
 
+  String _pickLabel(Map t) {
+    final s = t['side'];
+    if (s == 'draw') return 'Draw';
+    if (s == 'home') return '${t['home'] ?? 'Home'} to win';
+    if (s == 'away') return '${t['away'] ?? 'Away'} to win';
+    return '$s';
+  }
+
   Widget _tradeCard(Map t) {
     final pnl = t['realized_pnl_cents'];
     final hasSharp = t['sharp_prob'] != null;
@@ -191,7 +199,7 @@ class _S extends ConsumerState<KalshiBacktestResultScreen> {
           const SizedBox(width: 6),
           Text(_money(pnl), style: TextStyle(color: (pnl ?? 0) >= 0 ? AppColors.success : AppColors.danger, fontSize: 13, fontWeight: FontWeight.w600)),
         ]),
-        Text('${t['league'] ?? ''} · side ${t['side']} · entry ${t['entry_cents']}¢ × ${t['size']}', style: const TextStyle(color: AppColors.textMuted, fontSize: 11)),
+        Text('${t['league'] ?? ''} · ${_pickLabel(t)} · entry ${t['entry_cents']}¢ × ${t['size']}', style: const TextStyle(color: AppColors.textMuted, fontSize: 11)),
         const SizedBox(height: 6),
         Wrap(spacing: 6, runSpacing: 4, children: [
           _badge('edge ${((t['edge'] ?? 0) * 100).toStringAsFixed(1)}%', AppColors.textMuted),


### PR DESCRIPTION
Replaces 'side home/away/draw' with 'Netherlands to win' / 'Draw' on web + mobile trade cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)