### PR TITLE
fix(telemetry): don't flood the log on a transient DB outage

### DIFF
--- a/backend/llm_telemetry.py
+++ b/backend/llm_telemetry.py
@@ -464,9 +464,8 @@ def _do_flush() -> None:
         r_module.db(db_name).table(_LLM_USAGE_TABLE).insert(rows).run(conn)
         with _state_lock:
             _state["last_flush_ts"] = int(time.time() * 1000)
+            _state["consecutive_flush_failures"] = 0   # recovered
     except Exception as e:
-        print(f"[llm_telemetry] flush failed ({len(rows)} rows): {e}",
-              file=sys.stderr, flush=True)
         # Re-queue the failed batch so the next flush retries instead of
         # silently dropping the rows. Without this, a 30-second RethinkDB
         # outage at 50 rows/flush burns ~300 records. We bound the re-queue
@@ -474,11 +473,21 @@ def _do_flush() -> None:
         # if the buffer is already full of newer rows, drop the oldest of
         # the failed batch first (preserving the most recent activity).
         with _state_lock:
+            fails = int(_state.get("consecutive_flush_failures", 0)) + 1
+            _state["consecutive_flush_failures"] = fails
             _state["write_errors_24h"] = int(_state.get("write_errors_24h", 0)) + 1
             hard_cap = int(_state.get("max_buffer_hard_cap", 5000))
             remaining_capacity = max(0, hard_cap - len(_buffer))
             if remaining_capacity > 0:
                 _buffer.extendleft(reversed(rows[-remaining_capacity:]))
+        # THROTTLE + TRUNCATE: a transient DB blip must not flood the log. Log only
+        # the FIRST failure of an outage, then every 20th — and only the error's first
+        # line, never the giant insert payload (a rethinkdb write error stringifies the
+        # ENTIRE query otherwise, which is the wall of text we saw).
+        if fails == 1 or fails % 20 == 0:
+            first_line = (str(e).splitlines() or [str(e)])[0][:180]
+            print(f"[llm_telemetry] flush failed ({len(rows)} rows, {fails} consecutive): "
+                  f"{first_line}", file=sys.stderr, flush=True)
     finally:
         if conn is not None:
             try:
@@ -493,6 +502,11 @@ def _flusher_loop() -> None:
             if _state.get("stop_flusher"):
                 return
             interval = float(_state.get("flush_interval_s", 5.0))
+            fails = int(_state.get("consecutive_flush_failures", 0))
+        # Back off during a sustained outage so we stop hammering a down DB (and stop
+        # spamming): exponential up to a 2-minute cap while consecutive flushes fail.
+        if fails:
+            interval = min(interval * (2 ** min(fails, 5)), 120.0)
         time.sleep(interval)
         _do_flush()
 

--- a/backend/tests/test_llm_telemetry_throttle.py
+++ b/backend/tests/test_llm_telemetry_throttle.py
@@ -1,0 +1,60 @@
+"""A transient DB outage must not flood the log: the telemetry flusher logs the
+FIRST failure + every 20th (never the giant query payload), and backs off."""
+import llm_telemetry as t
+
+
+class FakeR:
+    """r_module whose .db().table().insert().run() always raises a HUGE, multi-line
+    error (mimics a rethinkdb write error that stringifies the entire insert query)."""
+    def __init__(self, exc):
+        self.exc = exc
+
+    def db(self, _n):
+        return self
+
+    def table(self, _n):
+        return self
+
+    def insert(self, _rows):
+        return self
+
+    def run(self, _conn):
+        raise self.exc
+
+
+def test_flush_failure_is_throttled_and_truncated(capsys):
+    t._reset_for_tests()
+    first_line = "Cannot perform write: primary replica for shard not available"
+    huge = Exception(first_line + "\n" + "GIANT_QUERY_PAYLOAD " * 2000)
+    t.configure(db_conn_factory=lambda: object(), enabled=True,
+                auto_start_flusher=False, r_module=FakeR(huge))
+    t._buffer.append({"id": "x", "provider": "p", "model": "m", "ok": True})
+
+    for _ in range(25):        # sustained outage: same re-queued row keeps failing
+        t._do_flush()
+    err = capsys.readouterr().err
+
+    assert "GIANT_QUERY_PAYLOAD" not in err          # never dumps the query payload
+    assert first_line[:40] in err                    # does log the real cause (truncated)
+    assert err.count("flush failed") <= 3            # throttled (logs #1 and #20), not 25×
+    # consecutive-failure counter tracked for backoff
+    assert t._state.get("consecutive_flush_failures", 0) >= 20
+    t._reset_for_tests()
+
+
+def test_success_resets_failure_counter():
+    t._reset_for_tests()
+    t._state["consecutive_flush_failures"] = 7  # pretend we were failing
+
+    class OKR:
+        def db(self, _n): return self
+        def table(self, _n): return self
+        def insert(self, _rows): return self
+        def run(self, _conn): return {"inserted": 1}
+
+    t.configure(db_conn_factory=lambda: object(), enabled=True,
+                auto_start_flusher=False, r_module=OKR())
+    t._buffer.append({"id": "y", "provider": "p", "model": "m", "ok": True})
+    t._do_flush()
+    assert t._state.get("consecutive_flush_failures", 0) == 0   # recovered -> reset
+    t._reset_for_tests()


### PR DESCRIPTION
The LLM-usage flusher dumped the entire insert query on every retry during a DB blip (that wall of text). Now: first-line-only + truncated, throttled (1st + every 20th), exponential backoff, counter reset on recovery. The bot itself already self-healed (PR #84); this quiets the telemetry reaction. 20 tests pass.