### PR TITLE
fix(kalshi): self-heal DB connection loss (engine + worker) + operator alerts

### DIFF
--- a/backend/kalshi/backtest_worker.py
+++ b/backend/kalshi/backtest_worker.py
@@ -228,27 +228,44 @@ def start_worker(conn_factory, *, max_workers: int = 2):  # pragma: no cover - i
         pool.submit(_task)
 
     def _loop():
-        c = conn_factory()
-        # Drain rows left pending/running from a prior process.
-        try:
-            for row in _db.pending_or_running_backtests(c):
-                if row.get("status") == "running":
-                    # orphaned mid-run -> re-queue as pending
-                    _db.update_backtest_progress(c, row["id"], status="pending")
-                    row = {**row, "status": "pending"}
-                _dispatch(row)
-        except Exception:
-            log.exception("backtest worker drain failed")
-        # Watch for new pending jobs.
-        try:
-            feed = (_db._r.db(_db.DB_NAME).table("KalshiBacktests")
-                    .filter({"status": "pending"}).changes(include_initial=False).run(c))
-            for change in feed:
-                new = (change or {}).get("new_val")
-                if new and new.get("status") == "pending":
-                    _dispatch(new)
-        except Exception:
-            log.exception("backtest worker changefeed ended")
+        # Self-healing: a dropped changefeed connection (idle timeout, DB restart,
+        # network blip) must NOT silently kill the worker thread and stop picking up
+        # new backtests. Reconnect + re-watch forever, with a short backoff.
+        import time as _time
+        backoff = 2
+        while True:
+            try:
+                c = conn_factory()
+            except Exception:
+                log.exception("backtest worker: DB connect failed; retrying in %ss", backoff)
+                _time.sleep(backoff); backoff = min(backoff * 2, 30); continue
+            backoff = 2  # connected — reset
+            # Drain rows left pending/running from a prior process.
+            try:
+                for row in _db.pending_or_running_backtests(c):
+                    if row.get("status") == "running":
+                        # orphaned mid-run -> re-queue as pending
+                        _db.update_backtest_progress(c, row["id"], status="pending")
+                        row = {**row, "status": "pending"}
+                    _dispatch(row)
+            except Exception:
+                log.exception("backtest worker drain failed")
+            # Watch for new pending jobs.
+            try:
+                feed = (_db._r.db(_db.DB_NAME).table("KalshiBacktests")
+                        .filter({"status": "pending"}).changes(include_initial=False).run(c))
+                for change in feed:
+                    new = (change or {}).get("new_val")
+                    if new and new.get("status") == "pending":
+                        _dispatch(new)
+            except Exception:
+                log.exception("backtest worker changefeed ended; reconnecting in %ss", backoff)
+            # Feed ended (conn drop / server close) -> close, back off, reconnect + re-watch.
+            try:
+                c.close(noreply_wait=False)
+            except Exception:
+                pass
+            _time.sleep(backoff)
 
     threading.Thread(target=_loop, name="kalshi-backtest-worker", daemon=True).start()
     log.info("kalshi backtest worker started")

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -56,6 +56,40 @@ def get_conn():
     return _r.connect(host=RETHINKDB_HOST, port=RETHINKDB_PORT)
 
 
+def is_conn_error(exc) -> bool:
+    """True when `exc` looks like a dropped/closed/unreachable DB connection (the
+    signal to reconnect and self-heal) rather than a genuine query/logic error.
+    Matches by exception type AND message so it works across rethinkdb driver
+    versions without importing their exception classes."""
+    name = type(exc).__name__
+    if name in ("ReqlDriverError", "ReqlTimeoutError", "ReqlAvailabilityError",
+                "ReqlOpFailedError", "ConnectionError", "ConnectionResetError",
+                "ConnectionAbortedError", "BrokenPipeError", "TimeoutError"):
+        return True
+    msg = str(exc).lower()
+    return any(s in msg for s in (
+        "connection is closed", "connection closed", "connection reset",
+        "broken pipe", "not connected", "connection refused", "lost connection",
+        "connection already closed", "socket is closed", "eof",
+    ))
+
+
+def reconnect(old_conn=None):
+    """Return a FRESH DB connection, best-effort closing a dead one first. Used by
+    the long-running engine loop to recover from a closed connection (idle timeout,
+    DB restart, network blip) instead of retrying forever on a dead handle. Prefers
+    the driver's own `.reconnect()` (reuses auth/host), else opens a new connection."""
+    if old_conn is not None:
+        try:
+            return old_conn.reconnect(noreply_wait=False)
+        except Exception:
+            try:
+                old_conn.close(noreply_wait=False)
+            except Exception:
+                pass
+    return get_conn()
+
+
 def ensure_tables(conn) -> list[str]:
     """Create any missing kalshi_* tables. Returns the names created."""
     existing = set(_r.db(DB_NAME).table_list().run(conn))

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -290,14 +290,62 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
     if not config.odds_api_key:
         log("No odds API key — pricing model-only. Set odds_api_key (or ODDS_API_KEY env) "
             "to anchor fair value to sharp bookmaker odds and trade where Kalshi disagrees.", "yellow")
