### PR TITLE
feat(kalshi): tuned-param + dual odds-key UI, OddsPapi fallback, in-match off by default

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4203,6 +4203,10 @@ class CreateKalshiInstanceBody(BaseModel):
     min_price_cents: Optional[int] = 15
     max_price_cents: Optional[int] = 90
     draw_min_edge: Optional[float] = 0.10
+    # Model-only guardrails (validated tuning). None on no_sharp -> tier default.
+    no_sharp_edge_threshold: Optional[float] = None   # bigger edge bar when no sharp line
+    market_shrink: Optional[float] = 0.4              # shrink model toward de-vig'd market when no sharp
+    one_bet_per_fixture: Optional[bool] = True        # never hold >1 side of a match
     # Order-size RANGE ($/trade): bot sizes within [min,max] by edge conviction.
     # None (omitted) -> the tier's suggested range; an explicit 0 stays auto (Kelly).
     order_size_min_dollars: Optional[float] = None
@@ -4213,15 +4217,17 @@ class CreateKalshiInstanceBody(BaseModel):
     bankroll_usage_pct: Optional[int] = 50
     tier: Optional[str] = "medium"
     model: Optional[str] = None          # LLM model id for the analyst panel
-    # Live in-match monitoring (two-way in-play; Kalshi-price-only).
-    live_monitoring: Optional[bool] = True
+    # Live in-match monitoring (two-way in-play; Kalshi-price-only). Defaults OFF —
+    # only the pregame strategy is backtest-validated; in-play is opt-in.
+    live_monitoring: Optional[bool] = False
     live_poll_seconds: Optional[int] = 30
     inplay_exposure_frac: Optional[float] = 0.15
     max_adds_per_match: Optional[int] = 2
     no_add_after_min: Optional[float] = 75.0
     stop_loss_frac: Optional[float] = 0.35
     # Sharp-odds anchor (fair value from de-vig'd bookmaker odds; edge vs Kalshi).
-    odds_api_key: Optional[str] = None
+    odds_api_key: Optional[str] = None        # The-Odds-API key — LIVE sharp odds
+    oddspapi_api_key: Optional[str] = None    # OddsPapi key — backtest historical odds
     sharp_weight: Optional[float] = 0.85
     devig_method: Optional[str] = "power"
     odds_refresh_secs: Optional[int] = 3600

--- a/backend/kalshi/data/sources/oddspapi_live.py
+++ b/backend/kalshi/data/sources/oddspapi_live.py
@@ -1,0 +1,54 @@
+"""OddsPapi as a FALLBACK live sharp source.
+
+The primary live sharp source is The-Odds-API (`data.sources.odds_api`). When it
+returns no data for the current slate (no key, monthly quota exhausted, or the
+service is down) and an OddsPapi key is configured, the engine falls back here.
+
+Events are returned in the SAME normalized shape as `odds_api.parse_events`
+(`{home, away, commence_time, books: {bookkey: {home, draw, away}}}`, decimal
+odds) so `odds_api.match_event` / `quote_for_event` consume them unchanged.
+Never raises; returns [] on any failure so the caller degrades to model-only.
+"""
+from __future__ import annotations
+
+_SOCCER_SPORT_ID = 10
+
+
+def fetch_events(oddspapi_key: str, date_from: str, date_to: str, *,
+                 client=None, sport_id: int = _SOCCER_SPORT_ID) -> list:
+    """Current OddsPapi soccer fixtures with a 3-way price in [date_from, date_to]
+    (YYYY-MM-DD), normalized to odds_api's event shape. The latest historical-odds
+    snapshot per fixture is used as the current line."""
+    if not oddspapi_key:
+        return []
+    if client is None:
+        from kalshi.ingest_odds import OddsPapiClient
+        client = OddsPapiClient(oddspapi_key)
+    try:
+        fixtures = client.list_fixtures(sport_id, date_from, date_to)
+    except Exception:
+        return []
+    out = []
+    for fx in fixtures or []:
+        if not fx.get("has_odds"):
+            continue
+        fid = fx.get("fixture_id")
+        if not fid:
+            continue
+        try:
+            snaps = client.historical_odds(fid)
+        except Exception:
+            continue
+        if not snaps:
+            continue
+        last = snaps[-1]  # snapshots are ascending by ts -> latest ≈ current line
+        try:
+            book = {"home": float(last["home"]), "draw": float(last["draw"]),
+                    "away": float(last["away"])}
+        except (KeyError, TypeError, ValueError):
+            continue
+        if any(v <= 1.0 for v in book.values()):  # decimal odds must be > 1.0
+            continue
+        out.append({"home": fx.get("home", ""), "away": fx.get("away", ""),
+                    "commence_time": "", "books": {"oddspapi": book}})
+    return out

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -118,7 +118,8 @@ class EngineConfig:
     inplay_caps: InPlayCaps = field(default_factory=InPlayCaps)
     analyst_max_calls: int = 10   # cap on LLM analyst calls per tick (cost control)
     # Sharp-odds anchor: fair value from de-vig'd bookmaker odds -> edge vs Kalshi.
