### PR TITLE
feat(kalshi): live-engine parity — market anchor + one-bet-per-fixture

### DIFF
--- a/backend/kalshi/backtest.py
+++ b/backend/kalshi/backtest.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from kalshi import instance_config
 from kalshi.client import yes_ask_close_at
 from kalshi.data.sources.clubelo import elo_for
-from kalshi.devig import power_devig, shin_devig, proportional_devig
+from kalshi.devig import power_devig, shin_devig, proportional_devig, market_probs_from_asks
 from kalshi.fees import DEFAULT_FEE_RATE
 from kalshi.intelligence.fusion import fuse, renormalize_group
 from kalshi.intelligence.pricing import model_market_probs
@@ -137,19 +137,11 @@ _TIER_FOR_MARKET_TYPES = "max"  # widest allowed-markets set; caps still gate vo
 def _market_probs_from_asks(kalshi_asks: dict, devig_method: str) -> dict:
     """De-vig the 3-way Kalshi YES asks (cents) into a coherent {side: prob} that
     sums to 1. The three YES asks sum to >1 (the vig); removing it yields the
-    market's implied probabilities. {} if the full 3-way isn't priced."""
-    sides = [s for s in ("home", "draw", "away") if s in kalshi_asks]
-    if len(sides) < 3:
-        return {}
-    raw = [float(kalshi_asks[s]) / 100.0 for s in sides]
-    if any(x <= 0 for x in raw):
-        return {}
-    fn = _DEVIG_FUNCS.get(devig_method, power_devig)
-    try:
-        p = fn(raw)
-    except Exception:
-        return {}
-    return {s: p[i] for i, s in enumerate(sides)}
+    market's implied probabilities. {} if the full 3-way isn't priced.
+
+    Delegates to `devig.market_probs_from_asks` — the single implementation
+    shared with the live path (`orchestrator.plan_and_allocate`)."""
+    return market_probs_from_asks(kalshi_asks, devig_method)
 
 
 @dataclass(frozen=True)

--- a/backend/kalshi/devig.py
+++ b/backend/kalshi/devig.py
@@ -71,3 +71,25 @@ def shin_devig(raw: list[float], tol: float = 1e-12, max_iter: int = 200) -> lis
         else:
             z_hi = z
     return p
+
+
+_DEVIG_FUNCS = {"power": power_devig, "shin": shin_devig, "proportional": proportional_devig}
+
+
+def market_probs_from_asks(asks_by_side: dict, devig_method: str = "power") -> dict:
+    """De-vig the 3-way Kalshi YES asks (cents) into a coherent {side: prob} that
+    sums to 1. The three YES asks sum to >1 (the vig); removing it yields the
+    market's implied probabilities. {} if the full 3-way isn't priced."""
+    asks_by_side = asks_by_side or {}
+    sides = [s for s in ("home", "draw", "away") if s in asks_by_side]
+    if len(sides) < 3:
+        return {}
+    raw = [float(asks_by_side[s]) / 100.0 for s in sides]
+    if any(x <= 0 for x in raw):
+        return {}
+    fn = _DEVIG_FUNCS.get(devig_method, power_devig)
+    try:
+        p = fn(raw)
+    except Exception:
+        return {}
+    return {s: p[i] for i, s in enumerate(sides)}

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -121,6 +121,9 @@ class EngineConfig:
     odds_api_key: str = ""
     sharp_weight: float = 0.7
     devig_method: str = "power"
+    # Overconfidence brake: when there is NO sharp line, pull the model prob this
+    # far toward the de-vigged Kalshi market (0 = pure model, 1 = pure market).
+    market_shrink: float = 0.4
     odds_refresh_secs: int = 3600
     odds_regions: str = "eu,uk,us"
     # Kalshi series to scan (empty = use discovery.DEFAULT_SOCCER_SERIES).
@@ -608,6 +611,9 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                 tier=config.tier, caps=_eff_caps, fee_rate=config.fee_rate,
                 edge_threshold=config.caps.edge_threshold, reserve_frac=config.reserve_frac,
                 expected_better_soon=False, w_sharp=config.sharp_weight,
+                market_shrink=config.market_shrink,
+                one_bet_per_fixture=getattr(config.caps, "one_bet_per_fixture", True),
+                devig_method=config.devig_method,
             )
             allocations, decisions = plan["allocations"], plan["decisions"]
             log(f"tick {tick}: {len(decisions)} candidate(s) evaluated → {len(allocations)} to place "

--- a/backend/kalshi/instance_config.py
+++ b/backend/kalshi/instance_config.py
@@ -130,6 +130,8 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         "devig_method": (str(raw.get("devig_method") or "power").lower()
                          if str(raw.get("devig_method") or "power").lower()
                          in ("power", "shin", "proportional") else "power"),
+        "market_shrink": min(1.0, max(0.0, float(raw.get("market_shrink", 0.4)))),
+        "one_bet_per_fixture": bool(raw.get("one_bet_per_fixture", True)),
         "odds_refresh_secs": max(300, int(raw.get("odds_refresh_secs", 3600))),
         "odds_regions": str(raw.get("odds_regions") or "eu,uk,us").strip() or "eu,uk,us",
         # Kalshi series tickers to scan ([] = engine uses DEFAULT_SOCCER_SERIES).
@@ -179,6 +181,7 @@ def risk_caps_from_config(config: dict) -> RiskCaps:
         maker_max_adverse_imbalance=float(c.get("maker_max_adverse_imbalance", -0.5)),
         cash_buffer_frac=float(c.get("cash_buffer_frac", 0.03)),
         max_concurrent_positions=int(c.get("max_concurrent_positions", 8)),
+        one_bet_per_fixture=bool(c.get("one_bet_per_fixture", True)),
     )
 
 

--- a/backend/kalshi/orchestrator.py
+++ b/backend/kalshi/orchestrator.py
@@ -10,6 +10,7 @@ from kalshi.strategy.candidates import generate_candidates
 from kalshi.capital.opportunity import score as opportunity_score
 from kalshi.capital.planner import allocate
 from kalshi.decisions import decision_doc
+from kalshi.devig import market_probs_from_asks
 
 
 def plan_and_allocate(
@@ -26,6 +27,9 @@ def plan_and_allocate(
     expected_better_soon: bool,
     w_sharp: float = 0.7,
     llm_cap: float = 0.05,
+    market_shrink: float = 0.0,
+    one_bet_per_fixture: bool = True,
+    devig_method: str = "power",
 ) -> dict:
     """fixtures: each {fixture_id, expected_goals, sharp_probs, analyst:{adjustments,
     rationales}, kalshi_markets, liquidity, hours_to_kickoff, model_confidence}.
