### PR TITLE
fix(llm): cap uncapped OpenRouter calls at 32k tokens — Nemotron reasoning burn broke enhanced_sentiment every cycle

### DIFF
--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -1562,6 +1562,35 @@ def _raw_structured_fallback_prompt(prompt: str, output_type: Any) -> str:
     return f"{base}\n\nTask:\n{prompt}"
 
 
+# OpenRouter reasoning models (e.g. nvidia/nemotron-3-ultra-550b-a55b) burn the
+# provider-default completion cap on *reasoning* tokens before emitting any JSON
+# — live telemetry showed ~13.7k reasoning tokens on a 14.7k-token completion.
+# Our call sites pass max_output_tokens=0 to mean "uncapped", which sends NO
+# max_tokens on the wire and lets OpenRouter apply its own finite default cap;
+# the reasoning burn then exhausts that cap before any structured JSON is
+# produced, and PydanticAI raises "Model token limit (provider default)
+# exceeded before any response was generated. Increase the `max_tokens` model
+# setting...". So for OpenRouter specifically an uncapped call gets an explicit,
+# generous cap large enough for reasoning + JSON to both fit. Bounded for
+# sanity (well under typical OpenRouter context windows). Other providers are
+# intentionally left uncapped when the caller asks for uncapped.
+_OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS = 32768
+
+
+def _openrouter_effective_max_output_tokens(max_output_tokens) -> int:
+    """Resolve the wire ``max_tokens`` for an OpenRouter call.
+
+    Honour an explicit positive cap; when the caller left it uncapped (<=0),
+    inject the generous reasoning-safe default so a reasoning model's thinking
+    tokens don't consume the provider-default cap before the JSON is emitted.
+    """
+    try:
+        n = int(max_output_tokens or 0)
+    except (TypeError, ValueError):
+        n = 0
+    return n if n > 0 else _OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS
+
+
 def _build_structured_model_settings(
     provider: str,
     max_output_tokens: int,
@@ -1572,6 +1601,11 @@ def _build_structured_model_settings(
     """Build provider-appropriate PydanticAI model settings for structured output."""
     effective_max_tokens = max_output_tokens if max_output_tokens and max_output_tokens > 0 else None
     p = (provider or "gemini").strip().lower()
+    # OpenRouter reasoning models need an explicit generous cap when uncapped —
+    # see _OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS. Only OpenRouter is affected;
+    # every other provider keeps its prior (uncapped => None) behaviour.
+    if p == "openrouter" and effective_max_tokens is None:
+        effective_max_tokens = _OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS
     skip_temp = _omit_temperature(model)
     if p == "gemini" and GoogleModelSettings is not None:
         if effective_max_tokens is None or effective_max_tokens < 256:
@@ -4608,8 +4642,13 @@ def _call_openrouter(
         }
         if not _omit_temperature(model):
             body["temperature"] = 0.2
-        if max_output_tokens and max_output_tokens > 0:
-            body["max_tokens"] = max_output_tokens
+        # Always send an explicit max_tokens for OpenRouter: honour a positive
+        # caller cap, else inject the generous reasoning-safe default so a
+        # reasoning model's thinking tokens don't exhaust the provider-default
+        # cap before the completion is emitted. See
+        # _OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS. This path also backs the
+        # raw-JSON structured fallback, so the fix covers both.
+        body["max_tokens"] = _openrouter_effective_max_output_tokens(max_output_tokens)
         effort = normalize_reasoning_effort(reasoning_effort)
         if effort:
             # OpenRouter accepts the OpenAI-style `reasoning_effort` alias AND its

--- a/backend/tests/test_openrouter_max_tokens.py
+++ b/backend/tests/test_openrouter_max_tokens.py
@@ -1,0 +1,134 @@
+"""Regression tests for the OpenRouter reasoning-model max_tokens gap.
+
+Root cause: OpenRouter reasoning models (e.g. nvidia/nemotron-3-ultra-550b-a55b)
+burn the provider-default completion cap on *reasoning* tokens before any JSON
+is emitted. Our call sites pass ``max_output_tokens=0`` to mean "uncapped",
+which sent NO ``max_tokens`` on the wire and let OpenRouter apply its own finite
+default cap — so the structured JSON never fit and PydanticAI raised
+"Model token limit (provider default) exceeded before any response was
+generated. Increase the `max_tokens` model setting...".
+
+Fix: for OpenRouter specifically, an uncapped call gets an explicit, generous
+``max_tokens`` (``_OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS``) so reasoning + JSON
+both fit. Every other provider path is untouched (uncapped stays uncapped).
+
+These tests are fully caged: no network (requests.post mocked / not reached for
+the pure settings builder) and no DB.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_NEMOTRON = "nvidia/nemotron-3-ultra-550b-a55b"
+
+
+class _FakeResp:
+    def __init__(self, *, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def _ok_payload():
+    return {
+        "choices": [{"message": {"content": '{"text": "hi"}'}}],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
+    }
+
+
+# ── structured model_settings builder ───────────────────────────────────────
+def test_structured_settings_openrouter_uncapped_gets_generous_cap():
+    import llm_utils
+    settings = llm_utils._build_structured_model_settings(
+        "openrouter", 0, 60.0, 0.2, model=_NEMOTRON
+    )
+    assert settings.get("max_tokens") == llm_utils._OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS
+    assert settings["max_tokens"] > 0
+
+
+def test_structured_settings_openrouter_respects_explicit_cap():
+    import llm_utils
+    settings = llm_utils._build_structured_model_settings(
+        "openrouter", 512, 60.0, 0.2, model=_NEMOTRON
+    )
+    assert settings.get("max_tokens") == 512
+
+
+@pytest.mark.parametrize("provider", ["openai", "nvidia", "deepseek", "azure"])
+def test_structured_settings_other_providers_uncapped_untouched(provider):
+    """Uncapped (0) for any non-OpenRouter, non-gemini provider must stay
+    uncapped (max_tokens=None) exactly as before this fix."""
+    import llm_utils
+    settings = llm_utils._build_structured_model_settings(
+        provider, 0, 60.0, 0.2, model="some-model"
+    )
+    assert settings.get("max_tokens") is None
+
+
+def test_structured_settings_gemini_uncapped_unchanged():
+    """Gemini keeps its pre-existing 256 floor — this fix does not touch it."""
+    import llm_utils
+    if llm_utils.GoogleModelSettings is None:
+        pytest.skip("GoogleModelSettings unavailable")
+    settings = llm_utils._build_structured_model_settings(
+        "gemini", 0, 60.0, 0.2, model="gemini-2.0-flash"
+    )
+    assert settings.get("max_tokens") == 256
+
+
+# ── plain OpenRouter path (also covers the raw-JSON structured fallback) ─────
+def _capture_body_call(**call_kwargs):
+    import llm_utils
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["body"] = json
+        return _FakeResp(payload=_ok_payload())
+
+    with patch("requests.post", side_effect=_fake_post):
+        out = llm_utils._call_openrouter(
+            "sk-or-key", _NEMOTRON, "decide", **call_kwargs
+        )
+    return out, captured.get("body", {})
+
+
+def test_plain_openrouter_uncapped_sends_generous_cap():
+    import llm_utils
+    _out, body = _capture_body_call(max_output_tokens=0)
+    assert body.get("max_tokens") == llm_utils._OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS
+
+
+def test_plain_openrouter_respects_explicit_cap():
+    _out, body = _capture_body_call(max_output_tokens=64)
+    assert body.get("max_tokens") == 64
+
+
+def test_plain_openai_uncapped_still_untouched():
+    """The OpenAI plain path must NOT gain an injected cap — only OpenRouter."""
+    import llm_utils
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["body"] = json
+        return _FakeResp(payload={
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+        })
+
+    with patch("requests.post", side_effect=_fake_post):
+        llm_utils._call_openai("oa-key", "gpt-4o-mini", "decide", max_output_tokens=0)
+    body = captured.get("body", {})
+    assert "max_tokens" not in body
+    assert "max_completion_tokens" not in body


### PR DESCRIPTION
## Why
The strategy's \"uncapped\" sentinel (max_output_tokens=0) sent NO max_tokens on OpenRouter calls. Nemotron-3-ultra-550b burns ~13.7k reasoning tokens per call, exhausting OpenRouter's finite provider default before any JSON is emitted → PydanticAI \"Model token limit exceeded\" → `enhanced_sentiment` returned no validated payload on EVERY cycle (live since 06-30 + all Nemotron backtests), silently degrading to company-article fallback classifications.

## Fix
- `_OPENROUTER_UNCAPPED_MAX_OUTPUT_TOKENS = 32768` injected at both chokepoints: the PydanticAI structured settings builder and the plain/raw-fallback wire path. Explicit user caps pass through unchanged; all other providers byte-identical (parametrized test proves it).
- No per-model token field exists in the Models rows and no config key existed — hardcoded with a justifying comment; per-model field is the follow-up if more OpenRouter models are added.
- PydanticAI deprecation warnings left as-is (pinned pydantic-ai 1.0.18 — replacement APIs don't exist there).
- 10 caged tests (RED→GREEN) asserting the real ModelSettings dict and captured request bodies; adjacent telemetry/provider suites green.

## Note
The in-flight June-replay backtest (#217590) runs pre-fix code — its sentiment signal is degraded the same way live currently is, so it measures the *broken* Nemotron baseline. A post-deploy re-run measures the fixed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)