### PR TITLE
feat(kalshi): context-aware home-field advantage (fix home-bias)

### DIFF
--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -29,7 +29,7 @@ from kalshi.devig import power_devig, shin_devig, proportional_devig
 from kalshi.fees import DEFAULT_FEE_RATE
 from kalshi.intelligence.fusion import fuse, renormalize_group
 from kalshi.intelligence.pricing import model_market_probs
-from kalshi.quant.elo import elo_to_expected_goals
+from kalshi.quant.elo import elo_to_expected_goals, HOME_FIELD_ADVANTAGE, NEUTRAL_HFA
 from kalshi.quant.national_elo import is_national_team, national_elo_from
 from kalshi.strategy.candidates import generate_candidates
 from kalshi.capital.planner import allocate
@@ -697,7 +697,12 @@ def build_model_fn(nat_elo_table: dict | None, elo_table: dict | None):
         home = fx.get("home", "")
         away = fx.get("away", "")
         home_elo, away_elo = _team_elo(home), _team_elo(away)
-        expected_goals = elo_to_expected_goals(home_elo, away_elo)
+        # Context-aware home advantage: neutral-site (both national teams -> a WC
+        # tournament game where "home" is arbitrary) uses ~0; a real home game
+        # (club) keeps the genuine ~65.
+        _neutral = is_national_team(home) and is_national_team(away)
+        expected_goals = elo_to_expected_goals(
+            home_elo, away_elo, hfa=(NEUTRAL_HFA if _neutral else HOME_FIELD_ADVANTAGE))
         probs = model_market_probs(expected_goals)
         return probs.get("winner", {})
 

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -233,7 +233,7 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
         f"bankroll ${config.caps.bankroll_cents / 100:.0f} · edge > {config.caps.edge_threshold:.1%} · "
         f"¼-Kelly {config.caps.kelly_fraction}", "white")
 
-    from kalshi.quant.elo import elo_to_expected_goals
+    from kalshi.quant.elo import elo_to_expected_goals, HOME_FIELD_ADVANTAGE, NEUTRAL_HFA
     from kalshi.quant.national_elo import is_national_team, national_elo, national_elo_from
     from kalshi.data.sources.clubelo import fetch_elo_table, elo_for
     from kalshi.data.sources.natelo import fetch_national_elo_table
@@ -431,7 +431,11 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                     return elo_for(elo_table, name)
 
                 he, ae = _team_elo(home), _team_elo(away)
-                eg = elo_to_expected_goals(he, ae)
+                # Context-aware home advantage: a neutral-site tournament game (WC
+                # series / both national) has ~0 home edge ("home" is arbitrary); a
+                # real home game keeps the genuine ~65.
+                _neutral = national_series or (is_national_team(home) and is_national_team(away))
+                eg = elo_to_expected_goals(he, ae, hfa=(NEUTRAL_HFA if _neutral else HOME_FIELD_ADVANTAGE))
                 # Sharp anchor: de-vig the matched bookmaker odds, then fuse sharp+model.
                 # No match -> sharp_probs={} -> fused == model (degrade-safe).
                 sharp = {}

--- a/backend/kalshi/quant/elo.py
+++ b/backend/kalshi/quant/elo.py
@@ -4,11 +4,11 @@ markets and trade on demo without OddsPapi. Tunable; the CLV gate is what
 decides whether the mapping is good enough to scale."""
 from __future__ import annotations
 
-HOME_FIELD_ADVANTAGE = 30.0   # Elo points. Lowered from 65 -> 45 -> 30: the old
-# value badly overrated the (often arbitrary, neutral-site) "home" team at the
-# World Cup, driving a heavy home-bet bias. A grid backtest found 30 maximizes
-# profit + trade count while holding profit-confidence — fewer home overbets,
-# ~11 bets vs 4, ~106% ROI on the WC slate.
+HOME_FIELD_ADVANTAGE = 65.0   # Elo points — a REAL home game (club leagues, a
+# host nation). Kept at the genuine ~65 value.
+NEUTRAL_HFA = 5.0             # Neutral-site game (World Cup group/knockout): the
+# "home" label is essentially arbitrary, so home advantage is ~0. Callers pick
+# NEUTRAL_HFA vs HOME_FIELD_ADVANTAGE by whether the fixture is neutral-site.
 BASE_TOTAL_GOALS = 2.7        # league-ish average total
 SUPREMACY_PER_100 = 0.45      # goal supremacy per 100 Elo of (adjusted) diff
 


### PR DESCRIPTION
Neutral-site WC games use ~0 home advantage (home is arbitrary there); real home games keep 65. Applied to backtest + live engine. Model now bets home AND away by strength (~9:8 vs ~9:2). Honestly lowers WC profit (the old tilt was bias/luck). Draws still unbet (no edge). 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)