-    odds_api_key: str = ""
+    odds_api_key: str = ""          # The-Odds-API — primary LIVE sharp source
+    oddspapi_api_key: str = ""      # OddsPapi — fallback LIVE sharp source
     sharp_weight: float = 0.7
     devig_method: str = "power"
     # Overconfidence brake: when there is NO sharp line, pull the model prob this
@@ -384,6 +385,22 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                         pass
                     log(f"tick {tick}: sharp odds — fetched {len(evs)} events for {sk}"
                         + (f" (quota left {quota})" if quota is not None else "") + ".", "white")
+
+            # Fallback: if The-Odds-API produced nothing (no key / quota / outage) and
+            # an OddsPapi key is configured, try OddsPapi as a secondary sharp source so
+            # a single feed dropping out doesn't force the whole slate to model-only.
+            if not all_events and getattr(config, "oddspapi_api_key", ""):
+                try:
+                    import datetime as _dt
+                    from kalshi.data.sources import oddspapi_live
+                    _d0 = _dt.datetime.utcfromtimestamp(now_wall)
+                    _df = (_d0 - _dt.timedelta(days=1)).strftime("%Y-%m-%d")
+                    _dto = (_d0 + _dt.timedelta(days=3)).strftime("%Y-%m-%d")
+                    all_events = oddspapi_live.fetch_events(config.oddspapi_api_key, _df, _dto)
+                    log(f"tick {tick}: sharp odds — The-Odds-API empty; OddsPapi fallback "
+                        f"returned {len(all_events)} event(s).", "cyan" if all_events else "yellow")
+                except Exception as e:
+                    log(f"tick {tick}: OddsPapi fallback failed: {type(e).__name__}: {e}", "yellow")
 
             # 2c) Live scores/clock (ESPN) — TIMING ONLY (not pricing): gives the true
             # in-play minute so the live monitor knows a match is actually live and can

--- a/backend/kalshi/instance_config.py
+++ b/backend/kalshi/instance_config.py
@@ -84,7 +84,8 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         # No-sharp-line gate: model-only fairs overrate favorites, so demand a bigger
         # edge before betting a market the sharp book doesn't price (keeps volume on
         # genuinely large disagreements rather than hard-skipping).
-        "no_sharp_edge_threshold": float(raw.get("no_sharp_edge_threshold", td["no_sharp_edge_threshold"])),
+        "no_sharp_edge_threshold": (float(_nse) if (_nse := raw.get("no_sharp_edge_threshold")) is not None
+                                    else td["no_sharp_edge_threshold"]),
         # Size haircut for model-only (no-sharp) bets — they're unanchored favorite
         # risk, so bet them smaller than sharp-anchored ones.
         "model_only_size_mult": float(raw.get("model_only_size_mult", td["model_only_size_mult"])),
@@ -113,8 +114,10 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         # HARD dry-run gate: when True the engine reads real prices but places NO real
         # orders (paper-fill grading). Lets a FUNDED live account be tested safely.
         "paper_mode": bool(raw.get("paper_mode", False)),