+    # DB self-heal state: the loop shares ONE `conn`, so a poll-level reconnect
+    # heals every DB op in the tick. Alert the operator ONCE per outage (not every
+    # tick for 20h) on loss and again on recovery.
+    _db_down = False
+    _db_fail_streak = 0
+
+    def _notify_kalshi(title, body, push_title, push_body):
+        """Best-effort operator alert (Discord + iOS push), same channel as the
+        crash alert. Never raises — a notify failure must not affect trading."""
+        try:
+            from notifications import notify as _n
+            _n(category="kalshi_runtime", instance_id=config.instance_id,
+               title=title, body=body, discord_channel="notifications",
+               push_title=push_title, push_body=push_body)
+        except Exception:
+            pass
+
     tick = 0
     while True:
         # Control-plane poll. A transient DB/connection blip must NOT kill the
         # 24/7 engine — log and retry next tick instead of propagating.
         try:
             inst = kdb._r.db(kdb.DB_NAME).table("Instances").get(config.instance_id).run(conn) or {}
+            if _db_down:  # a successful poll after an outage == recovered
+                log(f"control-plane: DB connection RECOVERED after {_db_fail_streak} "
+                    f"failed poll(s); engine resumed.", "green")
+                _notify_kalshi(
+                    f"KALSHI DB recovered [{config.instance_id}]",
+                    f"Database connection re-established after {_db_fail_streak} failed "
+                    f"poll(s) (~{_db_fail_streak * config.poll_seconds}s down). Engine resumed.",
+                    "Kalshi DB recovered", "Connection re-established — engine resumed.")
+                _db_down, _db_fail_streak = False, 0
         except Exception as e:
-            log(f"control-plane poll failed ({type(e).__name__}: {e}); retrying next tick.", "yellow")
+            # A closed/dropped connection (idle timeout, DB restart, network blip) must
+            # not wedge the engine on a dead handle — rebuild it and retry. This is the
+            # fix for the 20h "Connection is closed" stall. Non-connection errors are
+            # logged but not treated as an outage (no reconnect churn).
+            if kdb.is_conn_error(e):
+                _db_fail_streak += 1
+                try:
+                    conn = kdb.reconnect(conn)
+                    log(f"control-plane: DB connection lost ({type(e).__name__}); "
+                        f"reconnected (attempt {_db_fail_streak}), will re-poll next tick.", "yellow")
+                except Exception as e2:
+                    log(f"control-plane: DB lost ({type(e).__name__}); reconnect FAILED "
+                        f"({type(e2).__name__}: {e2}); retrying next tick.", "red")
+                if not _db_down:  # first failure of this outage -> alert once
+                    _db_down = True
+                    _notify_kalshi(
+                        f"KALSHI DB connection lost [{config.instance_id}]",
+                        f"{type(e).__name__}: {e}\n\nEngine is SELF-HEALING — auto-reconnecting "
+                        f"every {config.poll_seconds}s until the database is reachable. "
+                        f"You'll get a follow-up when it recovers.",
+                        "Kalshi DB connection lost", f"{type(e).__name__} — self-healing…")
+            else:
+                log(f"control-plane poll failed ({type(e).__name__}: {e}); retrying next tick.", "yellow")
             time.sleep(config.poll_seconds)
             continue
         if not inst.get("runCommand", False):

--- a/backend/tests/test_kalshi_reconnect.py
+++ b/backend/tests/test_kalshi_reconnect.py
@@ -1,0 +1,65 @@
+"""Engine DB reconnect helper: the long-running loop must recover from a closed
+connection instead of retrying forever on a dead handle (the 20h stall bug)."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import db
+
+
+class FakeConn:
+    def __init__(self, *, reconnect_ok=True):
+        self.reconnect_ok = reconnect_ok
+        self.closed = False
+        self.reconnected = False
+
+    def reconnect(self, noreply_wait=False):
+        if not self.reconnect_ok:
+            raise RuntimeError("Connection is closed.")
+        self.reconnected = True
+        return self  # driver returns a live connection
+
+    def close(self, noreply_wait=False):
+        self.closed = True
+
+
+def test_reconnect_prefers_driver_reconnect():
+    old = FakeConn(reconnect_ok=True)
+    new = db.reconnect(old)
+    assert new is old and old.reconnected
+
+
+def test_reconnect_falls_back_to_fresh_conn(monkeypatch):
+    fresh = FakeConn()
+    monkeypatch.setattr(db, "get_conn", lambda: fresh)
+    old = FakeConn(reconnect_ok=False)   # driver reconnect fails
+    new = db.reconnect(old)
+    assert new is fresh          # opened a brand-new connection
+    assert old.closed            # best-effort closed the dead one
+
+
+def test_reconnect_none_opens_fresh(monkeypatch):
+    fresh = FakeConn()
+    monkeypatch.setattr(db, "get_conn", lambda: fresh)
+    assert db.reconnect(None) is fresh
+
+
+class ReqlDriverError(Exception):
+    pass
+
+
+def test_is_conn_error_by_type():
+    assert db.is_conn_error(ReqlDriverError("boom"))
+    assert db.is_conn_error(ConnectionResetError())
+    assert db.is_conn_error(BrokenPipeError())
+
+
+def test_is_conn_error_by_message():
+    assert db.is_conn_error(RuntimeError("Connection is closed."))
+    assert db.is_conn_error(Exception("lost connection to server"))
+    assert db.is_conn_error(OSError("Broken pipe"))
+
+
+def test_is_conn_error_false_for_logic_errors():
+    assert not db.is_conn_error(ValueError("bad value"))
+    assert not db.is_conn_error(KeyError("missing"))
+    assert not db.is_conn_error(RuntimeError("table does not exist"))


### PR DESCRIPTION
Fixes the 20h 'Connection is closed' stall: the engine now reconnects on a dead handle instead of looping forever on it, and alerts the operator once on loss + once on recovery (Discord+push). Backtest worker changefeed now reconnects+re-watches instead of dying silently. New db.reconnect() + db.is_conn_error() helpers, tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)