### PR TITLE
feat(kalshi): per-fixture lock + bootstrap confidence (trustworthiness #2 + #3)

### DIFF
--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -72,6 +72,7 @@ class BacktestConfig:
     # This is the "market anchor" — it stops the model betting its own biased,
     # overconfident view of cheap home underdogs blind.
     market_shrink: float = 0.5
+    one_bet_per_fixture: bool = True  # never hold >1 side of the same match
 
 
 def config_from_body(body: dict) -> BacktestConfig:
@@ -122,6 +123,7 @@ def config_from_body(body: dict) -> BacktestConfig:
         analyst_max_calls=int(body.get("analyst_max_calls", 10) or 10),
         use_llm=bool(body.get("use_llm", False)),
         market_shrink=min(1.0, max(0.0, float(body.get("market_shrink", 0.5)))),
+        one_bet_per_fixture=bool(body.get("one_bet_per_fixture", True)),
     )
 
 
@@ -577,6 +579,11 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_
                     fx_for_eval = dict(fx)
                     fx_for_eval["market_tickers"] = tickers
                     bets = evaluate(cfg, model_probs, sharp_probs, kalshi_asks, fx_for_eval, llm_adj)
+                    # PER-FIXTURE LOCK: never hold more than one side of the same
+                    # match — keep only the single highest-edge bet (no correlated
+                    # both-sides exposure).
+                    if cfg.one_bet_per_fixture and len(bets) > 1:
+                        bets = sorted(bets, key=lambda b: b.edge, reverse=True)[:1]
                     rec.update({"model_prob": {k: round(v, 4) for k, v in model_probs.items()},
                                 "sharp_prob": {k: round(v, 4) for k, v in sharp_probs.items()},
                                 "asks": kalshi_asks, "has_sharp": bool(sharp_probs)})
@@ -616,14 +623,37 @@ def run_backtest(cfg: BacktestConfig, data, model_fn, progress_cb=None, analyst_
          f"cache_hits={getattr(data, 'cache_hits', 0)}")
 
     out = aggregate(trades, cfg.bankroll_cents)
+    ci_lo, ci_hi, p_profit = _bootstrap_pnl_ci([t.realized_pnl_cents for t in trades])
     out.summary = {
         "api_calls": getattr(data, "api_calls", 0),
         "cache_hits": getattr(data, "cache_hits", 0),
-        "n_fixtures": n, **counts,
+        "n_fixtures": n,
+        # Trustworthiness: 90% bootstrap CI on total P&L + P(profit>0). A CI that
+        # spans zero / a low profit-confidence means the result is indistinguishable
+        # from luck — the honest read on a small, longshot-heavy sample.
+        "pnl_ci_low_cents": ci_lo, "pnl_ci_high_cents": ci_hi,
+        "profit_confidence": p_profit,
+        **counts,
     }
     out.logs = logs
     out.decision_log = decision_log
     return out
+
+
+def _bootstrap_pnl_ci(pnls: list, n: int = 2000, seed: int = 42):
+    """Deterministic bootstrap: resample the per-trade P&L with replacement `n`
+    times, sum each. Returns (5th pct, 95th pct total, fraction of resamples > 0).
+    Empty -> (0, 0, 0.0)."""
+    if not pnls:
+        return 0, 0, 0.0
+    import random as _random
+    rng = _random.Random(seed)
+    k = len(pnls)
+    sums = sorted(sum(rng.choice(pnls) for _ in range(k)) for _ in range(n))
+    lo = int(sums[int(0.05 * n)])
+    hi = int(sums[int(0.95 * n)])
+    p_profit = sum(1 for s in sums if s > 0) / n
+    return lo, hi, round(p_profit, 3)
 
 
 # --------------------------------------------------------------------------

--- a/frontend/src/views/KalshiBacktestResultView.vue
+++ b/frontend/src/views/KalshiBacktestResultView.vue
@@ -98,6 +98,10 @@ function pickLabel(t) {
 function fmtPct(v) { return v == null ? '—' : `${(v * 100).toFixed(1)}%` }
 function fmtMoney(c) { return c == null ? '—' : `$${(c / 100).toFixed(2)}` }
 const s = computed(() => (status.value && status.value.summary) || {})
+const confColor = computed(() => {
+  const p = s.value.profit_confidence ?? 0
+  return p >= 0.9 ? 'text-emerald-400' : p >= 0.75 ? 'text-amber-400' : 'text-rose-400'
+})
 function statusColor(st) { return st === 'finished' ? 'text-emerald-400' : st === 'error' ? 'text-rose-400' : st === 'stopped' ? 'text-slate-400' : 'text-amber-400' }
 
 onMounted(async () => {
@@ -146,6 +150,12 @@ onBeforeUnmount(() => { if (pollTimer) clearInterval(pollTimer); if (clockTimer)
         <span>Unsettled: <span class="text-slate-300">{{ s.unsettled ?? 0 }}</span></span>
         <span>Unmatched: <span class="text-amber-400">{{ s.unmatched ?? 0 }}</span></span>
         <span>No-price: <span class="text-slate-300">{{ s.no_candle_data ?? 0 }}</span></span>
+      </div>
+      <div v-if="s.profit_confidence != null" class="mt-2 pt-2 border-t border-border-subtle/50 text-xs flex flex-wrap items-center gap-x-4 gap-y-1">
+        <span class="text-slate-500">Trust:</span>
+        <span :class="confColor">Profit confidence {{ (s.profit_confidence * 100).toFixed(0) }}%</span>
+        <span class="text-slate-500">90% P&L range {{ fmtMoney(s.pnl_ci_low_cents) }} → {{ fmtMoney(s.pnl_ci_high_cents) }}</span>
+        <span v-if="s.pnl_ci_low_cents < 0" class="text-amber-400/80">— spans a loss, so this edge is not statistically proven</span>
       </div>
     </section>
 

--- a/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_backtest_result_screen.dart
@@ -135,6 +135,12 @@ class _S extends ConsumerState<KalshiBacktestResultScreen> {
         const SizedBox(height: 8),
         Text('Fixtures ${s['n_fixtures'] ?? 0} · bet ${s['bet'] ?? 0} · no-edge ${s['no_bet'] ?? 0} · unsettled ${s['unsettled'] ?? 0} · unmatched ${s['unmatched'] ?? 0} · no-price ${s['no_candle_data'] ?? 0}',
             style: const TextStyle(color: AppColors.textDim, fontSize: 11)),
+        if (s['profit_confidence'] != null) Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            'Trust: profit confidence ${((s['profit_confidence'] as num) * 100).toStringAsFixed(0)}% · 90% range ${_money(s['pnl_ci_low_cents'])} → ${_money(s['pnl_ci_high_cents'])}${(s['pnl_ci_low_cents'] ?? 0) < 0 ? ' (spans a loss — not proven)' : ''}',
+            style: TextStyle(color: (s['profit_confidence'] as num) >= 0.9 ? AppColors.success : (s['profit_confidence'] as num) >= 0.75 ? AppColors.warning : AppColors.danger, fontSize: 11)),
+        ),
       ]);
 
   Widget _tabs() {


### PR DESCRIPTION
#2 one-bet-per-fixture lock (no correlated both-sides exposure). #3 deterministic bootstrap 90% CI on total P&L + P(profit>0), shown as a 'Trust' line on web+mobile. On the $83 WC result: CI -$46..+$227, P(profit)=84% -> not statistically distinguishable from a loss. 21 tests pass; web+mobile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)