-        # Live in-match monitoring (Kalshi-price-only, two-way in-play).
-        "live_monitoring": bool(raw.get("live_monitoring", True)),
+        # Live in-match monitoring (Kalshi-price-only, two-way in-play). Defaults
+        # OFF: only the pregame strategy is backtest-validated; in-play is a separate,
+        # unvalidated path. Opt in explicitly if you want in-match trading.
+        "live_monitoring": bool(raw.get("live_monitoring", False)),
         "live_poll_seconds": max(10, int(raw.get("live_poll_seconds", 30))),
         "analyst_max_calls": max(0, int(raw.get("analyst_max_calls", 10))),
         "inplay_exposure_frac": float(raw.get("inplay_exposure_frac", td["inplay_exposure_frac"])),
@@ -130,8 +133,8 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         "devig_method": (str(raw.get("devig_method") or "power").lower()
                          if str(raw.get("devig_method") or "power").lower()
                          in ("power", "shin", "proportional") else "power"),
-        "market_shrink": min(1.0, max(0.0, float(raw.get("market_shrink", 0.4)))),
-        "one_bet_per_fixture": bool(raw.get("one_bet_per_fixture", True)),
+        "market_shrink": (min(1.0, max(0.0, float(_msh))) if (_msh := raw.get("market_shrink")) is not None else 0.4),
+        "one_bet_per_fixture": (bool(_obf) if (_obf := raw.get("one_bet_per_fixture")) is not None else True),
         "odds_refresh_secs": max(300, int(raw.get("odds_refresh_secs", 3600))),
         "odds_regions": str(raw.get("odds_regions") or "eu,uk,us").strip() or "eu,uk,us",
         # Kalshi series tickers to scan ([] = engine uses DEFAULT_SOCCER_SERIES).

--- a/backend/kalshi/runner.py
+++ b/backend/kalshi/runner.py
@@ -115,6 +115,8 @@ def main(argv: list[str] | None = None) -> int:
             analyst_max_calls=int(cfg.get("analyst_max_calls", 10)),
             odds_api_key=(str(cfg.get("odds_api_key") or "").strip()
                           or __import__("os").environ.get("ODDS_API_KEY", "").strip()),
+            oddspapi_api_key=(str(cfg.get("oddspapi_api_key") or "").strip()
+                              or __import__("os").environ.get("ODDSPAPI_API_KEY", "").strip()),
             sharp_weight=float(cfg.get("sharp_weight", 0.7)),
             devig_method=str(cfg.get("devig_method", "power")),
             market_shrink=float(cfg.get("market_shrink", 0.4)),

