### PR TITLE
fix(telemetry): record OpenRouter LLM usage — Nemotron calls were invisible to Token Usage

### DIFF
--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -4586,6 +4586,9 @@ def _call_openrouter(
     if not api_key:
         return ""
     _t0 = time.monotonic()
+    # Pre-bind so the outer except can report the true attempt count even if
+    # the failure happens before (or on the first pass of) the retry loop.
+    attempt = 0
     try:
         import requests as _requests
         url = (base_url or "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions"
@@ -4690,6 +4693,15 @@ def _call_openrouter(
                 if attempt < max_retries:
                     time.sleep(_backoff_sleep_seconds(attempt))
                     continue
+                # Terminal HTTP-200 with no choices: still record (with any
+                # parsed usage/cost — OpenRouter may have billed the attempt)
+                # so truncated/empty completions stay visible in telemetry.
+                _safe_record(
+                    provider="openrouter", model=model, usage=_or_usage, ok=False,
+                    duration_ms=int((time.monotonic() - _t0) * 1000),
+                    retry_count=attempt, error="no choices",
+                    cost_usd_override=_or_cost, model_id=None,
+                )
                 return ""
             message = choices[0].get("message") or {}
             text = _extract_chat_message_text(message)
@@ -4708,6 +4720,14 @@ def _call_openrouter(
             if attempt < max_retries:
                 time.sleep(_backoff_sleep_seconds(attempt))
                 continue
+            # Terminal HTTP-200 with an empty completion after retries —
+            # same rationale as the no-choices case above.
+            _safe_record(
+                provider="openrouter", model=model, usage=_or_usage, ok=False,
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                retry_count=attempt, error="empty response",
+                cost_usd_override=_or_cost, model_id=None,
+            )
             return ""
         return ""
     except Exception as _exc:
@@ -4716,7 +4736,7 @@ def _call_openrouter(
             _safe_record(
                 provider="openrouter", model=model, usage={}, ok=False,
                 duration_ms=int((time.monotonic() - _t0) * 1000),
-                retry_count=int(retries or 0), error=str(_exc)[:200],
+                retry_count=attempt, error=str(_exc)[:200],
                 model_id=None,
             )
         except Exception:

--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -3126,6 +3126,48 @@ def _log_token_usage(provider: str, model: str, data: dict) -> None:
         pass
 
 
+def _extract_openrouter_usage(usage: Any) -> tuple[dict[str, int], float | None]:
+    """Normalize an OpenRouter ``/chat/completions`` usage block into the
+    telemetry token dict plus an optional OpenRouter-reported USD cost.
+
+    Returns ``(usage_dict, cost_usd_override_or_None)``. OpenRouter returns
+    ``usage.cost`` (credits == USD) when the request opts in with
+    ``usage: {"include": true}``; we surface it as an envelope cost override so
+    it wins over the pricing YAML / Models-row estimate. When absent or
+    non-positive we return ``None`` so the caller falls back to registry
+    pricing — but the token counts are ALWAYS returned so the row is never
+    dropped.
+    """
+    if not isinstance(usage, dict):
+        return {}, None
+    try:
+        inp = int(usage.get("prompt_tokens") or 0)
+    except (TypeError, ValueError):
+        inp = 0
+    try:
+        out = int(usage.get("completion_tokens") or 0)
+    except (TypeError, ValueError):
+        out = 0
+    reasoning = 0
+    details = usage.get("completion_tokens_details")
+    if isinstance(details, dict):
+        try:
+            reasoning = int(details.get("reasoning_tokens") or 0)
+        except (TypeError, ValueError):
+            reasoning = 0
+    u: dict[str, int] = {"input_tokens": inp, "output_tokens": out}
+    if reasoning:
+        u["reasoning_tokens"] = reasoning
+    cost_override: float | None = None
+    _cost = usage.get("cost")
+    try:
+        if _cost is not None and float(_cost) > 0:
+            cost_override = float(_cost)
+    except (TypeError, ValueError):
+        cost_override = None
+    return u, cost_override
+
+
 def _call_gemini(
     api_key: str,
     model: str,
@@ -4533,9 +4575,17 @@ def _call_openrouter(
 ) -> str:
     """Call OpenRouter (OpenAI-compatible /chat/completions). Structural clone of
     _call_nvidia without NVIDIA's RPM limiter, plus optional attribution headers
-    (HTTP-Referer / X-Title) and reasoning-effort passthrough."""
+    (HTTP-Referer / X-Title) and reasoning-effort passthrough.
+
+    Records one telemetry row per call (success or terminal failure) via
+    ``_safe_record`` — OpenRouter is otherwise invisible in LLMUsage because,
+    unlike every other provider path, it has no self-recording. Cost prefers
+    OpenRouter's own ``usage.cost`` (requested below via ``usage.include``),
+    then falls through to the pricing registry / Models-row override inside
+    ``record_llm_call``, then zero — but the row is never dropped."""
     if not api_key:
         return ""
+    _t0 = time.monotonic()
     try:
         import requests as _requests
         url = (base_url or "https://openrouter.ai/api/v1").rstrip("/") + "/chat/completions"
@@ -4548,6 +4598,10 @@ def _call_openrouter(
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "top_p": 0.95,
+            # Ask OpenRouter to include the per-call USD cost in the usage
+            # block so telemetry can record real spend without a second
+            # /generation round-trip or a local pricing table.
+            "usage": {"include": True},
         }
         if not _omit_temperature(model):
             body["temperature"] = 0.2
@@ -4628,6 +4682,9 @@ def _call_openrouter(
                 raise RuntimeError(f"HTTP {r.status_code}: {_err_body}")
             data = r.json()
             _log_token_usage("openrouter", model, data)
+            _or_usage, _or_cost = _extract_openrouter_usage(
+                data.get("usage") if isinstance(data, dict) else None
+            )
             choices = data.get("choices") or []
             if not choices:
                 if attempt < max_retries:
@@ -4641,6 +4698,12 @@ def _call_openrouter(
                     _stash_last_http(status=200, body=None, exc=None)
                 except Exception:
                     pass
+                _safe_record(
+                    provider="openrouter", model=model, usage=_or_usage, ok=True,
+                    duration_ms=int((time.monotonic() - _t0) * 1000),
+                    retry_count=attempt, error=None,
+                    cost_usd_override=_or_cost, model_id=None,
+                )
                 return text
             if attempt < max_retries:
                 time.sleep(_backoff_sleep_seconds(attempt))
@@ -4649,6 +4712,15 @@ def _call_openrouter(
         return ""
     except Exception as _exc:
         _LAST_PLAIN_LLM_CALL_ERROR.error = str(_exc)
+        try:
+            _safe_record(
+                provider="openrouter", model=model, usage={}, ok=False,
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                retry_count=int(retries or 0), error=str(_exc)[:200],
+                model_id=None,
+            )
+        except Exception:
+            pass
         try:
             tid = threading.get_ident()
             with _LAST_HTTP_LOCK:

--- a/backend/tests/test_openrouter_usage_tracking.py
+++ b/backend/tests/test_openrouter_usage_tracking.py
@@ -150,6 +150,48 @@ def test_plain_openrouter_records_failure_row(telemetry_clean):
     assert rows[0]["ok"] is False
 
 
+def test_plain_openrouter_records_empty_completion_terminal(telemetry_clean):
+    """HTTP 200 with an empty completion, retries exhausted → the call still
+    records one ok=False row carrying the parsed usage (OpenRouter may have
+    billed the attempt) instead of vanishing from telemetry."""
+    import llm_utils
+    resp = _FakeResp(payload=_ok_payload(content="", cost=0.004))
+    with patch("requests.post", return_value=resp):
+        out = llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b", "decide",
+            retries=0,
+        )
+    assert out == ""
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["provider"] == "openrouter"
+    assert row["ok"] is False
+    assert row["error"] == "empty response"
+    assert row["input_tokens"] == 120
+    assert row["output_tokens"] == 42
+    assert row["total_cost_usd"] == pytest.approx(0.004)
+    assert row["retry_count"] == 0
+
+
+def test_plain_openrouter_records_no_choices_terminal(telemetry_clean):
+    """HTTP 200 with no choices at all, retries exhausted → ok=False row."""
+    import llm_utils
+    resp = _FakeResp(payload={"choices": [], "usage": {"prompt_tokens": 33,
+                                                       "completion_tokens": 0}})
+    with patch("requests.post", return_value=resp):
+        out = llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b", "decide",
+            retries=0,
+        )
+    assert out == ""
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    assert rows[0]["ok"] is False
+    assert rows[0]["error"] == "no choices"
+    assert rows[0]["input_tokens"] == 33
+
+
 # ── Structured raw-JSON fallback path (what Nemotron actually uses) ──────────
 def test_structured_raw_json_fallback_records_row(telemetry_clean):
     import llm_utils

--- a/backend/tests/test_openrouter_usage_tracking.py
+++ b/backend/tests/test_openrouter_usage_tracking.py
@@ -1,0 +1,187 @@
+"""Regression tests for the OpenRouter usage-telemetry gap.
+
+Root cause: ``_call_openrouter`` was the only OpenAI-compatible provider path
+that never called ``_safe_record`` — so every OpenRouter call (plain AND the
+raw-JSON structured fallback that Nemotron uses on every request) produced
+ZERO rows in the LLMUsage table, making live + backtest cost invisible.
+
+These tests are fully caged: no real network (requests.post is mocked) and no
+real DB (telemetry is configured with a null conn factory + flusher disabled).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+
+class _OutSchema(BaseModel):
+    text: str
+
+
+@pytest.fixture
+def telemetry_clean():
+    import llm_telemetry
+    llm_telemetry._reset_for_tests()
+    llm_telemetry.configure(
+        db_conn_factory=lambda: None, enabled=True,
+        auto_start_flusher=False, pricing_yaml_path=None,
+    )
+    yield llm_telemetry
+    llm_telemetry._reset_for_tests()
+
+
+class _FakeResp:
+    def __init__(self, *, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def _ok_payload(*, content='{"text": "hi"}', cost=None, reasoning=0):
+    usage = {"prompt_tokens": 120, "completion_tokens": 42,
+             "total_tokens": 162}
+    if reasoning:
+        usage["completion_tokens_details"] = {"reasoning_tokens": reasoning}
+    if cost is not None:
+        usage["cost"] = cost
+    return {
+        "choices": [{"message": {"content": content}}],
+        "usage": usage,
+    }
+
+
+# ── Unit: usage extractor ────────────────────────────────────────────────────
+def test_extract_openrouter_usage_tokens_and_cost():
+    import llm_utils
+    u, cost = llm_utils._extract_openrouter_usage(
+        {"prompt_tokens": 120, "completion_tokens": 42, "cost": 0.0123,
+         "completion_tokens_details": {"reasoning_tokens": 7}}
+    )
+    assert u["input_tokens"] == 120
+    assert u["output_tokens"] == 42
+    assert u["reasoning_tokens"] == 7
+    assert cost == pytest.approx(0.0123)
+
+
+def test_extract_openrouter_usage_no_cost_returns_none():
+    import llm_utils
+    u, cost = llm_utils._extract_openrouter_usage(
+        {"prompt_tokens": 10, "completion_tokens": 5}
+    )
+    assert u == {"input_tokens": 10, "output_tokens": 5}
+    assert cost is None
+
+
+def test_extract_openrouter_usage_garbage():
+    import llm_utils
+    assert llm_utils._extract_openrouter_usage(None) == ({}, None)
+    assert llm_utils._extract_openrouter_usage("nope") == ({}, None)
+
+
+# ── Plain path records a row (with OpenRouter-reported cost) ──────────────────
+def test_plain_openrouter_records_row_with_cost(telemetry_clean):
+    import llm_utils
+    resp = _FakeResp(payload=_ok_payload(cost=0.0123, reasoning=7))
+    with patch("requests.post", return_value=resp):
+        out = llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b",
+            "decide", max_output_tokens=64,
+            provider_config={"openrouter_base_url": "https://openrouter.ai/api/v1"},
+        )
+    assert out == '{"text": "hi"}'
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["provider"] == "openrouter"
+    assert row["model"] == "nvidia/nemotron-3-ultra-550b-a55b"
+    assert row["input_tokens"] == 120
+    assert row["output_tokens"] == 42
+    assert row["reasoning_tokens"] == 7
+    assert row["ok"] is True
+    assert row["total_cost_usd"] == pytest.approx(0.0123)
+    assert row["cost_source"] == "envelope"
+
+
+def test_plain_openrouter_records_row_without_cost(telemetry_clean):
+    """No OpenRouter cost in the response → row still recorded with tokens,
+    cost falls back (0 here) but the row is NEVER dropped."""
+    import llm_utils
+    resp = _FakeResp(payload=_ok_payload(cost=None))
+    with patch("requests.post", return_value=resp):
+        out = llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b", "decide",
+        )
+    assert out == '{"text": "hi"}'
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    assert rows[0]["input_tokens"] == 120
+    assert rows[0]["output_tokens"] == 42
+    assert rows[0]["cost_source"] != "envelope"
+
+
+def test_plain_openrouter_records_failure_row(telemetry_clean):
+    """A 4xx (auth/model error) still records an ok=False row so live health
+    stays visible instead of silently vanishing."""
+    import llm_utils
+    resp = _FakeResp(status_code=401, payload={"error": {"message": "no key"}},
+                     text='{"error": {"message": "no key"}}')
+    with patch("requests.post", return_value=resp):
+        out = llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b", "decide",
+            retries=0,
+        )
+    assert out == ""
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    assert rows[0]["provider"] == "openrouter"
+    assert rows[0]["ok"] is False
+
+
+# ── Structured raw-JSON fallback path (what Nemotron actually uses) ──────────
+def test_structured_raw_json_fallback_records_row(telemetry_clean):
+    import llm_utils
+    resp = _FakeResp(payload=_ok_payload(content='{"text": "buy"}', cost=0.02))
+    with patch("requests.post", return_value=resp):
+        result = llm_utils.call_structured_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b",
+            prompt="decide", output_type=_OutSchema,
+            prefer_raw_json=True,
+            provider_config={"openrouter_base_url": "https://openrouter.ai/api/v1"},
+        )
+    assert result is not None
+    assert result.text == "buy"
+    rows = telemetry_clean.get_recent_calls(10)
+    assert len(rows) == 1
+    assert rows[0]["provider"] == "openrouter"
+    assert rows[0]["ok"] is True
+    assert rows[0]["total_cost_usd"] == pytest.approx(0.02)
+
+
+def test_call_openrouter_requests_cost_include(telemetry_clean):
+    """The request body must ask OpenRouter to include cost so the cheapest,
+    most-accurate cost source is available."""
+    import llm_utils
+    seen = {}
+
+    def _capture(url, headers=None, json=None, timeout=None):
+        seen["body"] = json
+        return _FakeResp(payload=_ok_payload(cost=0.01))
+
+    with patch("requests.post", side_effect=_capture):
+        llm_utils.call_llm_by_provider(
+            "openrouter", "sk-or-key", "nvidia/nemotron-3-ultra-550b-a55b", "decide",
+        )
+    assert seen["body"].get("usage") == {"include": True}

--- a/docs/superpowers/specs/2026-07-02-nemotron-baseline-results.md
+++ b/docs/superpowers/specs/2026-07-02-nemotron-baseline-results.md
@@ -1,0 +1,211 @@
+# Nemotron baseline backtests — Track C results (2026-07-02)
+
+Track C validation for the `graph_nexus` strategy (Strategies doc **179**, live
+instance `alpaca-main`). Runs in parallel with the gated live deploy; **does not
+gate it**. This document records the launch mechanism, the pilot outcome, the
+runs in flight, and how to finish the battery. It is intentionally honest about
+what is and is not a valid baseline.
+
+> Status at write time: **pilot phase only.** One healthy June-replay run is in
+> flight; the expensive tuned battery was deliberately **not** launched (see
+> "Decision" and "NOT done"). Numbers below are poll instructions, not final
+> results — no run completed within the session.
+
+---
+
+## 1. Launch mechanism (Step 1)
+
+Three candidate entry points were evaluated:
+
+| Candidate | Verdict |
+|---|---|
+| `backend/engines/ai_backtest_engine.py` | **No.** This is the AI *strategy-generation* agent (LLM invents strategies, `FIXED_START_DATE`/`FIXED_END_DATE` at `:45`, 2h timeout). Not a config-driven replay of doc-179. |
+| Run `broker.py backtest …` locally | **Impossible from this machine.** The broker needs Neo4j (graph_nexus), Alpaca market-data auth, an OpenRouter key, and the full backend deps. Local probe: **no Docker, Neo4j port 7687 closed, no `OPENROUTER_API_KEY`**. Only `.env` secret present is `INTELLISTOCK_CRED_KEY`. |
+| **Queue a `BacktestInstances` row → prod backtest-engine service** | **Chosen.** This is how the existing 1058 `BacktestResults` were made. |
+
+**How it actually runs.** `backend/engines/backtest_engine.py` is a standalone
+service that watches the `BacktestInstances` table via changefeed and, per
+pending row, spawns a **Docker container** running
+`broker.py <instance> backtest <start> <end> <gran> <key> <secret> [symbols]
+--backtest-id <id>` (`backend/engines/backtest_engine.py:582`). The broker reads
+the **strategy config from the referenced instance's `strategy_id` → Strategies
+doc** — config/model-roles/cadence are **not** passed on the CLI; they come from
+the linked doc. Market-data creds come from the instance's
+`alpaca_data_brokerage_id`.
+
+**Consequence for config selection:**
+- CURRENT doc-179 config → reference instance **`alpaca-main`** (`strategy_id=179`,
+  `alpaca_data_brokerage_id` set, key/secret present). ✅ available.
+- TUNED config → **has no instance in the DB.** It exists only as the transform
+  in `backend/scripts/apply_tune_2026_07.py::build_tuned_strategies`. Running it
+  requires standing up a *new* Strategies doc + a *new* backtest-only instance
+  carrying the tuned config **without editing doc-179** (forbidden). See "NOT
+  done".
+
+**Launch method used:** `interactive_utils.action_create_backtest(conn,
+"alpaca-main", [], start, end, granularity_sec=86400)` against **prod
+RethinkDB** (`get_conn()`, repo-root `.env` `RETHINKDB_HOST`). This is the exact
+code path behind `POST /backtests`; it inserts a queue row and is **not** a
+live-trading action. The prod API (`https://intellistock-api.pkrishna.dev`) is
+up but auth-gated (401); the direct DB insert avoids needing an API token and
+does not restart/reconfigure any server. Empty `stocks` = pure-discovery mode
+(Nexus discovers its own tickers, matching live). `granularity_sec=86400` (daily
+bars) matches all 452 historical doc-179 runs; the dual-cadence intraday
+simulation is driven by the config flag, not granularity.
+
+**Prod engine liveness (important):** first read of state looked *dead* —
+newest `BacktestResults` was 2026-05-29 (>1 month stale), `EngineControl.
+backtest_engine.running=False`, and 111 orphaned `BacktestInstances` rows stuck
+at `status=running, run=False`. But the pilot insert was **claimed in <20 s**
+(status → running), so the consumer **is alive**; the engine does not gate on
+`EngineControl` and the orphan rows are stale residue. Nobody had simply queued
+a real backtest in a month.
+
+---
+
+## 2. Pilot verdict (Step 2)
+
+**VIABLE.** The never-before-backtested OpenRouter Nemotron config runs.
+
+Two June-2026 replays (`2026-06-01 → 2026-07-01`, current config, `alpaca-main`)
+were queued. Observations:
+
+- **`992271`** — claimed in <20 s, ran the Nexus graph-build/macro phase
+  (discovered 106 symbols; prod Neo4j reachable at `bolt://100.95.106.23:7687`
+  via Tailscale), then **stopped at ~255 s, progress 0**, no error line, queue
+  `run` flipped False. Cause: almost certainly **concurrency starvation** — it
+  was killed mid-graph-build once the second high-difficulty run started. The
+  engine's `MAX_CONCURRENT_HIGH_DIFFICULTY=1` cap should have serialized them but
+  both got claimed. **Not a valid result.** Lesson: **run these sequentially.**
+- **`217590`** — healthy. Progressed past graph-build into the simulation phase
+  (fetching historical bars, e.g. `ITUB: 155 bars`). This is the viable pilot.
+  Left running.
+
+**Runtime signal.** Historical doc-179 daily-granularity runs over a ~6.5-month
+window took **~6 hours each** (`22,190 s / 23,494 s / 21,967 s / 25,120 s`; one
+outlier at `60,061 s` ≈ 16.7 h). That is **~0.9 h per simulated month**. So:
+- June replay (1 month) → projected **~1 h** (under the 2 h gate; will not finish
+  in-session).
+- Each tuned 6-month window → projected **~5–6 h** (each **exceeds** the 2 h
+  pilot-stop gate).
+
+**Cost signal (real OpenRouter tokens).** Nemotron-550b is called many times per
+bar per discovered ticker (~100+ tickers). Every observed call logged
+`ok=True` but **`raw_json_fallback=True`** — the 550b model is **not** returning
+schema-clean structured JSON; the pipeline salvages it via raw-JSON parsing.
+Calls succeed but this is a fragility/quality signal for a "baseline," and a
+~6 h × 550b run is genuinely expensive.
+
+**Config honesty finding (matters).** doc-179 CURRENT is **not** yet the tuned
+config, and is **not** fully Nemotron:
+- Default role: `openrouter / nvidia/nemotron-3-ultra-550b-a55b`. ✅
+- `macro_article_*` and `lookback_macro_article_*` roles: still
+  **`codex-cli / gpt-5.4-mini`** (the tune's B2 migration off codex-cli has
+  **not** been applied to the DB — despite the "apply 2026-07 live tune" commit,
+  all 25 tuned keys still differ from current: drawdown 12, max_positions 8,
+  etc.). So the *fully-Nemotron* config is actually the **TUNED** one. The
+  current-config pilot's macro-role calls hit codex-cli, which may not
+  authenticate inside the backtest container.
+
+**Decision:** per the HARD-RULE pilot gate ("if a single run would exceed ~2 h …
+STOP after the pilot attempt and report"), the three 6-month tuned runs are **not
+launched** — each exceeds the gate, each needs a tuned instance that does not
+exist, each costs real Nemotron tokens, and concurrency proved unstable. One
+healthy June-replay run (`217590`) is left in flight. The June *repeat* for
+variance was not re-queued concurrently (would starve again); launch it
+sequentially after `217590` finishes.
+
+---
+
+## 3. Runs & how to poll (Step 3/4)
+
+| Purpose | Window | Config | Instance | Run id | Status @ write |
+|---|---|---|---|---|---|
+| Pilot — June replay | 2026-06-01→2026-07-01 | CURRENT (Nemotron default + **codex-cli macro**) | alpaca-main | **217590** | **running** (sim phase) |
+| June replay (dupe, concurrency-starved) | 2026-06-01→2026-07-01 | CURRENT | alpaca-main | 992271 | **stopped @255 s — invalid** |
+| June replay repeat ×1 | 2026-06-01→2026-07-01 | CURRENT | alpaca-main | — | **NOT launched** (do sequentially) |
+| Tuned Jan–Jun ×2 | 2026-01-02→2026-06-30 | TUNED (fully Nemotron) | *new instance needed* | — | **NOT launched** |
+| Tuned non-bull ×1 | 2025-07-01→2025-12-31 | TUNED | *new instance needed* | — | **NOT launched** |
+
+**Poll (prod RethinkDB, table `BacktestResults`, primary key = run id):**
+
+```python
+# repo root; python3; .env RETHINKDB_HOST
+import sys, types; sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+sys.path.insert(0, "backend"); import os; os.chdir("backend")
+from dotenv import load_dotenv; load_dotenv("../.env"); load_dotenv(".env")
+from rethinkdb import RethinkDB; import interactive_utils as IU
+r = RethinkDB(); conn = IU.get_conn()
+row = r.db("IntelliStock").table("BacktestResults").get(217590).pluck(
+    "status","progress","pnl_percent","pnl","tickers",
+    "time_elapsed_seconds","start_date","end_date").run(conn)
+print(row)
+```
+
+Terminal `status`: `finished` (done), `stopped`/`failed` (aborted). Result
+fields: `pnl_percent`, `pnl` (dollars), `pnl_percent_per_stock`, `tickers`,
+`time_elapsed_seconds`, `initial_cash` (100000), `strategy_schema` (config
+snapshot), `backtest_trades`, `portfolio_value_history`. When `217590` reaches
+`finished`, fill the results table below (pnl%, trade count from
+`backtest_trades`, win rate = winning round-trips / total).
+
+**Analyses to complete once runs finish (methods, so the controller can finish):**
+- **vs SPY same window:** compare run `pnl_percent` to SPY buy-and-hold over the
+  identical dates. June 2026 SPY return must be pulled from `PriceHistory`/Alpaca
+  for `2026-06-01→2026-07-01`; a run only "beats the market" if it clears SPY.
+- **Variance across repeats:** needs ≥2 valid runs of the same window (currently
+  only 1 valid June run — launch the repeat sequentially).
+- **Gross-vs-net sensitivity:** backtest fills are **frictionless** (no
+  slippage/commission). Do **not** apply a fake precision haircut; note that a
+  ~100-ticker, high-churn daily strategy would lose an estimated few tens of bps
+  to spread+slippage per round-trip live, so net < gross — treat gross pnl% as an
+  optimistic upper bound, not a live estimate.
+- **June replay vs actual live June (+0.5%):** live `alpaca-main` returned
+  **+0.5%** in June 2026. Compare `217590`'s June pnl%. A large positive gap =
+  the backtest is over-optimistic (frictionless fills, no live halts/blocks,
+  cleaner data) and should be discounted accordingly — this is the core
+  live-vs-backtest divergence question this branch investigates.
+
+**Results (fill on completion):**
+
+| Run id | Window | pnl% (gross) | Trades | Win rate | SPY same-window | vs live/SPY |
+|---|---|---|---|---|---|---|
+| 217590 | Jun-2026 | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+
+---
+
+## 4. Historical baselines are INVALID (context)
+
+The pre-existing 90–266% doc-179 backtests are **not** honest baselines:
+
+- Single **bull window** (`2025-11-10 → ~2026-05` in every finished run).
+- In-sample tuned; `full_every_tick` cadence (not the live dual-cadence sim).
+- Old models (`gpt-5.4-mini` / kimi), **never Nemotron**.
+- Run against retired instance `main` (Robinhood), not `alpaca-main`.
+
+Sample finished runs (all bull-window, `full_every_tick`, non-Nemotron):
+`pnl% = 101.2 / 180.4 / 192.2 / 112.9 / 130.8 / 152.2 / 83.9` over ~6.5 months.
+Use these only to demonstrate why fresh, out-of-sample, dual-cadence, Nemotron
+runs are needed — not as a performance claim.
+
+---
+
+## 5. NOT done (explicit hand-off)
+
+1. **Tuned-config battery (Jan–Jun ×2, non-bull Jul–Dec ×1)** — blocked on two
+   things, both requiring authorization given real-money token cost:
+   - Each run ~5–6 h (> 2 h pilot gate).
+   - **No tuned instance exists.** To run without editing doc-179: create a new
+     Strategies doc from `build_tuned_strategies(doc179)[0]` (import from
+     `backend/scripts/apply_tune_2026_07.py`) under a fresh id, create a
+     backtest-only Instances row pointing at it (copy `alpaca-main`'s
+     `alpaca_data_brokerage_id`/key/secret), then `action_create_backtest` against
+     that instance. Note the tuned strategies embed real API keys — handle like
+     doc-179 (never print values).
+2. **June replay repeat** — launch **sequentially** after `217590` finishes
+   (concurrent high-difficulty runs starve each other — proven by `992271`).
+3. **All result analysis** (pnl%, trades, win rate, SPY, variance, net
+   sensitivity, June-vs-live +0.5%) — no run completed in-session.
+4. **Orphan cleanup** — `992271`'s queue row is left as `status=running,
+   run=False` residue (prod state not touched); the engine's reconcile loop
+   handles these.


### PR DESCRIPTION
## Why
Since the 06-30 switch to OpenRouter/Nemotron, the live decision model's usage and cost were completely untracked: `_call_openrouter` in `backend/llm_utils.py` was the only provider path that never called `_safe_record` — it printed usage and dropped it. Prod confirms 0 openrouter rows all-time (vs bedrock 1146 + codex-cli 14 since 06-30). The Token Usage dashboard and per-backtest cost cards were blind to the primary model.

## Fix
- `_call_openrouter` records success rows (tokens + OpenRouter-reported `usage.cost` via `usage:{include:true}` in the request envelope), terminal-failure rows (network/HTTP), and terminal HTTP-200 no-choices / empty-completion rows (`ok=False`, with any parsed usage since OpenRouter may have billed the attempt). Both the plain path and the raw_json_fallback structured path (Nemotron hits fallback on 100% of calls) are covered.
- Row never dropped for missing pricing (cost falls back to registry/zero).
- Recording is O(1) in-memory buffer append — no added latency on the live decision path; schema matches the other providers so the dashboard aggregates immediately.
- 10 caged tests asserting full row shape; 55 existing telemetry/openrouter tests pass.

## Notes
- Pre-deploy history cannot be backfilled (calls were never recorded).
- Separate known gap (documented, not fixed here): bedrock `openai.gpt-oss-120b-1:0` rows record but show $0.00 — missing pricing-registry entry.
- Latent same-shape gap in the unused `nvidia` provider path — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)