@@ -49,6 +53,23 @@ def plan_and_allocate(
         player_probs = fx.get("player_probs")
         fused = build_market_probs(eg, sharp, adjustments, player_probs=player_probs, w_sharp=w_sharp, llm_cap=llm_cap)
         model_only = build_market_probs(eg, {}, {}, player_probs=player_probs, w_sharp=w_sharp, llm_cap=llm_cap)
+        # MARKET ANCHOR: with no sharp line, pull the (overconfident) model toward the
+        # de-vigged Kalshi market so edge = a SHRUNK model-vs-market disagreement, not
+        # the model's blind view. Only fires when there is no sharp anchor already.
+        if not sharp and market_shrink > 0.0:
+            win_asks = {
+                m["side"]: m["yes_ask_cents"]
+                for m in fx.get("kalshi_markets", [])
+                if m.get("market_type") == "winner" and (m.get("yes_ask_cents") or 0) > 0
+            }
+            market = market_probs_from_asks(win_asks, devig_method)
+            if market and "winner" in fused:
+                for side in list(fused["winner"]):
+                    if side in market:
+                        fused["winner"][side] = (
+                            (1.0 - market_shrink) * fused["winner"][side]
+                            + market_shrink * market[side]
+                        )
         cands, skips = generate_candidates(
             fx["fixture_id"], tier, fused, fx.get("kalshi_markets", []),
             fee_rate=fee_rate, edge_threshold=edge_threshold,
@@ -59,6 +80,10 @@ def plan_and_allocate(
             no_sharp_edge_threshold=getattr(caps, "no_sharp_edge_threshold", 0.0),
             collect_skips=True,
         )
+        # PER-FIXTURE LOCK: never hold more than one side of the same match — keep
+        # only the single highest-edge candidate (no correlated both-sides exposure).
+        if one_bet_per_fixture and len(cands) > 1:
+            cands = sorted(cands, key=lambda c: c.edge, reverse=True)[:1]
         for s in skips:
             # Log what the bot evaluated and why it passed. Stable id (no ts) upserts
             # to ONE row per market = its latest evaluation -> the decision log shows

--- a/backend/kalshi/risk.py
+++ b/backend/kalshi/risk.py
@@ -51,6 +51,7 @@ class RiskCaps:
     maker_max_adverse_imbalance: float = -0.5  # skip a maker buy when asks stack this heavily
     cash_buffer_frac: float = 0.03          # keep this fraction of cash unspent (pre-trade balance gate)
     max_concurrent_positions: int = 8       # cap on number of open positions at once (live path)
+    one_bet_per_fixture: bool = True        # never hold >1 side of the same match
 
 
 def size_order(*, edge: float, yes_ask_cents: float, caps: RiskCaps) -> int:

--- a/backend/kalshi/runner.py
+++ b/backend/kalshi/runner.py
@@ -117,6 +117,7 @@ def main(argv: list[str] | None = None) -> int:
                           or __import__("os").environ.get("ODDS_API_KEY", "").strip()),
             sharp_weight=float(cfg.get("sharp_weight", 0.7)),
             devig_method=str(cfg.get("devig_method", "power")),
+            market_shrink=float(cfg.get("market_shrink", 0.4)),
             odds_refresh_secs=int(cfg.get("odds_refresh_secs", 3600)),
             odds_regions=str(cfg.get("odds_regions", "eu,uk,us")),
             soccer_series=list(cfg.get("soccer_series") or []),

--- a/backend/tests/test_kalshi_orchestrator.py
+++ b/backend/tests/test_kalshi_orchestrator.py
@@ -50,3 +50,115 @@ def test_no_edge_yields_no_placed_decisions():
         fee_rate=0.07, edge_threshold=0.05, reserve_frac=0.0, expected_better_soon=False,
     )
     assert all(d["decision"] != "placed" for d in out["decisions"])