--- a/backend/tests/test_kalshi_oddspapi_live.py
+++ b/backend/tests/test_kalshi_oddspapi_live.py
@@ -1,0 +1,61 @@
+"""OddsPapi fallback live-sharp adapter: normalizes to odds_api's event shape
+and degrades safely. Uses a fake client (no network)."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi.data.sources import oddspapi_live, odds_api
+
+
+class FakeOddsPapiClient:
+    def __init__(self, fixtures, snaps_by_id):
+        self._fixtures = fixtures
+        self._snaps = snaps_by_id
+        self.calls = []
+
+    def list_fixtures(self, sport_id, date_from, date_to):
+        self.calls.append(("list", sport_id, date_from, date_to))
+        return self._fixtures
+
+    def historical_odds(self, fixture_id):
+        return self._snaps.get(fixture_id, [])
+
+
+def test_fetch_events_normalizes_priced_fixtures():
+    client = FakeOddsPapiClient(
+        fixtures=[
+            {"fixture_id": "f1", "home": "Spain", "away": "Austria", "has_odds": True},
+            {"fixture_id": "f2", "home": "Brazil", "away": "Norway", "has_odds": False},  # no odds -> skip
+        ],
+        snaps_by_id={"f1": [
+            {"ts": 1, "home": 1.5, "draw": 4.0, "away": 7.0},
+            {"ts": 2, "home": 1.6, "draw": 3.9, "away": 6.5},  # latest snapshot is used
+        ]},
+    )
+    evs = oddspapi_live.fetch_events("k", "2026-06-01", "2026-06-05", client=client)
+    assert len(evs) == 1
+    ev = evs[0]
+    assert ev["home"] == "Spain" and ev["away"] == "Austria"
+    assert ev["books"]["oddspapi"] == {"home": 1.6, "draw": 3.9, "away": 6.5}
+    # The normalized event must be consumable by the existing sharp path.
+    q = odds_api.quote_for_event(ev)
+    assert q is not None and q.home == 1.6
+
+
+def test_empty_key_returns_empty():
+    assert oddspapi_live.fetch_events("", "2026-06-01", "2026-06-05") == []
+
+
+def test_no_odds_or_no_snaps_degrades_to_empty():
+    client = FakeOddsPapiClient(
+        fixtures=[{"fixture_id": "f1", "home": "A", "away": "B", "has_odds": True}],
+        snaps_by_id={},  # priced flag but no snapshots
+    )
+    assert oddspapi_live.fetch_events("k", "2026-06-01", "2026-06-05", client=client) == []
+
+
+def test_invalid_decimal_odds_skipped():
+    client = FakeOddsPapiClient(
+        fixtures=[{"fixture_id": "f1", "home": "A", "away": "B", "has_odds": True}],
+        snaps_by_id={"f1": [{"ts": 1, "home": 1.0, "draw": 3.0, "away": 5.0}]},  # 1.0 <= 1.0 invalid
+    )
+    assert oddspapi_live.fetch_events("k", "2026-06-01", "2026-06-05", client=client) == []

--- a/frontend/src/components/kalshi/KalshiCreateInstanceModal.vue
+++ b/frontend/src/components/kalshi/KalshiCreateInstanceModal.vue
@@ -58,9 +58,13 @@ const dailyLoss = ref(0)
 const dailyLossTouched = ref(false)
 const dailyLossPct = ref(0.08)
 const poll = ref(60)
-const liveMonitoring = ref(true)
+const liveMonitoring = ref(false)
 const oddsApiKey = ref('')
+const oddspapiKey = ref('')
 const sharpWeight = ref(85)
+const noSharp = ref(5)
+const marketShrink = ref(40)
+const oneBetPerFixture = ref(true)
 // Price band + draw gate (favorite-longshot guard) — tunable; 15/90/10 are the safe defaults.
 const minPrice = ref(15)
 const maxPrice = ref(90)
@@ -152,10 +156,14 @@ function prefillFromEdit() {
   if (c.poll_seconds != null) poll.value = c.poll_seconds
   if (c.live_monitoring != null) liveMonitoring.value = !!c.live_monitoring
   if (c.odds_api_key) oddsApiKey.value = c.odds_api_key
+  if (c.oddspapi_api_key) oddspapiKey.value = c.oddspapi_api_key
   if (c.sharp_weight != null) sharpWeight.value = Math.round(c.sharp_weight * 100)
   if (c.min_price_cents != null) minPrice.value = c.min_price_cents
   if (c.max_price_cents != null) maxPrice.value = c.max_price_cents
   if (c.draw_min_edge != null) drawMinEdge.value = Math.round(c.draw_min_edge * 1000) / 10
+  if (c.no_sharp_edge_threshold != null) noSharp.value = c.no_sharp_edge_threshold * 100
+  if (c.market_shrink != null) marketShrink.value = c.market_shrink * 100
+  if (c.one_bet_per_fixture != null) oneBetPerFixture.value = !!c.one_bet_per_fixture
   if (c.tier) risk.value = c.tier
   if (c.model) selectedModel.value = c.model
   if (c.paper_mode != null) paperMode.value = !!c.paper_mode
@@ -195,11 +203,15 @@ async function submit() {
       poll_seconds: Number(poll.value),
       bankroll_usage_pct: Number(usagePct.value),
       live_monitoring: liveMonitoring.value,
-      odds_api_key: oddsApiKey.value.trim(),
+      odds_api_key: oddsApiKey.value.trim() || undefined,
+      oddspapi_api_key: oddspapiKey.value.trim() || undefined,
       sharp_weight: Number(sharpWeight.value) / 100,
       min_price_cents: Number(minPrice.value),
       max_price_cents: Number(maxPrice.value),
       draw_min_edge: Number(drawMinEdge.value) / 100,
+      no_sharp_edge_threshold: Number(noSharp.value) / 100,
+      market_shrink: Number(marketShrink.value) / 100,
+      one_bet_per_fixture: oneBetPerFixture.value,
       order_size_min_dollars: Number(orderSizeMin.value) || 0,
       order_size_max_dollars: Number(orderSizeMax.value) || 0,
       tier: risk.value,
@@ -374,6 +386,14 @@ function fmt(n) { return `$${Number(n).toLocaleString(undefined, { maximumFracti
             <span class="flex items-center gap-1 text-xs font-medium text-slate-400 mb-1.5">Scan cadence (s) <InfoTip text="How often it polls odds, respecting the OddsPapi monthly budget." size="13px" /></span>
             <input v-model.number="poll" type="number" step="15" class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary" />
           </label>
+          <label class="block">
+            <span class="flex items-center gap-1 text-xs font-medium text-slate-400 mb-1.5">No-sharp edge bar (%) <InfoTip text="Higher edge required to bet a market with no sharp odds (model-only)." size="13px" /></span>
+            <input v-model.number="noSharp" type="number" step="1" class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary" />
+          </label>
+          <label class="block">
+            <span class="flex items-center gap-1 text-xs font-medium text-slate-400 mb-1.5">Market anchor (%) <InfoTip text="When there's no sharp line, shrink the model this far toward the de-vigged Kalshi market." size="13px" /></span>
+            <input v-model.number="marketShrink" type="number" step="5" class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary" />
+          </label>
           <label class="block col-span-2">
             <span class="flex items-center gap-1 text-xs font-medium text-slate-400 mb-1.5">Order size ($ / trade) <InfoTip text="Target dollar size per trade as a RANGE — the bot sizes within it by edge conviction (stronger edge → bigger trade), so trades stay meaningful even on a small account. Leave both 0 for auto (Kelly-sized)." size="13px" /></span>
             <div class="flex items-center gap-2">
@@ -400,11 +420,29 @@ function fmt(n) { return `$${Number(n).toLocaleString(undefined, { maximumFracti
           </span>
         </button>
 
+        <button type="button" @click="oneBetPerFixture = !oneBetPerFixture"
+                class="w-full flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface/50 px-3 py-2.5 text-left hover:border-primary/50 transition-colors">
+          <span class="min-w-0">
+            <span class="flex items-center gap-1 text-sm font-medium text-slate-200">One bet per fixture
+              <InfoTip text="Never hold more than one side of the same match." size="13px" /></span>
+            <span class="block text-[11px] text-slate-500 mt-0.5">Limit to a single open position per match</span>
+          </span>
+          <span class="shrink-0 w-10 h-6 rounded-full transition-colors relative" :class="oneBetPerFixture ? 'bg-primary' : 'bg-border-subtle'">
+            <span class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform" :class="oneBetPerFixture ? 'translate-x-4' : ''"></span>
+          </span>
+        </button>
+
         <div class="rounded-lg border border-border-subtle bg-surface/50 px-3 py-3 space-y-3">
           <label class="block">
-            <span class="flex items-center gap-1 text-sm font-medium text-slate-200 mb-1.5">Odds API key — sharp anchor
-              <InfoTip text="Anchor fair value to de-vig'd sharp bookmaker odds (The-Odds-API) so the bot bets where Kalshi disagrees with the books — the real edge. Free key at the-odds-api.com. Leave blank to price on the model only (rarely trades on efficient markets)." size="13px" /></span>
+            <span class="flex items-center gap-1 text-sm font-medium text-slate-200 mb-1.5">The-Odds-API key (live sharp odds)
+              <InfoTip text="Live bookmaker odds for the sharp anchor, e.g. Pinnacle via the-odds-api.com." size="13px" /></span>
             <input v-model="oddsApiKey" type="password" autocomplete="off" placeholder="the-odds-api.com key (optional)"
+                   class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary" />
+          </label>
+          <label class="block">
+            <span class="flex items-center gap-1 text-sm font-medium text-slate-200 mb-1.5">OddsPapi key (backtest odds)
+              <InfoTip text="Historical odds source used by backtests, from oddspapi.io. Optional; live trading uses the The-Odds-API key above." size="13px" /></span>
+            <input v-model="oddspapiKey" type="password" autocomplete="off" placeholder="oddspapi.io key (optional)"
                    class="w-full bg-surface border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-slate-100 focus:outline-none focus:border-primary" />
           </label>
           <label class="block">

--- a/mobile/lib/features/kalshi/presentation/kalshi_screen.dart
+++ b/mobile/lib/features/kalshi/presentation/kalshi_screen.dart
@@ -420,6 +420,9 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
   final _poll = TextEditingController(text: '60');
   final _manualBankroll = TextEditingController(text: '1000');
   final _oddsKey = TextEditingController();
+  final _oddspapiKey = TextEditingController();
+  final _noSharpEdge = TextEditingController(text: '5');
+  final _marketShrink = TextEditingController(text: '40');
   double _sharpWeight = 85;
   final Set<String> _leagues = {'EPL', 'Serie B', 'Ligue 2'};
   double _usagePct = 50;
@@ -428,10 +431,13 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
   bool _dailyLossTouched = false;
   double _dailyLossPct = 0.10;
   String _risk = 'medium';
-  bool _liveMonitoring = true;
+  // Off by default for a NEW instance — only the pregame strategy is validated;
+  // in-match live monitoring is opt-in. An edit still reflects the stored value (see _prefill).
+  bool _liveMonitoring = false;
   // HARD dry-run: read real prices, place NO real orders. Safe default for a funded
   // live account; toggle OFF to place REAL orders.
   bool _paperMode = true;
+  bool _oneBetPerFixture = true;
   List<Map<String, dynamic>> _models = [];
   String? _selectedModel;
   bool _creating = false;
@@ -465,12 +471,16 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
     if (n('poll_seconds') != null) _poll.text = _num(n('poll_seconds')!);
     if (n('bankroll_cents') != null) _manualBankroll.text = _num(n('bankroll_cents')! / 100);
     if (c['odds_api_key'] != null) _oddsKey.text = c['odds_api_key'].toString();
+    if (c['oddspapi_api_key'] != null) _oddspapiKey.text = c['oddspapi_api_key'].toString();
+    if (n('no_sharp_edge_threshold') != null) _noSharpEdge.text = _num(n('no_sharp_edge_threshold')! * 100);
+    if (n('market_shrink') != null) _marketShrink.text = _num(n('market_shrink')! * 100);
     if (n('sharp_weight') != null) _sharpWeight = (n('sharp_weight')! * 100).toDouble();
     if (n('bankroll_usage_pct') != null) _usagePct = n('bankroll_usage_pct')!.toDouble();
     if (c['tier'] != null) _risk = c['tier'].toString();
     if (c['model'] != null) _selectedModel = c['model'].toString();
     if (c['live_monitoring'] != null) _liveMonitoring = c['live_monitoring'] == true;
     if (c['paper_mode'] != null) _paperMode = c['paper_mode'] == true;
+    if (c['one_bet_per_fixture'] != null) _oneBetPerFixture = c['one_bet_per_fixture'] == true;
     final lg = c['leagues'];
     if (lg is List && lg.isNotEmpty) { _leagues..clear()..addAll(lg.map((e) => e.toString())); }
   }
@@ -484,7 +494,7 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
 
   @override
   void dispose() {
-    for (final c in [_name, _edge, _kelly, _maxContracts, _exposure, _leagueCap, _dailyLoss, _poll, _manualBankroll, _minPrice, _maxPrice, _drawMinEdge, _orderSizeMin, _orderSizeMax]) {
+    for (final c in [_name, _edge, _kelly, _maxContracts, _exposure, _leagueCap, _dailyLoss, _poll, _manualBankroll, _minPrice, _maxPrice, _drawMinEdge, _orderSizeMin, _orderSizeMax, _oddspapiKey, _noSharpEdge, _marketShrink]) {
       c.dispose();
     }
     super.dispose();
@@ -562,11 +572,15 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
         'poll_seconds': _i(_poll, 60),
         'bankroll_usage_pct': _usagePct.round(),
         'live_monitoring': _liveMonitoring,
-        'odds_api_key': _oddsKey.text.trim(),
+        if (_oddsKey.text.trim().isNotEmpty) 'odds_api_key': _oddsKey.text.trim(),
         'sharp_weight': _sharpWeight / 100,
         'tier': _risk,
         'model': _selectedModel,
         'paper_mode': _paperMode,   // dry-run by default; backend forces paper on live brokerages unless off
+        'no_sharp_edge_threshold': _d(_noSharpEdge, 5) / 100,
+        'market_shrink': _d(_marketShrink, 40) / 100,
+        'one_bet_per_fixture': _oneBetPerFixture,
+        if (_oddspapiKey.text.trim().isNotEmpty) 'oddspapi_api_key': _oddspapiKey.text.trim(),
       };
       final repo = ref.read(kalshiRepositoryProvider);
       if (_isEdit) {
@@ -721,10 +735,26 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
                   ),
                   const SizedBox(height: 12),
 
+                  // One bet per fixture
+                  Container(
+                    decoration: BoxDecoration(color: AppColors.surface, borderRadius: BorderRadius.circular(10), border: Border.all(color: AppColors.border)),
+                    child: SwitchListTile(
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                      activeColor: AppColors.primary,
+                      value: _oneBetPerFixture,
+                      onChanged: (v) => setState(() => _oneBetPerFixture = v),
+                      title: Text('One bet per fixture', style: AppTextStyles.body.copyWith(color: AppColors.textHi)),
+                      subtitle: Text('Only take one open position per match at a time.', style: AppTextStyles.nano.copyWith(color: AppColors.textDim)),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+
                   // Sharp-odds anchor
                   _label('Odds API key — sharp anchor',
                       'Anchor fair value to de-vig\'d sharp bookmaker odds (the-odds-api.com) so it bets where Kalshi disagrees with the books. Free key. Blank = model-only (rarely trades).'),
-                  _field(_oddsKey, 'Odds API key', hint: 'the-odds-api.com key (optional)', obscure: true),
+                  _field(_oddsKey, 'The-Odds-API key (live sharp odds)', hint: 'the-odds-api.com key (optional)', obscure: true),
+                  _label('OddsPapi key', 'Used for backtest odds only, not live trading.'),
+                  _field(_oddspapiKey, 'OddsPapi key (backtest odds)', hint: 'oddspapi.io key (optional)', obscure: true),
                   Padding(
                     padding: const EdgeInsets.only(top: 4, bottom: 12),
                     child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
@@ -808,6 +838,11 @@ class _KalshiInstanceSheetState extends ConsumerState<KalshiInstanceSheet> {
                     Expanded(child: _field(_orderSizeMin, 'Order size min (\$)', number: true)),
                     const SizedBox(width: 12),
                     Expanded(child: _field(_orderSizeMax, 'Order size max (\$)', number: true)),
+                  ]),
+                  Row(children: [
+                    Expanded(child: _field(_noSharpEdge, 'No-sharp edge bar (%)', number: true)),
+                    const SizedBox(width: 12),
+                    Expanded(child: _field(_marketShrink, 'Market anchor (%)', number: true)),
                   ]),
                   TextField(
                     controller: _dailyLoss,


### PR DESCRIPTION
Surfaces no_sharp/market_shrink/one_bet_per_fixture + both odds keys (The-Odds-API live, OddsPapi backtest) in web+mobile create/edit. Live in-match trading defaults OFF (pregame-only validated). New OddsPapi live-fallback adapter + engine wiring. The-Odds-API key confirmed valid (prices WC via Pinnacle). Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)