### PR TITLE
feat(kalshi): SP1 self-improving training loop (continuous isotonic calibration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **IntelliStock** (29072 symbols, 57552 relationships, 142 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **IntelliStock** (30081 symbols, 59505 relationships, 143 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **IntelliStock** (29072 symbols, 57552 relationships, 142 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **IntelliStock** (30081 symbols, 59505 relationships, 143 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4170,6 +4170,23 @@ def api_kalshi_scan_budget(brokerage_id: str, conn=Depends(conn_dependency), cur
     return scan_budget_payload(used, days_left_in_month=days_left)
 
 
+@app.get("/brokerages/{brokerage_id}/kalshi/instances/{instance_id}/model", response_class=JSONResponse)
+def api_kalshi_instance_model(brokerage_id: str, instance_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
+    """Champion calibrator for an instance (self-improving training loop): method,
+    sample count, held-out raw-vs-calibrated log-loss/Brier, and reliability points
+    (predicted vs actual). {champion: null} until the loop produces one."""
+    _kalshi_brokerage_row(conn, brokerage_id)
+    from kalshi.db import get_champion
+    champ = get_champion(conn, instance_id, "calibrator")
+    if not champ:
+        return {"champion": None}
+    return {"champion": {
+        "id": champ.get("id"), "method": champ.get("method"),
+        "n_samples": champ.get("n_samples"), "created_at": champ.get("created_at"),
+        "metrics": champ.get("metrics", {}), "reliability": champ.get("reliability", []),
+    }}
+
+
 @app.post("/brokerages/{brokerage_id}/kalshi/kill", response_class=JSONResponse)
 def api_kalshi_kill(brokerage_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
     """KILL: stop the instance bound to this Kalshi account and cancel its

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -47,6 +47,8 @@ KALSHI_TABLES: list[tuple[str, str]] = [
     ("KalshiHistOdds", "id"),            # cached OddsPapi historical odds, id = fixture_id
     ("KalshiHistFixtures", "fixture_key"),  # cached per-fixture final-score resolution
     ("KalshiBtFixtureList", "id"),  # cached fixture-list query results (zero-cost re-runs)
+    # self-improving training pipeline: versioned calibrators + metrics per instance
+    ("KalshiModelRegistry", "id"),  # fitted calibrator versions; is_champion flags the live one
 ]
 
 
@@ -571,3 +573,37 @@ def pending_or_running_backtests(conn) -> list:
     return list(_r.db(DB_NAME).table("KalshiBacktests")
                 .filter(lambda d: (d["status"] == "pending") | (d["status"] == "running"))
                 .run(conn))
+
+
+# --- model registry (self-improving training pipeline) ---
+
+def save_model_version(conn, doc: dict) -> str:
+    """Persist a model-registry version (fitted calibrator + held-out metrics).
+    Caller stamps id/instance_id/kind/created_at. Returns the id."""
+    _r.db(DB_NAME).table("KalshiModelRegistry").insert(doc, conflict="replace").run(conn)
+    return doc["id"]
+
+
+def get_champion(conn, instance_id: str, kind: str = "calibrator"):
+    """Current champion doc for (instance, kind). Falls back to the global
+    '__default__' scope when the instance has none. None if neither exists.
+    Degrade-safe: returns None on any error (engine then uses identity)."""
+    try:
+        tbl = _r.db(DB_NAME).table("KalshiModelRegistry")
+        for scope in (instance_id, "__default__"):
+            rows = list(tbl.filter({"instance_id": scope, "kind": kind,
+                                    "is_champion": True}).limit(1).run(conn))
+            if rows:
+                return rows[0]
+    except Exception:
+        pass
+    return None
+
+
+def set_champion(conn, id: str, instance_id: str, kind: str = "calibrator") -> None:
+    """Promote `id` to champion for (instance, kind), demoting any prior champion in
+    the same scope so exactly one is live."""
+    tbl = _r.db(DB_NAME).table("KalshiModelRegistry")
+    tbl.filter({"instance_id": instance_id, "kind": kind, "is_champion": True}) \
+       .update({"is_champion": False}).run(conn)
+    tbl.get(id).update({"is_champion": True}).run(conn)

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -281,6 +281,7 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
     live_news_cache: dict = {}  # fixture_id -> {"ts": wall, "snip": str}; live-card news (5 min)
     odds_cache: dict = {}       # sport_key -> {"ts": wall, "events": [...], "quota": int|None}
     espn_cache: dict = {"ts": 0.0, "board": []}   # ESPN live scores+clock (timing only, ~30s)
+    _calibrator = None            # champion isotonic calibrator (self-improving loop); None = identity
     raw_dumped = False           # one-time raw-market field dump (price diagnostics)
     placed_markets: set = set()  # market_tickers already held/ordered — don't re-order
     _soccer_series = config.soccer_series or discovery.DEFAULT_SOCCER_SERIES
@@ -360,6 +361,18 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                 elo_table = fetch_elo_table() or {}
                 log(f"tick {tick}: loaded {len(elo_table)} club Elo ratings.",
                     "white" if elo_table else "yellow")
+            # 1a) Champion calibrator from the self-improving training loop (refit by
+            # the training worker as games settle). Degrade to identity on any failure.
+            if tick == 1 or tick % 60 == 1:
+                try:
+                    _calibrator = kdb.get_champion(conn, config.instance_id, "calibrator")
+                    if _calibrator:
+                        _m = _calibrator.get("metrics", {})
+                        log(f"tick {tick}: loaded champion calibrator ({_calibrator.get('method')}, "
+                            f"{_calibrator.get('n_samples')} samples, held-out log-loss "
+                            f"{_m.get('cal_logloss', 0):.3f}).", "cyan")
+                except Exception:
+                    _calibrator = None
             # 1b) Live national-team Elo (eloratings.net) for World Cup / international
             # markets — replaces the frozen static table when reachable. Degrade-safe:
             # {} keeps the static fallback (national_elo_from), so a feed outage is a no-op.
@@ -679,6 +692,7 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                 market_shrink=config.market_shrink,
                 one_bet_per_fixture=getattr(config.caps, "one_bet_per_fixture", True),
                 devig_method=config.devig_method,
+                calibrator=_calibrator,
             )
             allocations, decisions = plan["allocations"], plan["decisions"]
             log(f"tick {tick}: {len(decisions)} candidate(s) evaluated → {len(allocations)} to place "

--- a/backend/kalshi/orchestrator.py
+++ b/backend/kalshi/orchestrator.py
@@ -11,6 +11,8 @@ from kalshi.capital.opportunity import score as opportunity_score
 from kalshi.capital.planner import allocate
 from kalshi.decisions import decision_doc
 from kalshi.devig import market_probs_from_asks
+from kalshi.intelligence.fusion import renormalize_group
+from kalshi import training
 
 
 def plan_and_allocate(
@@ -30,6 +32,7 @@ def plan_and_allocate(
     market_shrink: float = 0.0,
     one_bet_per_fixture: bool = True,
     devig_method: str = "power",
+    calibrator: dict | None = None,
 ) -> dict:
     """fixtures: each {fixture_id, expected_goals, sharp_probs, analyst:{adjustments,
     rationales}, kalshi_markets, liquidity, hours_to_kickoff, model_confidence}.
@@ -70,6 +73,12 @@ def plan_and_allocate(
                             (1.0 - market_shrink) * fused["winner"][side]
                             + market_shrink * market[side]
                         )
+        # CALIBRATION: remap the winner probs through the champion isotonic calibrator
+        # (fit on settled outcomes by the training worker) so a stated 60% actually
+        # wins ~60%. Monotone + renormalized to sum to 1. No champion -> no-op.
+        if calibrator and fused.get("winner"):
+            fused["winner"] = renormalize_group(
+                {s: training.apply(calibrator, p) for s, p in fused["winner"].items()})
         cands, skips = generate_candidates(
             fx["fixture_id"], tier, fused, fx.get("kalshi_markets", []),
             fee_rate=fee_rate, edge_threshold=edge_threshold,

--- a/backend/kalshi/runner.py
+++ b/backend/kalshi/runner.py
@@ -45,6 +45,45 @@ def _configure_telemetry() -> None:  # pragma: no cover - integration
         pass
 
 
+def _start_training_worker(instance_id, cfg) -> None:  # pragma: no cover - integration
+    """Start the self-improving calibration worker as a daemon alongside the engine.
+    Best-effort: any failure here must NOT block trading (the engine simply runs
+    with the last champion, or identity)."""
+    try:
+        import datetime as _dt
+        from kalshi import training_worker
+        from kalshi.backtest_data import BacktestDataProvider
+        from kalshi.backtest import build_model_fn
+        from kalshi.client import KalshiClient
+        leagues = list(cfg.get("leagues") or [])
+        if not leagues:
+            return
+        try:
+            from kalshi.data.sources.clubelo import fetch_elo_table
+            elo = fetch_elo_table() or {}
+        except Exception:
+            elo = {}
+        model_fn = build_model_fn({}, elo)  # static national Elo + club Elo (calibration is robust to small model diffs)
+
+        def provider_factory(conn):
+            return BacktestDataProvider(
+                conn=conn,
+                kalshi_client=KalshiClient(key_id="training", private_key_pem="", environment="prod"))
+
+        refit = training_worker.build_refit_fn(
+            provider_factory=provider_factory, model_fn=model_fn, leagues=leagues,
+            start_date="2020-01-01",
+            end_date_fn=lambda: _dt.datetime.utcnow().strftime("%Y-%m-%d"),
+            instance_id="__default__", min_total=100)
+        try:
+            from notifications import notify as _notify
+        except Exception:
+            _notify = None
+        training_worker.start_worker(kdb.get_conn, refit, refresh_secs=3600, notify=_notify)
+    except Exception:
+        pass
+
+
 def _run_with_crash_alert(config, *, run=run_instance, notify=None) -> None:
     """Run the engine; on an uncaught crash, alert the operator (Discord + iOS push,
     category 'kalshi_runtime') then re-raise so the supervisor still sees the failure.
@@ -98,6 +137,7 @@ def main(argv: list[str] | None = None) -> int:
             pass
 
     _configure_telemetry()
+    _start_training_worker(instance_id, cfg)
     _run_with_crash_alert(
         EngineConfig(
             instance_id=instance_id,

--- a/backend/kalshi/training.py
+++ b/backend/kalshi/training.py
@@ -1,0 +1,128 @@
+"""Self-supervised calibration training (PURE — no DB/network, unit-tested).
+
+Turns settled soccer outcomes into a fitted probability calibrator plus held-out
+metrics for the model registry. The core learning loop: the model predicts, games
+settle, and its probabilities are remapped toward the empirical hit-rate so a
+stated "60%" actually wins ~60% of the time.
+
+Reuses `kalshi.calibration` (isotonic PAV + global shrink). Degrades safely: no /
+thin data -> shrink or identity, never a hard failure.
+"""
+from __future__ import annotations
+
+import math
+
+from kalshi import calibration
+
+_SIDES = ("home", "draw", "away")
+
+
+def gather_samples_from_settled(fixtures, model_fn) -> list:
+    """One `(pred, outcome01)` sample per SIDE of each settled fixture — the richest
+    training signal (every game, every side), no trading required.
+
+    `fixtures`: dicts carrying `result` in {home,draw,away}. `model_fn(fx)` ->
+    `{home,draw,away}` probabilities. Sides the model doesn't price are skipped."""
+    out = []
+    for fx in fixtures or []:
+        res = (fx or {}).get("result")
+        if res not in _SIDES:
+            continue
+        probs = model_fn(fx) or {}
+        for side in _SIDES:
+            p = probs.get(side)
+            if p is None:
+                continue
+            out.append((float(p), 1.0 if side == res else 0.0))
+    return out
+
+
+def gather_samples_from_decisions(rows) -> list:
+    """`(fused_fair, win01)` from PLACED + settled decision rows — the bot's own
+    realized bets. Narrower than the settled-fixture signal (only sides it bet),
+    but grades exactly what it traded."""
+    out = []
+    for r in rows or []:
+        if (r or {}).get("decision") != "placed":
+            continue
+        oc = r.get("outcome")
+        fair = r.get("fused_fair")
+        if oc not in ("win", "loss") or fair is None:
+            continue
+        out.append((float(fair), 1.0 if oc == "win" else 0.0))
+    return out
+
+
+def fit_calibrator(samples, *, min_total: int = 100, shrink_strength: float = 0.4) -> dict:
+    """Fit a registry-shaped calibrator doc from `(pred, 0/1)` samples: an ISOTONIC
+    remap once there's enough data, else a conservative global SHRINK, else identity
+    when there's nothing. Never raises."""
+    clean = [(p, o) for p, o in (samples or []) if p is not None and o is not None]
+    n = len(clean)
+    if n == 0:
+        return {"method": "identity", "calibrator": None, "shrink_strength": 0.0, "n_samples": 0}
+    if n >= min_total:
+        cal = calibration.fit_isotonic(clean)
+        if cal:
+            return {"method": "isotonic",
+                    "calibrator": [[float(x), float(y)] for x, y in cal],
+                    "shrink_strength": 0.0, "n_samples": n}
+    # thin data -> shrink toward the base rate (never trust a curve fit on noise)
+    return {"method": "shrink", "calibrator": None,
+            "shrink_strength": float(shrink_strength), "n_samples": n}
+
+
+def apply(doc, p):
+    """Apply a calibrator doc to a probability. Identity for a missing/identity doc.
+    Result is clamped to [0,1]. Monotone."""
+    if p is None:
+        return p
+    p = max(0.0, min(1.0, float(p)))
+    if not doc:
+        return p
+    method = doc.get("method")
+    if method == "isotonic" and doc.get("calibrator"):
+        cal = [(float(x), float(y)) for x, y in doc["calibrator"]]
+        return max(0.0, min(1.0, calibration.apply_isotonic(cal, p)))
+    if method == "shrink":
+        return calibration.shrink(p, strength=float(doc.get("shrink_strength", 0.4)))
+    return p
+
+
+def _logloss_brier(samples, doc):
+    if not samples:
+        return 0.0, 0.0
+    ll = 0.0
+    br = 0.0
+    for p, o in samples:
+        q = apply(doc, p) if doc else max(0.0, min(1.0, float(p)))
+        q = max(1e-6, min(1.0 - 1e-6, q))
+        ll += -(o * math.log(q) + (1.0 - o) * math.log(1.0 - q))
+        br += (q - o) ** 2
+    n = len(samples)
+    return ll / n, br / n
+
+
+def evaluate(samples, doc) -> dict:
+    """Held-out raw-vs-calibrated log-loss + Brier on `(pred, 0/1)` samples."""
+    raw_ll, raw_br = _logloss_brier(samples, None)
+    cal_ll, cal_br = _logloss_brier(samples, doc)
+    return {"raw_logloss": raw_ll, "cal_logloss": cal_ll,
+            "raw_brier": raw_br, "cal_brier": cal_br, "n_eval": len(samples)}
+
+
+def reliability_buckets(samples, doc=None, *, n_buckets: int = 5) -> list:
+    """Predicted-vs-actual reliability points (for a UI reliability curve). Bins
+    calibrated predictions into `n_buckets` and reports avg predicted vs hit rate."""
+    buckets = [[0, 0.0, 0.0] for _ in range(n_buckets)]  # [n, sum_pred, sum_outcome]
+    for p, o in samples or []:
+        q = apply(doc, p)
+        idx = min(n_buckets - 1, max(0, int(q * n_buckets)))
+        buckets[idx][0] += 1
+        buckets[idx][1] += q
+        buckets[idx][2] += o
+    out = []
+    for n, sp, so in buckets:
+        if n:
+            out.append({"n": n, "predicted": round(sp / n, 4), "actual": round(so / n, 4)})
+    return out

--- a/backend/kalshi/training_worker.py
+++ b/backend/kalshi/training_worker.py
@@ -1,0 +1,146 @@
+"""Background training worker: continuously refit the probability calibrator from
+settled outcomes and promote it to champion ONLY when it beats the raw model on a
+held-out split. Mirrors the backtest worker's self-heal loop (reconnect on a
+dropped DB connection instead of dying) — PR #84 pattern.
+
+`refit_once` is the pure-ish core (inject conn + samples + id/timestamp) so the
+promotion gate is unit-tested without a DB. `start_worker` wraps it in the
+resilient loop the runner starts as a daemon thread.
+"""
+from __future__ import annotations
+
+import logging
+
+from kalshi import db as _db, training
+
+log = logging.getLogger("kalshi.training_worker")
+
+
+def refit_once(conn, instance_id, train_samples, test_samples, *, new_id, now_iso,
+               min_total: int = 100, promote: bool = True) -> dict:
+    """Fit a calibrator on `train_samples`, score it on held-out `test_samples`,
+    persist the version, and promote to champion IFF calibrated log-loss does not
+    regress vs the raw model. Returns the version doc with a `promoted` flag.
+
+    Falls back to train_samples for evaluation when no test split is given (thin
+    data) — the promotion gate then just guards against an actively harmful fit."""
+    doc = training.fit_calibrator(train_samples, min_total=min_total)
+    eval_set = test_samples or train_samples
+    metrics = training.evaluate(eval_set, doc)
+    version = {
+        "id": new_id, "instance_id": instance_id, "kind": "calibrator",
+        "created_at": now_iso, "is_champion": False,
+        "method": doc["method"], "calibrator": doc["calibrator"],
+        "shrink_strength": doc["shrink_strength"], "n_samples": doc["n_samples"],
+        "metrics": metrics,
+        "reliability": training.reliability_buckets(eval_set, doc),
+    }
+    _db.save_model_version(conn, version)
+    # Never ship a worse model: promote only if calibration helped (or is neutral)
+    # AND we actually have data. Identity fits are neutral and harmless to promote,
+    # but there's no point — require a real (isotonic/shrink) fit with samples.
+    improved = (metrics["cal_logloss"] <= metrics["raw_logloss"] + 1e-9)
+    promoted = bool(promote and doc["n_samples"] > 0 and doc["method"] != "identity" and improved)
+    if promoted:
+        _db.set_champion(conn, new_id, instance_id, "calibrator")
+    version["promoted"] = promoted
+    return version
+
+
+def _now_iso() -> str:
+    import datetime as _dt
+    return _dt.datetime.utcnow().isoformat() + "Z"
+
+
+def _new_id(instance_id: str) -> str:
+    import uuid as _uuid
+    return f"cal|{instance_id}|{_uuid.uuid4().hex[:12]}"
+
+
+def build_refit_fn(*, provider_factory, model_fn, leagues, start_date,
+                   end_date_fn, instance_id: str = "__default__", min_total: int = 100):
+    """Return a `refit(conn) -> dict|None` that fetches settled fixtures, gathers
+    per-side calibration samples, splits train/test by fixture (no leakage), and
+    calls `refit_once`. `end_date_fn()` returns today's date string so the window
+    rolls forward. Degrade-safe: returns None on any data failure."""
+    def refit(conn):
+        try:
+            provider = provider_factory(conn)
+            fixtures = [f for f in provider.fixtures(leagues, start_date, end_date_fn())
+                        if (f or {}).get("result") in ("home", "draw", "away")]
+        except Exception:
+            log.exception("training: fixture fetch failed")
+            return None
+        if not fixtures:
+            return None
+        fixtures.sort(key=lambda f: str(f.get("kickoff_ts") or f.get("fixture_id") or ""))
+        train_fx, test_fx = fixtures[::2], fixtures[1::2]
+        train = training.gather_samples_from_settled(train_fx, model_fn)
+        test = training.gather_samples_from_settled(test_fx, model_fn)
+        return refit_once(conn, instance_id, train, test,
+                          new_id=_new_id(instance_id), now_iso=_now_iso(),
+                          min_total=min_total)
+    return refit
+
+
+def start_worker(conn_factory, refit_fn, *, refresh_secs: int = 3600, notify=None,
+                 run_once_now: bool = True, _max_cycles=None):
+    """Daemon loop: periodically call `refit_fn(conn)`; reconnect + retry on a
+    dropped connection; alert the operator when a new champion is promoted.
+    `_max_cycles` bounds the loop for tests."""
+    import threading
+    import time as _time
+
+    def _alert(v):
+        if not notify or not v or not v.get("promoted"):
+            return
+        m = v.get("metrics", {})
+        try:
+            notify(category="kalshi_runtime", instance_id=v.get("instance_id", ""),
+                   title=f"KALSHI model recalibrated [{v.get('instance_id')}]",
+                   body=(f"New champion calibrator ({v.get('method')}, {v.get('n_samples')} "
+                         f"samples): held-out log-loss {m.get('raw_logloss'):.3f} -> "
+                         f"{m.get('cal_logloss'):.3f}."),
+                   discord_channel="notifications",
+                   push_title="Kalshi model recalibrated",
+                   push_body=f"log-loss {m.get('raw_logloss'):.3f} -> {m.get('cal_logloss'):.3f}")
+        except Exception:
+            pass
+
+    def _loop():
+        backoff = 2
+        cycles = 0
+        conn = None
+        first = run_once_now
+        while _max_cycles is None or cycles < _max_cycles:
+            if not first:
+                _time.sleep(refresh_secs)
+            first = False
+            cycles += 1
+            try:
+                if conn is None:
+                    conn = conn_factory()
+                v = refit_fn(conn)
+                _alert(v)
+                if v is not None:
+                    log.info("training: refit ok (promoted=%s)", v.get("promoted"))
+                backoff = 2
+            except Exception as e:
+                if _db.is_conn_error(e):
+                    log.warning("training: DB connection lost (%s); reconnecting", type(e).__name__)
+                    try:
+                        conn = _db.reconnect(conn)
+                    except Exception:
+                        conn = None
+                    _time.sleep(backoff)
+                    backoff = min(backoff * 2, 30)
+                else:
+                    log.exception("training: refit cycle failed")
+
+    if _max_cycles is not None:  # synchronous for tests
+        _loop()
+        return None
+    t = threading.Thread(target=_loop, name="kalshi-training-worker", daemon=True)
+    t.start()
+    log.info("kalshi training worker started")
+    return t

--- a/backend/tests/test_kalshi_model_registry.py
+++ b/backend/tests/test_kalshi_model_registry.py
@@ -1,0 +1,105 @@
+"""Model registry writers: save version, champion get/set, instance->default
+fallback. Uses an in-memory fake of the rethinkdb query chain (no DB)."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import db
+
+
+# --- minimal in-memory fake for the exact query chains db.py uses ---
+class _Insert:
+    def __init__(self, rows, doc): self.rows, self.doc = rows, doc
+    def run(self, conn):
+        for d in (self.doc if isinstance(self.doc, list) else [self.doc]):
+            self.rows[:] = [r for r in self.rows if r.get("id") != d.get("id")]
+            self.rows.append(dict(d))
+        return {"inserted": 1}
+
+
+class _Upd:
+    def __init__(self, targets, upd): self.targets, self.upd = targets, upd
+    def run(self, conn):
+        for r in self.targets:
+            r.update(self.upd)
+        return {"replaced": len(self.targets)}
+
+
+class _Limited:
+    def __init__(self, matched): self.matched = matched
+    def run(self, conn): return list(self.matched)
+
+
+class _Filtered:
+    def __init__(self, rows, pred): self.rows, self.pred = rows, pred
+    def _m(self, r): return all(r.get(k) == v for k, v in self.pred.items())
+    def limit(self, n): return _Limited([r for r in self.rows if self._m(r)][:n])
+    def update(self, upd): return _Upd([r for r in self.rows if self._m(r)], upd)
+
+
+class _GetOne:
+    def __init__(self, rows, _id): self.rows, self._id = rows, _id
+    def _row(self): return next((r for r in self.rows if r.get("id") == self._id), None)
+    def update(self, upd):
+        r = self._row()
+        return _Upd([r] if r else [], upd)
+    def run(self, conn): return self._row()
+
+
+class FakeTable:
+    def __init__(self, rows): self.rows = rows
+    def insert(self, doc, conflict=None): return _Insert(self.rows, doc)
+    def filter(self, pred): return _Filtered(self.rows, pred)
+    def get(self, _id): return _GetOne(self.rows, _id)
+
+
+class FakeR:
+    def __init__(self): self.store = {}
+    def db(self, name): return self
+    def table(self, name): return FakeTable(self.store.setdefault(name, []))
+
+
+def _setup(monkeypatch):
+    fake = FakeR()
+    monkeypatch.setattr(db, "_r", fake)
+    return fake, object()  # (fake driver, dummy conn)
+
+
+def _doc(id, inst, ll):
+    return {"id": id, "instance_id": inst, "kind": "calibrator",
+            "is_champion": False, "metrics": {"cal_logloss": ll}}
+
+
+def test_save_and_get_champion(monkeypatch):
+    _, conn = _setup(monkeypatch)
+    db.save_model_version(conn, _doc("v1", "inst-A", 0.80))
+    db.set_champion(conn, "v1", "inst-A")
+    champ = db.get_champion(conn, "inst-A")
+    assert champ and champ["id"] == "v1" and champ["is_champion"] is True
+
+
+def test_set_champion_demotes_prior(monkeypatch):
+    _, conn = _setup(monkeypatch)
+    db.save_model_version(conn, _doc("v1", "inst-A", 0.80))
+    db.save_model_version(conn, _doc("v2", "inst-A", 0.75))
+    db.set_champion(conn, "v1", "inst-A")
+    db.set_champion(conn, "v2", "inst-A")  # promote v2
+    champ = db.get_champion(conn, "inst-A")
+    assert champ["id"] == "v2"
+    # exactly one champion in scope
+    champs = [r for r in db._r.store["KalshiModelRegistry"]
+              if r["instance_id"] == "inst-A" and r["is_champion"]]
+    assert len(champs) == 1
+
+
+def test_instance_falls_back_to_default_scope(monkeypatch):
+    _, conn = _setup(monkeypatch)
+    db.save_model_version(conn, _doc("g1", "__default__", 0.9))
+    db.set_champion(conn, "g1", "__default__")
+    # instance with no champion of its own -> gets the global default
+    champ = db.get_champion(conn, "inst-NEW")
+    assert champ and champ["id"] == "g1"
+
+
+def test_get_champion_none_when_empty(monkeypatch):
+    _, conn = _setup(monkeypatch)
+    assert db.get_champion(conn, "inst-A") is None

--- a/backend/tests/test_kalshi_orchestrator.py
+++ b/backend/tests/test_kalshi_orchestrator.py
@@ -162,3 +162,35 @@ def test_one_bet_per_fixture_caps_placed_candidates():
 
     assert len(placed_capped) <= 1
     assert len(placed_uncapped) == 2
+
+
+def test_calibrator_remaps_and_renormalizes_winner_probs():
+    """The champion calibrator remaps the winner fair values (here a shrink toward
+    the base rate flattens a strong favorite), renormalized to a coherent book."""
+    asks = {"home": 55, "draw": 26, "away": 19}
+    common = dict(instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+                  fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0,
+                  expected_better_soon=False, market_shrink=0.0)
+    base = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common, calibrator=None)
+    shrunk = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common,
+                               calibrator={"method": "shrink", "calibrator": None, "shrink_strength": 0.5})
+
+    def side_fair(out, side):
+        return next(d["fused_fair"] for d in out["decisions"] if d.get("side") == side)
+
+    # favorite (home) is flattened toward uniform; the group still ~sums to 1
+    assert side_fair(shrunk, "home") < side_fair(base, "home")
+    total = sum(side_fair(shrunk, s) for s in ("home", "draw", "away"))
+    assert abs(total - 1.0) < 1e-6
+
+
+def test_calibrator_none_is_identity():
+    asks = {"home": 55, "draw": 26, "away": 19}
+    common = dict(instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+                  fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0,
+                  expected_better_soon=False, market_shrink=0.0)
+    a = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common, calibrator=None)
+    b = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common)  # default None
+    fa = {d.get("side"): d["fused_fair"] for d in a["decisions"]}
+    fb = {d.get("side"): d["fused_fair"] for d in b["decisions"]}
+    assert fa == fb

--- a/backend/tests/test_kalshi_training.py
+++ b/backend/tests/test_kalshi_training.py
@@ -1,0 +1,73 @@
+"""Pure training core: sample gathering, calibrator fit/apply, evaluation."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import training
+
+
+def _model_fn(fx):
+    return fx["_probs"]
+
+
+def test_gather_from_settled_one_sample_per_side():
+    fx = [{"result": "home", "_probs": {"home": 0.6, "draw": 0.25, "away": 0.15}},
+          {"result": "draw", "_probs": {"home": 0.4, "draw": 0.3, "away": 0.3}}]
+    s = training.gather_samples_from_settled(fx, _model_fn)
+    assert len(s) == 6  # 2 games x 3 sides
+    # home side of game 1 happened -> outcome 1.0
+    assert (0.6, 1.0) in s and (0.25, 0.0) in s
+    # draw side of game 2 happened
+    assert (0.3, 1.0) in s
+
+
+def test_gather_from_settled_skips_unsettled():
+    fx = [{"result": None, "_probs": {"home": 0.5, "draw": 0.3, "away": 0.2}}]
+    assert training.gather_samples_from_settled(fx, _model_fn) == []
+
+
+def test_gather_from_decisions():
+    rows = [{"decision": "placed", "outcome": "win", "fused_fair": 0.7},
+            {"decision": "placed", "outcome": "loss", "fused_fair": 0.4},
+            {"decision": "skipped", "outcome": None, "fused_fair": 0.9},  # not placed
+            {"decision": "placed", "outcome": None, "fused_fair": 0.5}]   # open
+    s = training.gather_samples_from_decisions(rows)
+    assert s == [(0.7, 1.0), (0.4, 0.0)]
+
+
+def test_fit_identity_when_empty():
+    doc = training.fit_calibrator([])
+    assert doc["method"] == "identity" and doc["n_samples"] == 0
+    assert training.apply(doc, 0.42) == 0.42
+
+
+def test_fit_shrink_when_thin():
+    doc = training.fit_calibrator([(0.9, 1.0), (0.1, 0.0)], min_total=100)
+    assert doc["method"] == "shrink"
+    # shrink pulls toward 0.5
+    assert 0.5 < training.apply(doc, 0.9) < 0.9
+
+
+def test_fit_isotonic_when_enough_data():
+    # 120 samples where the model is systematically overconfident at the top:
+    # predicts 0.8 but only wins half the time -> isotonic should pull 0.8 down.
+    samples = [(0.8, 1.0 if i % 2 == 0 else 0.0) for i in range(60)]
+    samples += [(0.2, 1.0 if i % 5 == 0 else 0.0) for i in range(60)]
+    doc = training.fit_calibrator(samples, min_total=100)
+    assert doc["method"] == "isotonic" and doc["calibrator"]
+    assert training.apply(doc, 0.8) < 0.8   # overconfidence corrected downward
+
+
+def test_apply_is_monotone_and_bounded():
+    doc = training.fit_calibrator([(0.3, 0.0)] * 50 + [(0.7, 1.0)] * 80, min_total=100)
+    lo, hi = training.apply(doc, 0.2), training.apply(doc, 0.9)
+    assert 0.0 <= lo <= 1.0 and 0.0 <= hi <= 1.0
+    assert lo <= hi  # monotone
+
+
+def test_evaluate_reports_raw_and_calibrated():
+    samples = [(0.8, 0.0)] * 50 + [(0.8, 1.0)] * 50  # 0.8 pred, actual 50%
+    doc = training.fit_calibrator(samples, min_total=50)
+    ev = training.evaluate(samples, doc)
+    assert ev["n_eval"] == 100
+    # calibrating a badly-overconfident predictor lowers log-loss
+    assert ev["cal_logloss"] <= ev["raw_logloss"] + 1e-9

--- a/backend/tests/test_kalshi_training_worker.py
+++ b/backend/tests/test_kalshi_training_worker.py
@@ -1,0 +1,67 @@
+"""Training worker: the promotion gate (never ship a worse model) + self-heal loop."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import training_worker, db
+
+
+class FakeConn:
+    pass
+
+
+def _patch_registry(monkeypatch):
+    saved, champs = [], []
+    monkeypatch.setattr(db, "save_model_version", lambda conn, doc: saved.append(doc) or doc["id"])
+    monkeypatch.setattr(db, "set_champion", lambda conn, id, inst, kind="calibrator": champs.append(id))
+    return saved, champs
+
+
+def test_promotes_when_calibration_improves(monkeypatch):
+    saved, champs = _patch_registry(monkeypatch)
+    # overconfident predictor across two levels: says 0.8 but wins ~50%, says 0.2 but
+    # wins ~20% -> isotonic (needs >=2 distinct preds) corrects the 0.8 down.
+    def data():
+        return ([(0.8, 1.0 if i % 2 == 0 else 0.0) for i in range(60)]
+                + [(0.2, 1.0 if i % 5 == 0 else 0.0) for i in range(60)])
+    v = training_worker.refit_once(FakeConn(), "__default__", data(), data(),
+                                   new_id="v1", now_iso="t", min_total=100)
+    assert v["method"] == "isotonic"
+    assert v["promoted"] is True and champs == ["v1"]
+
+
+def test_does_not_promote_identity_or_no_data(monkeypatch):
+    saved, champs = _patch_registry(monkeypatch)
+    v = training_worker.refit_once(FakeConn(), "__default__", [], [],
+                                   new_id="v0", now_iso="t")
+    assert v["method"] == "identity" and v["promoted"] is False
+    assert champs == []            # nothing promoted
+    assert saved and saved[0]["id"] == "v0"   # but the version IS recorded
+
+
+def test_does_not_promote_when_worse(monkeypatch):
+    # Force a doc whose calibrated log-loss is WORSE than raw by monkeypatching fit
+    # to return a harmful shrink, and evaluate to report regression.
+    saved, champs = _patch_registry(monkeypatch)
+    monkeypatch.setattr(training_worker.training, "fit_calibrator",
+                        lambda s, **k: {"method": "shrink", "calibrator": None,
+                                        "shrink_strength": 0.9, "n_samples": len(s)})
+    monkeypatch.setattr(training_worker.training, "evaluate",
+                        lambda s, doc: {"raw_logloss": 0.60, "cal_logloss": 0.80,
+                                        "raw_brier": 0.2, "cal_brier": 0.3, "n_eval": len(s)})
+    v = training_worker.refit_once(FakeConn(), "__default__", [(0.7, 1.0)] * 10, [(0.7, 1.0)] * 10,
+                                   new_id="vbad", now_iso="t")
+    assert v["promoted"] is False and champs == []   # worse model rejected
+
+
+def test_start_worker_self_heals_on_conn_error(monkeypatch):
+    # First cycle raises a connection error, second succeeds -> loop reconnects.
+    calls = {"n": 0, "reconnected": 0}
+    def refit(conn):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("Connection is closed.")
+        return {"promoted": False}
+    monkeypatch.setattr(db, "reconnect", lambda c=None: calls.__setitem__("reconnected", calls["reconnected"] + 1) or FakeConn())
+    training_worker.start_worker(lambda: FakeConn(), refit, refresh_secs=0,
+                                 run_once_now=True, _max_cycles=2)
+    assert calls["n"] == 2 and calls["reconnected"] == 1

--- a/docs/superpowers/plans/2026-07-03-credit-safety-exit-fixes.md
+++ b/docs/superpowers/plans/2026-07-03-credit-safety-exit-fixes.md
@@ -1,0 +1,301 @@
+# Credit Safety, Exit Layer & P&L Levers — Round 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make credit exhaustion loud and safe, make risk exits real, make backtest P&L truthful, and ship the evidence-backed P&L levers (rotation graph-gate, concentration, overrides) from the three hunter reports.
+
+**Architecture:** Code changes land in `backend/llm_utils.py` (usage recording, 402 handling), `backend/llm_critical_guard.py` + `backend/live_critical_abort.py` (new critical class), new `backend/openrouter_credits.py` (balance guard), `backend/strategies/graph_nexus_analysis.py` (grace bypass, rotation gate, position caps, overlay attribution, outcomes tracking), `backend/broker.py` (P&L mark, max_positions gate, sell-proceeds crediting, backtest abort), `backend/live_mode_overrides.py` (two more user-overridable keys). Config levers + dead-secret scrub ship via a new one-shot apply script (dry-run default, `--apply` USER-GATED). Spec: `docs/superpowers/specs/2026-07-03-credit-safety-exit-fixes-design.md`.
+
+**Tech Stack:** Python 3 (`python3`), pytest (`backend/tests/`), RethinkDB prod via repo-root `.env`, OpenRouter API.
+
+## Global Constraints
+
+- **Real money adjacent:** graph_nexus_analysis.py / broker.py / live_mode_overrides.py run the live instance. Surgical edits only. NO prod-DB writes outside the Task-13 script's `--apply` (which nobody runs this session).
+- **Test hygiene (two prior incidents):** every test file that can reach alerts/notify/kill-switch/RethinkDB gets an AUTOUSE cage fixture stubbing those seams (pattern: `backend/tests/test_llm_critical_role_scope.py::cage_alerts`). No network, no prod DB, no real Discord.
+- **Real-config-pinned tests:** Track-2/5 strategy tests must build config from the committed snapshot `docs/superpowers/specs/2026-07-02-strategy-179-pre-tune-snapshot.json` via the Task-5 fixture helper, overlaid with the 2026-07 tune values where relevant (grace stays 14d) — never bare fixture defaults for keys the test's behavior depends on.
+- **GitNexus (CLAUDE.md):** `mcp__gitnexus__impact` (upstream) on each symbol BEFORE editing; `mcp__gitnexus__detect_changes` before every commit; report blast radius; warn on HIGH/CRITICAL. Load via ToolSearch `select:mcp__gitnexus__impact,mcp__gitnexus__detect_changes`.
+- Tests: `python3 -m pytest backend/tests/<file> -v` from repo root; socketio stub `sys.modules.setdefault("socketio", MagicMock())` before importing instance/broker modules.
+- Commit trailer verbatim last line: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Known pre-existing suite failures (do not chase): test_claude_cli_provider (15), test_live_calendar (2), test_models_api_ollama (1), test_nexus_v25 profit-take-once (1).
+- Key anchors (verified 2026-07-03, may drift ±lines): native usage read `llm_utils.py:246`; `_safe_record` + `_call_openrouter` ~:4586-4740; max_tokens default `_openrouter_effective_max_output_tokens` ~:1581-1614; `classify` `llm_critical_guard.py:63-110`; grace suppression writer emits `V31 grace period (day x/y): suppressed [...]` in `_evaluate_position_risk` (GNA ~:16415-16879); P&L wrap-up `broker.py:7102-7118`, dup-bar seeding `broker.py:7042-7099`, `_get_prices_at_time` `broker.py:6210-6240`; overlay workers GNA `:18135/:18258/:18335`, thread pool `:18618`; `llm_call_context` in `backend/llm_telemetry.py` (`_merge_active_ctx` :228); outcomes updater `_update_indefinite_outcomes` GNA `:9252-9316`; sell-first ordering `broker.py:8619-8631`, cached cash read `:8706`, earnings proceeds-credit pattern `:7519`; sizing `broker.py:9145-9176`; LIVE_OVERRIDES `backend/live_mode_overrides.py` (`_USER_OVERRIDABLE_KEYS`).
+
+---
+
+### Task 1: Record PydanticAI-native structured usage (spec 1a)
+
+**Files:**
+- Modify: `backend/llm_utils.py` (structured success path where `result.usage()` is read, ~:246 region and/or the structured-call wrapper that owns provider/model context)
+- Test: `backend/tests/test_native_structured_usage.py` (create)
+
+**Interfaces:**
+- Consumes: existing `_safe_record(provider=, model=, usage=, ok=, duration_ms=, retry_count=, error=, cost_usd_override=, model_id=)`; `record_llm_call` pricing-registry fallback (cost_source="models_override" path).
+- Produces: every PydanticAI-native structured SUCCESS records one usage row: provider, model, `usage={"input_tokens":…, "output_tokens":…, "reasoning_tokens":…}`, ok=True, `cost_usd_override=None` (registry/zero pricing; PydanticAI has no cost envelope). This is the $6.71-invisible-spend fix.
+
+- [ ] **Step 1: Locate the exact seam.** Read `llm_utils.py:200-320` (the `result.usage()` consumer) and the structured wrapper (`_call_structured_llm*` family) to find where a SUCCESSFUL native run returns with provider/model/timing in scope. Confirm which providers route through it (openrouter + azure + others). Run gitnexus impact on the function you'll touch.
+- [ ] **Step 2: Failing tests** — caged (no DB/network): fake a PydanticAI result object with `usage` (`request_tokens`/`response_tokens`/`details` per pydantic-ai 1.0.18 — check the real attr names on the installed version with `python3 -c "from pydantic_ai.usage import Usage; print(Usage.__dataclass_fields__ if hasattr(Usage,'__dataclass_fields__') else dir(Usage))"`), monkeypatch `_safe_record` with a recorder, call the seam function, assert one row with correct provider/model/tokens/ok=True. Second test: recording failure must not break the call (exception-safe). Third: the raw-fallback path does NOT double-record when native succeeds (one row per HTTP call remains the invariant — a native success is one call → one row).
+- [ ] **Step 3: RED** `python3 -m pytest backend/tests/test_native_structured_usage.py -v`
+- [ ] **Step 4: Implement** — extract tokens from the PydanticAI usage object (map request→input, response→output, details reasoning if present), wrap the whole recording in try/except, call `_safe_record`. Do NOT touch the failure paths (already recorded via LLMCriticalFailure flow) — guard against double-record there.
+- [ ] **Step 5: GREEN** new file + `backend/tests/test_openrouter_usage_tracking.py` + `backend/tests/test_openrouter_max_tokens.py` (must stay green).
+- [ ] **Step 6: detect_changes, commit** `fix(telemetry): record PydanticAI-native structured successes — most Nemotron spend was invisible`
+
+---
+
+### Task 2: 402 = insufficient_credits critical class (spec 1b)
+
+**Files:**
+- Modify: `backend/llm_critical_guard.py` (classify :63-110, `is_immediately_fatal` :143-145)
+- Modify: `backend/live_critical_abort.py` (handle — 402 is role-INDEPENDENT fatal: bypasses the article-role degrade)
+- Test: `backend/tests/test_insufficient_credits_critical.py` (create; reuse the autouse cage from test_llm_critical_role_scope.py verbatim incl. kill-switch seams)
+
+**Interfaces:**
+- Consumes: `LLMCriticalFailure(class_tag=…, provider=…, model=…, role=…)`; `role_is_halt_worthy(role)`.
+- Produces: `classify` returns class_tag `"insufficient_credits"` for HTTP 402 or body matching `re.compile(r"requires more credits|can only afford", re.I)`; `is_immediately_fatal` includes it; `handle()` treats it as halt-worthy REGARDLESS of role (article roles included — nothing runs without credits): live → existing halt path with halt_reason `"LLM critical: insufficient_credits"` + alert; the alert body must say "OpenRouter credits exhausted — top up at openrouter.ai/settings/credits".
+
+- [ ] **Step 1:** Read classify + the strategy-side catch sites (GNA company/macro catches from round 1 — they check `role_is_halt_worthy`; an article-role 402 must RE-RAISE, not degrade). Decide the cleanest override: `role_is_halt_worthy` stays role-based; add `failure_is_role_independent(failure) -> bool` (True for insufficient_credits) checked BEFORE the role check at every degrade site (live_critical_abort.handle + the two GNA catch sites).
+- [ ] **Step 2: Failing tests:** (a) classify 402 → insufficient_credits, immediately fatal; (b) handle() with role="macro_article" + insufficient_credits → HALT (not degrade), alert fired once via cage; (c) auth_failure with article role still degrades (round-1 behavior preserved); (d) body-regex variant without status code.
+- [ ] **Step 3-4: RED → implement → GREEN** (+ `test_llm_critical_role_scope.py` stays green — its degrade tests must not regress).
+- [ ] **Step 5:** GNA catch sites: add the `failure_is_role_independent` check (import from llm_critical_guard) before the degrade branch. detect_changes, commit `fix(llm-guard): 402 insufficient-credits is role-independent fatal — never trade LLM-blind`
+
+---
+
+### Task 3: Backtest pause on critical LLM failure (spec 1b, backtest side)
+
+**Files:**
+- Modify: `backend/broker.py` (the backtest per-day loop — find where `run_run_once_strategies` exceptions propagate in backtest mode; the June sim previously kept looping through 30 days of 402s)
+- Test: `backend/tests/test_backtest_credit_pause.py` (create)
+
+**Interfaces:**
+- Produces: when `LLMCriticalFailure` (any immediately-fatal class) escapes a backtest simulation day, the run STOPS: BacktestResults row updated `{status: "paused_credits", error: "<class_tag>: <human message>", paused_at_date: <sim date>}`, partial results preserved, Discord/push alert fired once (`alert_strategy_error` seam), process exits cleanly (no further sim days). Resumability = re-queue (the existing resume-date query skips processed days).
+
+- [ ] **Step 1:** Trace the backtest day loop: `grep -n "Historic lookback progress\|for.*trading_days\|BACKTEST" backend/broker.py | head -30`, then read the sim-day loop and its exception handling. Determine why 402s did NOT propagate (llm calls caught somewhere → empty results returned). The fix point: LLMCriticalFailure is a BaseException — verify the loop doesn't `except BaseException`/bare-except it; if the strategy-side catches degrade it (Task 2 fixed article roles; decision roles re-raise), the loop just needs a `except LLMCriticalFailure` → pause handler.
+- [ ] **Step 2: Failing test:** simulate the loop handler with a fake results-row writer + caged alerts: raise LLMCriticalFailure(insufficient_credits) from a stubbed run-once inside the extracted/patched loop body → assert status update payload + alert + loop termination. (Extract a `_pause_backtest_on_credit_exhaustion(rrow_id, failure, sim_date, conn)` helper for testability.)
+- [ ] **Step 3-4: RED → implement → GREEN.**
+- [ ] **Step 5:** detect_changes, commit `fix(backtest): pause with status=paused_credits on critical LLM failure instead of simulating blind`
+
+---
+
+### Task 4: Preflight balance guard + 402 de-cliff (spec 1c, 1d)
+
+**Files:**
+- Create: `backend/openrouter_credits.py`
+- Modify: `backend/llm_utils.py` (`_call_openrouter` 402 handling; `_openrouter_effective_max_output_tokens` pre-clamp), `backend/broker.py` (guard call at live FULL start + backtest start/every 5 sim days — co-locate with the Task-3 loop)
+- Test: `backend/tests/test_openrouter_credits_guard.py` (create)
+
+**Interfaces:**
+- Produces: `get_balance(api_key, timeout=5.0) -> float | None` (GET `https://openrouter.ai/api/v1/credits`, returns `total_credits - total_usage`; None on ANY error). `check_credit_guard(api_key, config, notify_fn) -> "ok"|"warn"|"halt"` using config keys `openrouter_low_credit_warn_usd` (default 3.0) / `openrouter_halt_credit_usd` (default 0.5), one-shot warn latch per process. De-cliff in `_call_openrouter`: on 402 whose body matches `can only afford (\d+)`, retry ONCE with `max_tokens=max(2048, N-512)`; second 402 → normal terminal failure (feeds Task-2 classify). Pre-clamp: when a cached balance is known and `< 32768 × price`, clamp the default max_tokens proportionally (only when balance-fetch succeeded).
+
+- [ ] **Step 1:** Verify the credits endpoint shape (`curl -s https://openrouter.ai/api/v1/credits -H "Authorization: Bearer $KEY"` — get the key from env/config at runtime, NEVER print it; the response is `{"data":{"total_credits":…,"total_usage":…}}` — confirm against docs/response).
+- [ ] **Step 2: Failing tests (all caged, requests mocked):** balance math; None-on-error (timeout, 500, bad JSON); guard thresholds (2.9→warn once, second call no re-warn; 0.4→halt); de-cliff retry (mock 402 body with "can only afford 10773" → second request carries max_tokens=10261 → 200 ok recorded); double-402 → terminal.
+- [ ] **Step 3-4: RED → implement → GREEN** (+ usage-tracking + max-tokens suites green).
+- [ ] **Step 5:** Wire guard calls: live FULL-run start (broker.py, near the FULL dispatch) and backtest start + every 5 sim days (Task-3 loop site) — `halt` result routes into the Task-2/3 critical paths. detect_changes, commit `feat(llm): OpenRouter credit guard (warn $3 / halt $0.50) + 402 affordability de-cliff`
+
+---
+
+### Task 5: Real-config test fixture (prereq for Tracks 2/5)
+
+**Files:**
+- Create: `backend/tests/nexus_real_config.py` (helper, not a test)
+- Test: `backend/tests/test_nexus_real_config.py` (create, trivial)
+
+**Interfaces:**
+- Produces: `def real_config(**overrides) -> dict` — loads `docs/superpowers/specs/2026-07-02-strategy-179-pre-tune-snapshot.json`, takes `["strategies"][0]["config"]`, overlays the 2026-07 tune deltas (`{"portfolio_drawdown_halt_pct": 8, "profitable_min_hold_conviction_override_enabled": False, "new_entry_reserved_budget_pct": 0.1, "cash_reserve_floor_pct": 0.02, "allocation_max_new_stock_buys": 10, "max_propagated_scoring_slots": 40, "max_positions": 10, "rotation_break_glass_delta": 2.5, "rotation_break_glass_raw_score": 3.5, "rotation_profitable_min_incoming_raw_score": 2.0}`), strips every key containing `key|secret|password|token` (defense in depth), then applies `overrides`. This makes strategy tests run against the REAL live config so config-vs-default divergence (the V31-grace blind spot) can't recur.
+
+- [ ] **Step 1:** Write helper + test asserting: grace-related keys present as in live (find the actual grace key names first: `grep -n "grace" backend/strategies/graph_nexus_analysis.py | grep -i "config\|get(" | head -20` — record the exact keys and their live values in the helper's docstring), `fast_loser_cut_pct == -10`, no secret-like keys, overrides win.
+- [ ] **Step 2: GREEN, commit** `test(nexus): real-config fixture from committed doc-179 snapshot`
+
+---
+
+### Task 6: Risk exits bypass V31 grace (spec 2a)
+
+**Files:**
+- Modify: `backend/strategies/graph_nexus_analysis.py` (the grace gate inside `_evaluate_position_risk` that logs `V31 grace period (day x/y): suppressed [<reason>]`)
+- Test: extend `backend/tests/test_nexus_evaluate_position_risk.py`
+
+**Interfaces:**
+- Consumes: `real_config(**overrides)` from Task 5; existing `_Emu` fixture pattern.
+- Produces: grace suppression applies ONLY to signal-driven sells. Risk-exit reasons (`Fast loser cut`, `Circuit breaker`, `Trailing stop`, `Hold-limit`) are exempt: when the pre-grace decision is one of these, the sell survives grace untouched (score −1, reason preserved, `_forced_exit` semantics intact).
+
+- [ ] **Step 1:** Read the grace gate: `grep -n "grace period" backend/strategies/graph_nexus_analysis.py` → read ±60 lines. Map how the suppressed reason string is captured (it's embedded in the log: `suppressed [Fast loser cut: …]`) — the gate sees the fresh_reason, so exemption = check `any(tag in reason for tag in _RISK_EXIT_TAGS)` where `_RISK_EXIT_TAGS = ("Fast loser", "Circuit breaker", "Trailing stop", "Hold-limit")` (verify exact strings from the emit sites :16657-16694 area). gitnexus impact on `_evaluate_position_risk`.
+- [ ] **Step 2: Failing tests (real_config — grace ACTIVE at its live value):**
+
+```python
+def test_circuit_breaker_fires_inside_grace_avgo():
+    """AVGO 2026-06: -13.79% on grace day 3 was suppressed to hold; must cut."""
+    cfg = real_config()
+    # entry 3 days ago, current price -13.79% below entry, fresh_score 0
+    ... assert score == -1 and ("Circuit breaker" in reason or "Fast loser" in reason)
+
+def test_signal_sell_still_suppressed_inside_grace():
+    """A plain negative-signal sell on grace day 3 stays suppressed (grace's purpose)."""
+    cfg = real_config()
+    ... entry 3 days ago, current -2%, fresh_score -1 (signal sell)
+    ... assert score != -1  # suppressed to hold, log contains 'grace'
+```
+
+(Copy the file's real invocation pattern; the first test MUST fail on current code — if it passes, the grace key isn't active in real_config: stop and re-check Task 5's key mapping before proceeding.)
+- [ ] **Step 3-4: RED → implement the tag-exemption at the gate → GREEN** (full file + test_nexus_v25 + v9_preflight suites; profit-take-once stays the known red).
+- [ ] **Step 5:** detect_changes (expect MEDIUM+ radius — FULL and MONITOR paths — proceed, it's the intended protective change), commit `fix(nexus): risk exits bypass V31 grace — grace only gates signal sells`
+
+---
+
+### Task 7: max_positions hard gate (spec 2b)
+
+**Files:**
+- Modify: `backend/broker.py` (order-emission loop, near :8619-8631) and/or GNA allocation if investigation shows the overshoot originates there
+- Test: `backend/tests/test_max_positions_gate.py` (create)
+
+**Interfaces:**
+- Produces: no NEW-name buy order is emitted when `len(current_positions) - len(sells_this_cycle_for_full_exit) + new_names_already_emitted >= max_positions`. Adds/winner-adds to EXISTING names are exempt. Blocked buys log `MAX_POSITIONS_GATE: blocked <sym> (held=N, cap=M)`.
+
+- [ ] **Step 1: Root-cause first.** 586767 peaked at 13 with cap 10. Investigate: does the allocation count queue/backfill buys against max_positions? Do rotation buys emit before their funding sells reduce the count? `grep -n "max_positions" backend/strategies/graph_nexus_analysis.py backend/broker.py | head -20`, read each gate. Write the finding in the report — the fix must target the real leak (likely: backfill-queue drain + rotation buys bypass the slate-level cap).
+- [ ] **Step 2: Failing test** on an extracted pure helper `def max_positions_gate(held_symbols, cap, planned_sells_full_exit, emitted_new_names, candidate) -> bool` + a wiring test with a fake emulator/order list asserting the 11th new name is blocked and logged.
+- [ ] **Step 3-4: RED → implement (helper + wire at emission) → GREEN.**
+- [ ] **Step 5:** detect_changes, commit `fix(broker): hard max_positions gate at order emission`
+
+---
+
+### Task 8: One truthful P&L + dup-bar fix (spec 3a)
+
+**Files:**
+- Modify: `backend/broker.py` (:7102-7118 wrap-up; :7042-7099 seeding)
+- Test: `backend/tests/test_backtest_pnl_consistency.py` (create)
+
+**Interfaces:**
+- Produces: (1) `final_value` derives from the LAST portfolio snapshot's own prices (`portfolio_emulator.get_portfolio_value(last_snapshot_prices)` or the snapshot's stored value) so `pnl`/`pnl_percent` == equity-curve end by construction; (2) the end-of-run seeding no longer appends a second same-date close per symbol (dedupe: keep the bar already present for that date; only append when the date is absent).
+
+- [ ] **Step 1:** Read :7020-7130. Identify exactly where the duplicate 07-01 bars enter `data` (the sibling report: "writes both the raw bar `c` and snapshot-derived prices"). gitnexus impact on the wrap-up function.
+- [ ] **Step 2: Failing test:** construct a minimal emulator with 2 positions + a `data` dict carrying DUPLICATE end-date bars with different closes + snapshots list; run the extracted wrap-up computation (extract `def compute_backtest_summary(emulator, snapshots, data, initial_cash) -> dict` if not already isolable); assert `summary["pnl"] == snapshots[-1]["value"] - initial_cash` exactly.
+- [ ] **Step 3-4: RED → implement both fixes → GREEN.**
+- [ ] **Step 5:** detect_changes, commit `fix(backtest): summary P&L uses the equity curve's own final mark; dedupe end-date bars`
+
+---
+
+### Task 9: Overlay call-site attribution (spec 3b)
+
+**Files:**
+- Modify: `backend/strategies/graph_nexus_analysis.py` (`_apply_trade_overlay` :18135ff, `_apply_etf_trade_overlay` :18335ff — the worker bodies submitted at :18618)
+- Test: `backend/tests/test_overlay_call_site_attribution.py` (create)
+
+**Interfaces:**
+- Consumes: `llm_telemetry.llm_call_context(call_site=…, instance_id=…, backtest_id=…)` (context manager; thread-local — must be entered INSIDE the worker function, not around the executor.submit).
+- Produces: overlay usage rows carry `call_site="overlay"` / `"overlay_etf"`; `(unset)` disappears for these paths.
+
+- [ ] **Step 1:** Read the two overlay functions + how sibling sites (sentiment :14437) enter the context INSIDE their workers; confirm what instance/backtest ids are in scope at the overlay call sites.
+- [ ] **Step 2: Failing test:** monkeypatch the telemetry recorder; invoke the overlay LLM-call wrapper (or a thin extraction of the worker body) on a fake executor (synchronous); assert the recorded row's call_site.
+- [ ] **Step 3-4: RED → wrap worker bodies → GREEN.** Keep `attribution_keys` (exception enrichment) untouched.
+- [ ] **Step 5:** detect_changes, commit `fix(telemetry): overlay LLM calls attribute call_site from worker threads`
+
+---
+
+### Task 10: Outcomes forward-tracking (spec 3c)
+
+**Files:**
+- Modify: `backend/strategies/graph_nexus_analysis.py` (`_update_indefinite_outcomes` :9252-9316 and/or its caller; `_save_trade_contexts_and_outcomes` for action_intent)
+- Test: `backend/tests/test_outcomes_forward_tracking.py` (create)
+
+**Interfaces:**
+- Produces: outcome rows' `latest_return` / `max_return_so_far` / `min_return_so_far` / `latest_observation_date` advance on subsequent days when a price is available (reuse `_outcome_entry_price`-style fallbacks — the held-only `prices` dict is suspect #1 again); `action_intent` persists the real intent (was 'unknown' on 870/877).
+
+- [ ] **Step 1: Root-cause.** Read `_update_indefinite_outcomes` + caller: why did 877 rows stay frozen (all with latest_observation_date == entry_date)? Suspects: (a) `prices` held-only again, (b) it only runs in live mode / a gate skips backtests, (c) exact-scope query mismatch, (d) writes swallowed. Verify against the 586767 rows READ-ONLY (prod query allowed). State the mechanism in your report before coding.
+- [ ] **Step 2: Failing test** against the extracted update logic with fake rows + a prices source: day-2 update advances latest_return and dates; missing price leaves row untouched (no regression to zeros).
+- [ ] **Step 3-4: RED → fix (price fallback and/or gate) → GREEN** (+ test_nexus_outcome_entry_price.py stays green).
+- [ ] **Step 5:** detect_changes, commit `fix(nexus): outcome rows track forward returns; persist real action_intent`
+
+---
+
+### Task 11: LIVE_OVERRIDES user-overridable keys #2/#3 (spec 5.6)
+
+**Files:**
+- Modify: `backend/live_mode_overrides.py` (`_USER_OVERRIDABLE_KEYS`)
+- Test: extend `backend/tests/test_live_overrides_drawdown.py`
+
+**Interfaces:**
+- Produces: explicit doc-179 values for `quality_filter_missing_metadata_policy` and `break_glass_fresh_shield_enabled` survive live-override application; absent keys still get the live defaults ("block" / True).
+
+- [ ] **Step 1: Failing tests** (mirror the existing drawdown tests): explicit "warn" survives; explicit False survives; absent → "block"/True; other overrides unchanged.
+- [ ] **Step 2-3: RED → add both keys to the frozenset (+ docstring note on why each is operator-owned) → GREEN.**
+- [ ] **Step 4:** detect_changes, commit `fix(live-overrides): quality-filter policy + fresh-shield are operator-owned when explicitly set`
+
+---
+
+### Task 12: Rotation graph-gate + single-position cap (spec 5.1 code, 5.7)
+
+**Files:**
+- Modify: `backend/strategies/graph_nexus_analysis.py` (rotation candidate selection — `_rotation_candidate_allowed` ~:7524 region and the backfill-rotation outgoing-position picker; buy/winner-add/amplifier sizing sites for the cap)
+- Test: `backend/tests/test_rotation_graph_gate.py` (create), extend `backend/tests/test_nexus_evaluate_position_risk.py` only if cap logic lands nearby
+
+**Interfaces:**
+- Consumes: `real_config(**overrides)` (Task 5).
+- Produces: (1) a position whose CURRENT raw graph signal is positive (`raw_net > 0` — find the exact per-symbol field the rotation picker sees) cannot be selected as a rotation-funding sell, regardless of winner-lock-bypass thresholds; log `ROTATION_GRAPH_GATE: kept <sym> (raw=+x.xx)`. (2) `single_position_max_pct` (live value 25) enforced: any buy/add/amplifier order that would push `position_value / portfolio_total > pct/100` is clipped to the cap (partial fill of the intent, or skipped if already ≥ cap), logged `SINGLE_POS_CAP: clipped <sym>`.
+
+- [ ] **Step 1:** Read the rotation outgoing-position selection (grep `backfill_rotation|_rotation_candidate|winner_lock_bypass` in GNA) and the three add paths (initial sizing, `_plan_winner_adds` :8061ff, momentum amplifier :18457 region). gitnexus impact on each function you'll touch. Map where current raw score per held symbol is available to the rotation picker.
+- [ ] **Step 2: Failing tests:** (a) held AMAT-like position raw=+0.284, pnl +9%, all bypass thresholds met → NOT selected for rotation; (b) raw=−0.5 same pnl → selected (rotation still works); (c) buy that would create a 30% position on a $6k portfolio → clipped to 25%; (d) winner-add pushing 24%→28% → clipped to 25%.
+- [ ] **Step 3-4: RED → implement → GREEN** (risk suite + rotation-adjacent suites).
+- [ ] **Step 5:** detect_changes, commit `feat(nexus): rotation respects positive graph signal; wire single_position_max_pct as a real cap`
+
+---
+
+### Task 13: Sell-proceeds crediting in live cycles (spec 5.8)
+
+**Files:**
+- Modify: `backend/broker.py` (the submit loop :8619-8706 region; mirror the earnings-proceeds pattern at :7519)
+- Test: `backend/tests/test_live_sell_proceeds_credit.py` (create)
+
+**Interfaces:**
+- Produces: within one live cycle, after sell orders are submitted, the buy-affordability ceiling = `cached_cash + 0.95 × Σ(expected proceeds of this cycle's submitted sells)` (0.95 partial-fill haircut), never exceeding `cash + proceeds`. Backtest path unchanged (emulator already credits synchronously). Config kill-switch `live_credit_sell_proceeds_enabled` default True.
+
+- [ ] **Step 1:** Read :8590-8720 (ordering + cash read) and the earnings pattern :7519. Confirm sells are identified before buys in `_exec_order` and their qty×price is computable at submit time.
+- [ ] **Step 2: Failing test** on an extracted `def buy_ceiling(cached_cash, submitted_sells, enabled=True, haircut=0.95) -> float` + a wiring test with fake adapter: cycle with $840 cash + $1,388 sells → buys see $2,158.60 ceiling; disabled → $840.
+- [ ] **Step 3-4: RED → implement → GREEN.**
+- [ ] **Step 5:** detect_changes, commit `feat(broker): live rotation buys may spend same-cycle sell proceeds (95% haircut)`
+
+---
+
+### Task 14: Round-2 apply script — config levers + dead-secret scrub (spec 5.2-5.5, 5.9, 5.10, 5.1-config)
+
+**Files:**
+- Create: `backend/scripts/apply_round2_2026_07.py`
+- Test: `backend/tests/test_apply_round2_2026_07.py`
+
+**Interfaces:**
+- Consumes: patterns from `backend/scripts/apply_tune_2026_07.py` (argparse --apply gating, `_fp` redaction, scrubbed `raise … from None`, snapshot dump, `nexus_restamp.preview_change`).
+- Produces: one-shot script, dry-run default, USER-GATED apply. Changes to `strategies[0].config`:
+
+```python
+R2_CHANGES = {
+    "max_positions": 8,                                   # was 10 (5.2)
+    "allocation_max_new_stock_buys": 6,                    # was 10 (5.2)
+    "profitable_min_hold_release_peak_drop_pct": 12,       # was 8 (5.3)
+    "backfill_rotation_winner_lock_bypass_max_held_pnl_pct": 3,  # was 10 (5.1)
+    "backfill_rotation_min_hold_days": 15,                 # was 10 (5.1)
+    "backfill_budget_reserve_pct": 0.1,                    # was 0.2 (5.9)
+    "macro_risk_scale_min": 0.9,                           # was 0.8 (5.5) — VERIFY exact key name in GNA first
+    # ETF sleeve (5.4): VERIFY the real key (budget-split log says etf_pct=0.20;
+    # grep GNA for the config key behind it) then 0.20 -> 0.05
+}
+DELETE_KEYS_WITH_SECRETS = [  # dead keys carrying live credentials (5.10) — verified dead by config archaeology
+    # every strategies[0].config key matching r".*_llm_azure_openai_(api_key|endpoint|api_version|model_id)$"
+    # for roles analyst_panel, company_article, event_maintenance, macro_article, overlay, sentiment, lookback_*
+]
+```
+
+- [ ] **Step 1:** VERIFY the two flagged key names by reading GNA (`grep -n "macro_risk_scale_min\|etf_pct\|etf_portfolio" backend/strategies/graph_nexus_analysis.py`) — if a key doesn't exist in code, DO NOT include it (report instead; a dead-key write is the exact disease this round treats). Confirm each DELETE key has zero code references (`grep -c` per key) and matches the secret-family regex.
+- [ ] **Step 2: Tests** on pure `build_round2_strategies(doc179) -> (proposed, diff_rows, deleted_keys)`: every change lands; deletions only hit regex-matching dead keys; secrets never in diff output (fingerprints only); untouched spot-checks (fast_loser_cut_pct −10, single_position_max_pct still present — Task 12 now reads it!, grace keys untouched).
+- [ ] **Step 3: GREEN → dry-run against prod** (read-only): print full diff + preview_change verdict (these keys are in NO identity hash — expect needs_prompt=False / no restamp; if preview says otherwise, STOP and report).
+- [ ] **Step 4:** detect_changes, commit `feat(scripts): round-2 config levers (concentration, winner room, reserves, macro floor) + dead-secret scrub`. Do NOT run --apply.
+
+---
+
+### Task 15: PR + runbook + Track 4 rerun (process; deploy/apply USER-GATED)
+
+- [ ] **Step 1:** Full suite `python3 -m pytest backend/tests/ -q` — green minus the 4 known pre-existing files; verify at merge-base if any NEW failure looks suspicious.
+- [ ] **Step 2:** Final whole-branch review (SDD flow), fix wave if needed.
+- [ ] **Step 3:** Push branch, open PR titled `fix(live): credit safety, risk-exit grace bypass, truthful backtest P&L + P&L levers`, admin-merge per repo convention.
+- [ ] **Step 4 (runbook, user-gated):** user tops up OpenRouter credits + rotates key → Dokploy backend restart (also revives the dead instance spawner) → `python3 -m backend.scripts.apply_round2_2026_07 --apply` pre-market → instance boots (module_drift rebuild expected — new GNA code) → verify: risk exits fire inside grace (watch first FULL run), credit guard logs balance, no `(unset)` call sites.
+- [ ] **Step 5 (Track 4):** re-queue the June-2026 replay (same params as 586767); on finish, compare pnl (now single-mark) vs SPY vs live June; write results into `docs/superpowers/specs/2026-07-02-nemotron-baseline-results.md` as "Run 2 (valid)". Only then decide the gpt-5.4-mini model A/B.
+
+---
+
+## Verification (after all tasks)
+
+1. Suite green (minus 4 known). 2. All new tests use cages + real-config fixture where specified. 3. The three hunter top-levers each map to a shipped task (5.1→12/14, exec#3→13, S2→12, clobbers→11) or an explicit deferral in the spec. 4. Report to user: shipped list, gated runbook, deferred levers.

--- a/docs/superpowers/plans/2026-07-03-kalshi-training-pipeline.md
+++ b/docs/superpowers/plans/2026-07-03-kalshi-training-pipeline.md
@@ -1,0 +1,48 @@
+# SP1 Learning-Loop Backbone — Implementation Plan
+
+**Goal:** Wire a continuous, self-supervised isotonic-calibration loop onto the
+existing physical model: settled outcomes → refit → registry champion → engine
+applies it to fair value. Degrade-safe, never ships a worse model.
+
+**Tech:** Python 3.14, RethinkDB, pytest. Reuse `calibration.py` (isotonic/shrink)
+and the PR#84 reconnect/self-heal pattern.
+
+## Global Constraints
+- Degrade-safe: any failure → identity calibrator, never crash engine/worker.
+- Promotion gated on held-out log-loss not regressing (never ship worse).
+- No look-ahead: worker only ever sees already-settled games; train/test split by fixture.
+- Calibration is monotone in [0,1]; renormalize the winner group after applying.
+
+## Tasks
+
+### Task 1: `kalshi/training.py` — pure sample/fit/eval core
+- `gather_samples_from_settled(fixtures, model_fn)` → `[(pred, 0/1)]`, one per side of each settled fixture.
+- `gather_samples_from_decisions(rows)` → `[(pred,0/1)]` from placed+settled decisions (fused_fair, outcome).
+- `fit_calibrator(samples, *, min_total=100)` → registry doc `{method, calibrator|null, shrink_strength, n_samples}` via `calibration.calibrate`/`fit_isotonic`.
+- `evaluate(samples, doc)` → `{raw_logloss, cal_logloss, raw_brier, cal_brier, n_eval}` (applies doc's calibrator).
+- `apply(doc, p)` → calibrated prob (isotonic interp or shrink or identity).
+- Tests: `tests/test_kalshi_training.py` — isotonic vs shrink selection, evaluate math, apply monotonic, empty/thin degrade to identity.
+
+### Task 2: `kalshi/db.py` — registry table + writers
+- Add `("KalshiModelRegistry", "id")` to `KALSHI_TABLES`.
+- `save_model_version(conn, doc)`, `get_champion(conn, instance_id, kind="calibrator")` (instance → `__default__` fallback), `set_champion(conn, id, instance_id, kind)` (clears prior champion for that scope+kind).
+- Tests: `tests/test_kalshi_model_registry.py` with a fake conn — save, champion get/set, fallback.
+
+### Task 3: `kalshi/training_worker.py` — background refit loop
+- `refit_once(conn, instance_id, *, provider, model_fn, min_total, promote=True)`: gather settled → split train/test by fixture → fit(train) → evaluate(test) → save version → promote iff `cal_logloss <= raw_logloss`. Returns the doc. Pure-ish (provider/model_fn injected).
+- `start_worker(conn_factory, ...)`: self-heal loop (mirror `backtest_worker`): boot refit + periodic + `kalshi_decisions` settlement changefeed; reconnect on drop; notify on promotion via `notifications.notify` (best-effort).
+- Tests: `tests/test_kalshi_training_worker.py` — `refit_once` promotes only on improvement (fake provider/model_fn/conn); worse calibrator rejected.
+
+### Task 4: engine + orchestrator integration
+- `orchestrator.plan_and_allocate`: new `calibrator: dict|None=None` kwarg; after market-anchor block, if calibrator, apply to each `fused["winner"][side]` then `renormalize_group`. None → no-op.
+- `engine.run_instance`: load champion calibrator into `_calibrator` on boot + every 60 ticks (degrade to None on failure); pass to `plan_and_allocate`.
+- `EngineConfig`: none needed (registry read by instance_id). Runner: start the training worker thread alongside the engine.
+- Tests: orchestrator applies calibrator (fair shifts toward calibrated, renormalized); None = identical to before.
+
+### Task 5: API endpoint
+- `GET /brokerages/{bid}/kalshi/instances/{id}/model` → champion doc + reliability buckets (predicted vs actual from recent settled samples). Degrade to `{champion:null}`.
+- Test: endpoint shape with a fake champion.
+
+### Task 6: startup wiring + smoke
+- Runner starts the training worker (daemon) using the same conn_factory pattern.
+- Full backend test sweep green; `refit_once` smoke on the real cached settled WC games shows calibrated ≤ raw log-loss.

--- a/docs/superpowers/specs/2026-07-02-strategy-179-pre-tune-snapshot.json
+++ b/docs/superpowers/specs/2026-07-02-strategy-179-pre-tune-snapshot.json
@@ -207,7 +207,7 @@
         "allocation_profile": "conviction",
         "allocation_top2_min_raw_score": 0.5,
         "alpaca_key": "AK\u2026(len 26)",
-        "alpaca_secret": "JD\u2026(len 44)",
+        "alpaca_secret": "qs\u2026(len 43)",
         "analyst_panel_cache_enabled": true,
         "analyst_panel_cooldown_seconds": -1,
         "analyst_panel_debate_style": "adversarial",

--- a/docs/superpowers/specs/2026-07-03-credit-safety-exit-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-03-credit-safety-exit-fixes-design.md
@@ -131,14 +131,49 @@ After deploy + user tops up credits: rerun the June-2026 replay (same params). T
 — with credits, working exits, true P&L — is the first valid Nemotron baseline. Compare
 against SPY and live June; THEN decide whether a model A/B is warranted.
 
-### Track 5 — P&L levers (pending hunter reports)
+### Track 5 — P&L levers (finalized from the three hunter reports, 2026-07-03)
 
-Three Opus agents are mining trade economics, config archaeology (incl. dead keys +
-LIVE_OVERRIDES clobbers), and execution/cadence (open-auction drag, reserve stacking,
-order sequencing). Their ranked levers get appended here; adopt the top items whose
-evidence is strong and risk is low; config-only levers ship in the same apply-script
-pattern as the 2026-07 tune. This section will be finalized before the implementation
-plan is written.
+Core finding (trade economics): the strategy's historical +180–266% came from a fat
+right tail — winners averaging +14–21%, held 14–28d, with 8–10 wins >+50% per run. In
+586767, 27 of 28 exits were MECHANICAL rotations ejecting graph-HOLD-rated positions at
++3–10% (AMAT rotated at +9.3%, ran +30% in 12d); holding each exit +10 trading days
+flips June −2.3% → +2.3%. The exit machinery, not entry signal, kills the tail.
+
+**ADOPTED (this round):**
+
+| # | Lever | Change | Kind |
+|---|---|---|---|
+| 5.1 | Rotation respects the graph | Code gate: never rotate out a position whose current raw graph signal is positive (rotation may only eject negative/neutral-signal names); tighten `backfill_rotation_winner_lock_bypass_max_held_pnl_pct` 10→3 and `backfill_rotation_min_hold_days` 10→15 | code + config |
+| 5.2 | Re-concentrate | `max_positions` 10→8, `allocation_max_new_stock_buys` 10→6 (matches all three historical winners; reverses part of the 2026-07 tune — the June evidence shows slot scarcity was an EXIT problem, and 2b's enforcement makes 8 real) | config |
+| 5.3 | Winners' breathing room | `profitable_min_hold_release_peak_drop_pct` 8→12 (the +266% value; supports 5.1's fat-tail goal) | config |
+| 5.4 | Trim ETF sleeve | ETF budget mix 0.2→0.05 (June: 18% win rate, −$598; the +266% run traded ~0 ETFs) | config |
+| 5.5 | Macro-scale floor | `macro_risk_scale_min` 0.8→0.9 (LLM strength-weights bearish 1.47×; June budget was pinned at the 0.8 floor in an up-tape) | config |
+| 5.6 | LIVE_OVERRIDES clobbers #2/#3 | Add `quality_filter_missing_metadata_policy` and `break_glass_fresh_shield_enabled` to `_USER_OVERRIDABLE_KEYS` (live currently forces "block"/shield-on against doc-179's explicit values — the "block" clobber silently narrows the LIVE buy universe vs every backtest) | code + tests |
+| 5.7 | Single-position cap | Wire `single_position_max_pct` (25) as a REAL cap at buy/winner-add/amplifier time — currently a dead key; no concentration cap exists at all while the momentum amplifier is silently ON | code |
+| 5.8 | Same-cycle sell-proceeds crediting (live) | Live sells only free cash on async fill, so rotation-day buys can't use the proceeds (works in backtest — divergence): credit expected proceeds of already-submitted sells to the buy ceiling within the cycle, mirroring the existing earnings-path pattern (broker.py:7519); guard partial fills conservatively (credit ×0.95, cap at cash+proceeds) | code |
+| 5.9 | Reserve de-stack | `backfill_budget_reserve_pct` 0.2→0.1 (stacks multiplicatively with the cash floor; day-1 deploy was $72k on $100k) | config |
+| 5.10 | Dead-key secret scrub | Delete from doc 179 ONLY the dead `*_llm_azure_openai_*` key family + other dead keys carrying live secrets (they are read by nothing; leaving credentials in dead config rows is pure exposure) | apply-script |
+
+**DEFERRED (explicit, with reasons):**
+- Buying-power/margin sizing (7.5× deployable capital): a leverage decision for the
+  user, not an optimization — flag only. Amplifies losses on an unproven edge.
+- VWAP/limit execution (~65 bps vs VWAP but ~$100–170/mo at $6k; delay-to-10:30
+  measured flat — no cheap win) and intraday signal-sells / second FULL run (new
+  trading code paths) — next round.
+- Full bear-regime ladder + trailing-stop ratchet wiring (operator's configured
+  protections are DEAD KEYS — documented as known-dead in this spec; the 8% halt +
+  circuit breaker remain the active protections; proper wiring is its own project).
+- Momentum amplifier: left ON deliberately (operator's "off" key is a dead typo, but
+  the amplifier was ON in all historical winners and pyramids winners — consistent
+  with the fat-tail goal; 5.7's cap bounds its risk).
+- `new_entry_reserved_budget_pct` back to 0.3, Benzinga re-enable, drawdown 12%,
+  nexus_ml, analyst panel: insufficient/conflicting evidence or pending user actions.
+- Model swap to gpt-5.4-mini: this is the A/B question — decide AFTER the Track-4
+  valid baseline rerun, holding config constant.
+
+Config levers (5.1-partial/5.2/5.3/5.4/5.5/5.9) + 5.10 ship via a new one-shot apply
+script (same --dry-run/--apply/snapshot/restamp-check pattern as apply_tune_2026_07;
+none of these keys are in the identity hashes except none — verify via preview).
 
 ## 5. Testing
 

--- a/docs/superpowers/specs/2026-07-03-credit-safety-exit-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-03-credit-safety-exit-fixes-design.md
@@ -1,0 +1,163 @@
+# Credit Safety, Exit Layer & Metrics Integrity — Fix Round 2
+
+**Date:** 2026-07-03
+**Status:** Approved (user, 2026-07-03), Track 5 pending P&L-hunter findings
+**Predecessor:** `2026-07-02-live-underperformance-fix-design.md` (fix round 1, shipped as PRs #81/#82/#83)
+
+## 1. Problem
+
+Backtest 586767 (June-2026 replay, tuned config, Nemotron, fixed-code image) exposed five
+new defects — three of them invalidate the run as a baseline and two are live-money risks:
+
+1. **OpenRouter credits ran out mid-run and nothing noticed.** 195 calls failed with
+   HTTP 402 from 19:11Z onward; the ENTIRE June trade simulation (19:16–19:42Z) ran
+   LLM-blind (no overlay on 100% of rows, active-event set decayed to empty from 06-03,
+   only Bedrock company sentiment surviving). The run produced a full month of misleading
+   results with zero alerts. User's account: $10 top-up (06-29) → −$0.01.
+2. **~$6.71 of ~$9.25 real spend was invisible** on the cost dashboard ($2.54 recorded):
+   calls succeeding through the PydanticAI-native structured path record NO usage row
+   (known PR #82 gap); only plain-path and raw-JSON-fallback calls record.
+3. **PR #83's blanket `max_tokens=32768` created a hard credit cliff:** OpenRouter's
+   preflight requires affording max_tokens×output-price (~$1.30 for Nemotron), so once
+   balance < that, EVERY call 402s ("can only afford 10773" × 195) even though real calls
+   cost ~$0.01.
+4. **The V31 14-day grace period vetoes ALL risk exits.** Verified: `V31 grace period
+   (day 3/14): suppressed [Fast loser cut: −10.x%]`; zero protective sells in the whole
+   run (and zero EVER live); AVGO breached −10% three straight closes, exited −16.88% by
+   sentiment. Median hold 10d < grace 14d → the exit layer effectively does not exist.
+   Round-1's regression tests missed it because fixtures didn't include the grace config
+   (config-vs-default divergence).
+5. **Metrics integrity:** (a) headline P&L −2.32% vs equity-curve +0.44% — the summary
+   re-marks open positions against DUPLICATE end-date bars (two 2026-07-01 closes per
+   symbol; equity curve uses one, `_get_prices_at_time` picks the other, ≈$2,756 lower);
+   the truthful number is +0.44%. (b) `(unset)` call-site on $0.60 of spend — overlay
+   calls run in a ThreadPoolExecutor without `llm_call_context`; `attribution_keys` only
+   feeds the exception, never telemetry. (c) Outcomes forward-tracking inert:
+   entry_price now writes (877/877) but latest/max/min returns stay 0 and
+   latest_observation_date never advances. (d) `max_positions=10` not enforced (peaked
+   13, rotation overlap).
+
+Also verified WORKING (round-1 fixes): sentiment healthy all 108 days (no token-limit
+errors), outcomes entry_price populated, usage rows for plain/fallback paths with
+accurate token accounting (Nemotron genuinely burns ~99.7% of completion on reasoning),
+8% halt armed and correctly not triggered (−6.11% max from peak).
+
+## 2. Goals
+
+- No LLM-blind trading, ever: credit exhaustion halts work loudly instead of degrading it.
+- The cost dashboard equals the OpenRouter bill.
+- Risk exits actually protect positions, in backtest and live, with tests pinned to the
+  REAL live config values.
+- One truthful P&L number per backtest.
+- (Track 5) Adopt the highest-confidence P&L levers surfaced by the three opportunity
+  hunters (trade economics / config archaeology / execution & cadence).
+
+## 3. Non-goals
+
+- Enabling nexus_ml, analyst panel, or margin sizing without Track-5 evidence.
+- UI redesigns; Benzinga renewal (user action); OpenRouter key rotation (user action).
+
+## 4. Design
+
+### Track 1 — Credit safety
+
+**1a. Record PydanticAI-native structured successes.** In the structured-call success
+path (llm_utils.py, where `result.usage()` is already read at ~:246), call the same
+`_safe_record` used by `_call_openrouter`: provider/model/tokens (input, output,
+reasoning subset)/duration/ok=True. Cost: PydanticAI does not expose OpenRouter's
+`usage.cost` envelope → price from the model registry when available, else record
+tokens with cost_source="registry_missing" — NEVER drop the row. All providers routed
+through the PydanticAI path benefit, closing the $6.71-class hole.
+
+**1b. 402 = critical.** `llm_critical_guard.classify`: new class `insufficient_credits`
+(HTTP 402 or body matching `requires more credits|can only afford`), immediately fatal,
+role-independent (unlike article-role degrade — no role can run without credits).
+Live: halts instance (existing kill-switch path) with halt_reason
+"LLM critical: insufficient_credits" + Discord/push. Backtest: aborts the run with
+status="paused_credits" (resumable) + Discord/push; must NOT keep simulating days.
+
+**1c. Preflight balance guard.** New `backend/openrouter_credits.py`:
+`get_balance(api_key) -> float|None` (GET /api/v1/credits, 5s timeout, None on any
+error — the guard degrades to reactive-402 mode, never blocks on its own failure).
+Checked at: live FULL-run start, backtest start AND every N simulated days (N=5).
+Config keys (doc-179, code defaults): `openrouter_low_credit_warn_usd=3.0` (one
+warning notification per process per threshold-cross), `openrouter_halt_credit_usd=0.5`
+(same critical path as 1b, but proactive).
+
+**1d. De-cliff max_tokens.** In `_call_openrouter` + the structured settings path: on
+HTTP 402 whose body carries "can only afford N", retry ONCE with
+`max_tokens=max(2048, N−512)`; if the retry also 402s → escalate per 1b. Additionally,
+when a preflight balance is known and < (32768 × price), pre-clamp instead of relying
+on the 402 round-trip.
+
+### Track 2 — Exit layer
+
+**2a. Risk cuts bypass V31 grace.** In `_evaluate_position_risk`'s grace gate (the
+`V31 grace period (day x/y): suppressed [...]` writer): grace continues to suppress
+SIGNAL-driven sells but must not suppress fast_loser_cut, circuit-breaker
+(max_open_loss), trailing-stop, or hold-limit exits. Regression tests MUST build config
+from the actual doc-179 inner values (grace 14d active, fast_loser −10, circuit −15)
+— add a fixture helper that loads the committed pre-tune snapshot JSON so
+config-vs-default divergence can't blind tests again. Include the AVGO scenario
+(−13.79% on day 3 of grace → cut fires) and the suppressed-hold inverse for a plain
+negative-signal sell inside grace.
+
+**2b. Enforce max_positions.** Find why 13 concurrent positions existed with
+max_positions=10 (rotation buy executing before the funding sell settles / backfill
+queue bypass). Enforcement: a hard gate at order-emission time — no NEW-name buy when
+current position count ≥ max_positions (rotation pairs count net). Log + context-reason
+when the gate blocks.
+
+### Track 3 — Metrics integrity
+
+**3a. One truthful P&L.** broker.py backtest wrap-up (~:7102): derive `final_value`
+from the last portfolio snapshot's own marks (`get_portfolio_value(snapshots[-1].prices)`
+or the snapshot value itself) so row `pnl`/`pnl_percent` equals the equity curve by
+construction. ALSO fix the duplicate end-date bar seeding (~:7042-7099) so `data`
+carries one close per symbol per day (root cause).
+
+**3b. Overlay attribution.** Wrap `_apply_trade_overlay` / `_apply_etf_trade_overlay`
+worker bodies in `with llm_call_context(call_site="overlay"/"overlay_etf", ...)` (the
+thread-pool workers have no ambient context). Keep `attribution_keys` for exceptions.
+
+**3c. Outcomes forward-tracking.** Root-cause why `_update_indefinite_outcomes` leaves
+latest/max/min returns at 0 with observation date == entry date (suspects: prices dict
+again, scope filter, or it never runs in the backtest loop) and fix; also populate
+`action_intent` (870/877 'unknown').
+
+### Track 4 — Valid baseline rerun
+
+After deploy + user tops up credits: rerun the June-2026 replay (same params). This run
+— with credits, working exits, true P&L — is the first valid Nemotron baseline. Compare
+against SPY and live June; THEN decide whether a model A/B is warranted.
+
+### Track 5 — P&L levers (pending hunter reports)
+
+Three Opus agents are mining trade economics, config archaeology (incl. dead keys +
+LIVE_OVERRIDES clobbers), and execution/cadence (open-auction drag, reserve stacking,
+order sequencing). Their ranked levers get appended here; adopt the top items whose
+evidence is strong and risk is low; config-only levers ship in the same apply-script
+pattern as the 2026-07 tune. This section will be finalized before the implementation
+plan is written.
+
+## 5. Testing
+
+- Test-hygiene rules from round 1 (autouse cages; no prod side effects) are mandatory.
+- Track-2 tests pinned to real doc-179 values via the committed snapshot fixture.
+- 402/preflight paths: caged requests mocks incl. the exact OpenRouter 402 body.
+- P&L fix: regression test constructing duplicate end-date bars and asserting
+  summary == equity-curve final.
+
+## 6. Risks
+
+- 1b live-halt on 402 is deliberate fail-closed: a credit outage stops trading rather
+  than trading blind. Mitigated by 1c warnings at $3.
+- 2a changes live exit behavior: the change direction is protective (more exits), but a
+  false-positive cut costs real P&L — tests pin thresholds; grace still governs signal
+  sells.
+- 3a changes reported backtest P&L for future runs (historical rows untouched).
+
+## 7. User actions
+
+- Top up OpenRouter credits (Auto Top-Up recommended) BEFORE live restart or rerun.
+- Rotate the exposed OpenRouter key.

--- a/docs/superpowers/specs/2026-07-03-kalshi-training-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-03-kalshi-training-pipeline-design.md
@@ -1,0 +1,113 @@
+# Kalshi Self-Improving Training Pipeline — Design
+
+**Status:** SP1 (learning-loop backbone) specced for build; SP2/SP3 outlined.
+**Date:** 2026-07-03
+
+## Goal
+Make the Kalshi soccer model *learn from its own settled results continuously*, so
+its probabilities get better-calibrated over time and the sharp/model blend earns
+its weight — instead of a frozen, hand-tuned model. Approach A: a versioned model
+**registry** + a **training worker** that refits on a schedule and on each
+settlement; the trading engine just loads the current champion + calibrator.
+
+## Why now (environment facts, verified)
+- `calibration.py` is a complete, tested isotonic + shrink calibrator, explicitly
+  "data-blocked, made ready" — nothing wires it in. The engine applies **no**
+  calibration today.
+- Every settled Kalshi WC market yields a **free** final score (ground truth), so
+  the loop trains on real data even in this simulated environment.
+- External historical data (`soccerdata`) is **not installed** and the sim blocks
+  real historical scrapes — so SP3 (feature enrichment) is built degrade-safe and
+  validated only in a real deployment. SP1/SP2 do not depend on it.
+
+## Decomposition (each ships working software)
+- **SP1 — Learning-loop backbone (THIS SPEC):** registry + training worker + wire
+  the isotonic calibrator onto the existing physical model + evaluation harness.
+- **SP2 — Learned model + ensemble:** feature vector + learned classifier +
+  ensemble blend + rank physical/learned/ensemble → auto-champion.
+- **SP3 — External-data enrichment:** `soccerdata` → feature store (form, xG,
+  lineups, player availability), degrade-safe.
+
+---
+
+# SP1 — Learning-loop backbone
+
+## Components (each a focused, testable unit)
+
+### 1. Model registry (`kalshi/db.py` + new table `KalshiModelRegistry`)
+Versioned rows, pk `id`:
+```
+{ id, instance_id, created_at, kind: "calibrator",
+  calibrator: [[pred, calibrated], ...] | null,   # isotonic breakpoints, or null=shrink-only
+  shrink_strength: float,                          # fallback when data-thin
+  n_samples: int, method: "isotonic"|"shrink",
+  metrics: { raw_logloss, cal_logloss, raw_brier, cal_brier, n_eval },
+  is_champion: bool }
+```
+Writers: `save_model_version(conn, doc)`, `get_champion(conn, instance_id, kind)`,
+`set_champion(conn, id)`. Registry is **per-instance** (scoped by `instance_id`,
+falling back to a global `"__default__"` champion when an instance has none).
+
+### 2. Sample gathering + calibration fit (`kalshi/training.py`, pure where possible)
+- `gather_samples(decisions_rows) -> list[(pred, outcome01)]`: from settled placed
+  decisions (`decision=="placed"`, `outcome in {win,loss}`, `fused_fair` present)
+  build `(fused_fair, 1.0 if outcome=="win" else 0.0)`.
+- `gather_samples_from_settled(fixtures, model_fn) -> list[(pred, outcome01)]`: the
+  RICHER signal — for every settled fixture (not just bet ones), one sample **per
+  side** `(model_prob[side], 1 if side==result else 0)`. This is the primary
+  training set (all games, all sides), no trading required.
+- `fit_calibrator(samples, *, min_total=100) -> dict`: wraps `calibration.calibrate`
+  logic → returns a registry-shaped doc (`calibrator` breakpoints or shrink).
+- `evaluate(samples, calibrator) -> dict`: held-out raw-vs-calibrated logloss+brier.
+
+### 3. Training worker (`kalshi/training_worker.py`)
+Background loop (mirrors `backtest_worker` self-heal pattern from PR #84):
+- On boot + every `train_refresh_secs` (default 3600) + on a `kalshi_decisions`
+  settlement changefeed tick:
+  1. pull settled fixtures (cached final scores) + build `model_fn`,
+  2. `gather_samples_from_settled` → split train/test by fixture (out-of-sample),
+  3. `fit_calibrator(train)`, `evaluate(test)`,
+  4. persist a registry version; promote to champion **only if** calibrated test
+     logloss ≤ raw test logloss (never ship a worse calibrator),
+  5. log + notify on refit/promotion; reconnect+continue on DB drop.
+
+### 4. Engine integration (`kalshi/engine.py` + `orchestrator.py`)
+- On boot + every N ticks, load the champion calibrator from the registry into
+  engine state (`_calibrator`), degrade to `None` (identity) on any failure.
+- In `orchestrator.plan_and_allocate`, AFTER building `fused` and the market
+  anchor, apply the calibrator to `fused["winner"]` per side
+  (`calibration.apply_isotonic`), then renormalize the group. No calibrator →
+  no-op. This is the ONLY behavioural change to live pricing, and it is
+  monotone + bounded (safe).
+
+### 5. API + minimal UI (`api/main.py`)
+- `GET /brokerages/{bid}/kalshi/instances/{id}/model` → champion doc + metrics +
+  reliability points (predicted-vs-actual buckets) for a small card. (UI card is
+  nice-to-have; the endpoint is required so the loop is observable.)
+
+## Data flow
+settled Kalshi scores → `gather_samples_from_settled` → `fit_calibrator` →
+registry (champion) → engine loads → `apply_isotonic` on fused fair → edge/trade →
+settlement → (next refit).
+
+## Error handling / safety (hard requirements)
+- **Degrade-safe everywhere:** no samples / thin data → shrink or identity; any
+  fit/DB/network failure → keep the last champion (or identity), never crash the
+  engine or worker (reuse the reconnect + self-heal from PR #84).
+- **Never ship a worse model:** promotion gated on held-out logloss not regressing.
+- **Bounded effect:** calibration is monotone in [0,1]; renormalize after applying.
+- **No look-ahead:** train/test split by fixture; the champion used live was fit on
+  PRIOR settlements only (the worker only ever sees already-settled games).
+
+## Testing
+- `calibration.py` already unit-tested. New pure units get direct tests:
+  `gather_samples*`, `fit_calibrator` (isotonic vs shrink selection), `evaluate`
+  (logloss/brier), registry writers (fake conn), promotion gate (worse calibrator
+  rejected), engine apply (calibrator changes fair monotonically; None = identity).
+- Worker loop: self-heal + refit tested with a fake conn/changefeed (mirror
+  `test_kalshi_backtest_worker`).
+
+## Out of scope for SP1 (→ SP2/SP3)
+Learned ML model, ensemble, feature vector beyond current model, `soccerdata`
+ingestion, live shadow A/B. SP1 ships a continuously self-calibrating **physical**
+model + the registry/worker/eval backbone they all plug into.


### PR DESCRIPTION
The model now learns from its own settled results. Registry + training worker + wire the isotonic calibrator onto the physical model; promote to champion ONLY on a genuine held-out win. Engine loads + applies the champion (degrade-safe); worker self-heals. Smoke on real WC games: held-out log-loss 0.527->0.514 (+2.3%). Two adversarial bug-sweeps run + all findings fixed (in-sample-promotion CRITICAL, apply hardening, instance scoping, endpoint auth). 395 kalshi tests pass. Spec+plan in docs/superpowers. SP2 (learned model+ensemble) / SP3 (soccerdata) layer on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)