+
+
+def _fixture_3way(fid, home_xg, away_xg, asks, sharp=None):
+    """A fixture with a full 3-way `winner` market (home/draw/away asks in
+    cents) — used for the market-anchor tests."""
+    return {
+        "fixture_id": fid,
+        "expected_goals": (home_xg, away_xg),
+        "sharp_probs": {"winner": sharp} if sharp else {},
+        "analyst": {"adjustments": {}, "rationales": {}},
+        "kalshi_markets": [
+            {"market_ticker": f"{fid}-{side.upper()}", "market_type": "winner",
+             "side": side, "yes_ask_cents": price}
+            for side, price in asks.items()
+        ],
+        "liquidity": 800,
+        "hours_to_kickoff": 6,
+        "model_confidence": 0.7,
+    }
+
+
+def _decision_for(out, market_ticker):
+    for d in out["decisions"]:
+        if d["market_ticker"] == market_ticker:
+            return d
+    raise AssertionError(f"no decision for {market_ticker}")
+
+
+def test_market_shrink_pulls_fused_fair_toward_market_when_no_sharp():
+    # Strong home favorite per the model; the market (near-even asks) disagrees.
+    asks = {"home": 34, "draw": 34, "away": 34}
+    fixtures_noshrink = [_fixture_3way("f1", 2.5, 0.3, asks)]
+    fixtures_shrink = [_fixture_3way("f1", 2.5, 0.3, asks)]
+
+    out_noshrink = plan_and_allocate(
+        fixtures_noshrink, instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+        fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0, expected_better_soon=False,
+        market_shrink=0.0,
+    )
+    out_shrink = plan_and_allocate(
+        fixtures_shrink, instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+        fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0, expected_better_soon=False,
+        market_shrink=0.5,
+    )
+    fair_noshrink = _decision_for(out_noshrink, "f1-HOME")["fused_fair"]
+    fair_shrink = _decision_for(out_shrink, "f1-HOME")["fused_fair"]
+
+    # De-vigged near-even asks put the market's "home" prob near 1/3 — well below
+    # the model's strong-favorite fair. Shrinking toward the market must pull the
+    # fused fair DOWN (toward the market), not leave it unchanged.
+    assert fair_shrink < fair_noshrink
+
+
+def test_market_shrink_is_a_noop_when_sharp_present():
+    asks = {"home": 34, "draw": 34, "away": 34}
+    sharp = {"home": 0.62, "draw": 0.23, "away": 0.15}
+    fixtures_noshrink = [_fixture_3way("f1", 2.5, 0.3, asks, sharp=sharp)]
+    fixtures_shrink = [_fixture_3way("f1", 2.5, 0.3, asks, sharp=sharp)]
+
+    out_noshrink = plan_and_allocate(
+        fixtures_noshrink, instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+        fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0, expected_better_soon=False,
+        market_shrink=0.0,
+    )
+    out_shrink = plan_and_allocate(
+        fixtures_shrink, instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+        fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0, expected_better_soon=False,
+        market_shrink=0.5,
+    )
+    fair_noshrink = _decision_for(out_noshrink, "f1-HOME")["fused_fair"]
+    fair_shrink = _decision_for(out_shrink, "f1-HOME")["fused_fair"]
+
+    # The anchor only fires when there is NO sharp line — with a sharp line
+    # present, market_shrink must not move the fused fair at all.
+    assert fair_shrink == fair_noshrink
+
+
+def test_one_bet_per_fixture_caps_placed_candidates():
+    # Strong home favorite -> both `winner:home` and `double_chance:home_draw`
+    # clear the edge bar at these prices, and they are DIFFERENT market types so
+    # generate_candidates' own mutual-exclusion (per-type) doesn't collapse them.
+    fixture = {
+        "fixture_id": "f1",
+        "expected_goals": (2.5, 0.3),
+        "sharp_probs": {},
+        "analyst": {"adjustments": {}, "rationales": {}},
+        "kalshi_markets": [
+            {"market_ticker": "f1-HOME", "market_type": "winner", "side": "home", "yes_ask_cents": 30},
+            {"market_ticker": "f1-HOMEDRAW", "market_type": "double_chance", "side": "home_draw", "yes_ask_cents": 50},
+        ],
+        "liquidity": 800,
+        "hours_to_kickoff": 6,
+        "model_confidence": 0.7,
+    }
+    caps = RiskCaps(max_contracts_per_market=50, bankroll_cents=1000000,
+                    edge_threshold=0.03, max_open_exposure_frac=0.9, per_league_cap_frac=0.9)
+
+    out_capped = plan_and_allocate(
+        [dict(fixture)], instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=caps,
+        fee_rate=0.07, edge_threshold=0.03, reserve_frac=0.0, expected_better_soon=False,
+        one_bet_per_fixture=True,
+    )
+    out_uncapped = plan_and_allocate(
+        [dict(fixture)], instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=caps,
+        fee_rate=0.07, edge_threshold=0.03, reserve_frac=0.0, expected_better_soon=False,
+        one_bet_per_fixture=False,
+    )
+    placed_capped = [d for d in out_capped["decisions"] if d["decision"] == "placed"]
+    placed_uncapped = [d for d in out_uncapped["decisions"] if d["decision"] == "placed"]
+
+    assert len(placed_capped) <= 1
+    assert len(placed_uncapped) == 2


### PR DESCRIPTION
Ports the two backtest-only safeguards into the live decision core so live == validated backtest: market anchor (shrink model toward de-vigged Kalshi market when no sharp) + one-bet-per-fixture. Shared de-vig helper (DRY). Wired market_shrink/one_bet_per_fixture through config. 48 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)