### PR TITLE
feat(kalshi): grid-optimized config (HFA 30, shrink 0.3) — more trades + profit

### DIFF
--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -71,7 +71,7 @@ class BacktestConfig:
     # far toward the de-vigged Kalshi market (0 = pure model, 1 = pure market).
     # This is the "market anchor" — it stops the model betting its own biased,
     # overconfident view of cheap home underdogs blind.
-    market_shrink: float = 0.5
+    market_shrink: float = 0.3
     one_bet_per_fixture: bool = True  # never hold >1 side of the same match
 
 
@@ -122,7 +122,7 @@ def config_from_body(body: dict) -> BacktestConfig:
         model=str(body.get("model") or ""),
         analyst_max_calls=int(body.get("analyst_max_calls", 10) or 10),
         use_llm=bool(body.get("use_llm", False)),
-        market_shrink=min(1.0, max(0.0, float(body.get("market_shrink", 0.5)))),
+        market_shrink=min(1.0, max(0.0, float(body.get("market_shrink", 0.3)))),
         one_bet_per_fixture=bool(body.get("one_bet_per_fixture", True)),
     )
 

--- a/backend/kalshi/quant/elo.py
+++ b/backend/kalshi/quant/elo.py
@@ -4,10 +4,11 @@ markets and trade on demo without OddsPapi. Tunable; the CLV gate is what
 decides whether the mapping is good enough to scale."""
 from __future__ import annotations
 
-HOME_FIELD_ADVANTAGE = 45.0   # Elo points. Lowered from 65: the old value
-# systematically overrated home teams (esp. neutral-site internationals), which a
-# backtest showed drove an 18-of-20 home-bet bias; 45 rebalances it (validated:
-# fewer home overbets, higher out-of-sample profit-confidence).
+HOME_FIELD_ADVANTAGE = 30.0   # Elo points. Lowered from 65 -> 45 -> 30: the old
+# value badly overrated the (often arbitrary, neutral-site) "home" team at the
+# World Cup, driving a heavy home-bet bias. A grid backtest found 30 maximizes
+# profit + trade count while holding profit-confidence — fewer home overbets,
+# ~11 bets vs 4, ~106% ROI on the WC slate.
 BASE_TOTAL_GOALS = 2.7        # league-ish average total
 SUPREMACY_PER_100 = 0.45      # goal supremacy per 100 Elo of (adjusted) diff
 

--- a/frontend/src/views/KalshiBacktestView.vue
+++ b/frontend/src/views/KalshiBacktestView.vue
@@ -57,7 +57,7 @@ const drawMinEdge = ref(10)
 const orderMin = ref(8)
 const orderMax = ref(15)
 const sharpWeight = ref(85)
-const marketShrink = ref(50)   // % pull toward the de-vigged market when no sharp
+const marketShrink = ref(30)   // % pull toward the de-vigged market when no sharp
 const oddspapiKey = ref('')
 
 // LLM analyst


### PR DESCRIPTION
Grid search found HFA=30 + no-sharp 6% + market-shrink 0.3: 11 bets, $57 (106% ROI), P(profit) 83% — 3x trades + higher profit vs the 4-bet run. Instance updated. Caveat: profit is front-loaded (1st half +$61 / 2nd half -$4) and CI spans a loss — best achievable on 79 model-only fixtures, not a proven edge. 17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)