### PR TITLE
feat(kalshi): SP2 learned model + ensemble + auto-champion

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4183,7 +4183,7 @@ def api_kalshi_instance_model(brokerage_id: str, instance_id: str, conn=Depends(
     except Exception:
         _inst = {}
     if _inst.get("kind") != "kalshi" or _inst.get("brokerage_id") != brokerage_id:
-        return {"champion": None}
+        return {"champion": None, "model": None}
     from kalshi.db import get_champion
     champ = get_champion(conn, instance_id, "calibrator")
     model = get_champion(conn, instance_id, "model")   # SP2: physical/learned/ensemble

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4186,13 +4186,18 @@ def api_kalshi_instance_model(brokerage_id: str, instance_id: str, conn=Depends(
         return {"champion": None}
     from kalshi.db import get_champion
     champ = get_champion(conn, instance_id, "calibrator")
-    if not champ:
-        return {"champion": None}
-    return {"champion": {
-        "id": champ.get("id"), "method": champ.get("method"),
-        "n_samples": champ.get("n_samples"), "created_at": champ.get("created_at"),
-        "metrics": champ.get("metrics", {}), "reliability": champ.get("reliability", []),
-    }}
+    model = get_champion(conn, instance_id, "model")   # SP2: physical/learned/ensemble
+    model_out = None
+    if model:
+        model_out = {"champion": model.get("champion"), "ranked": model.get("ranked", []),
+                     "metrics": model.get("metrics", {}), "n_train": model.get("n_train"),
+                     "n_test": model.get("n_test"), "created_at": model.get("created_at")}
+    calib = None
+    if champ:
+        calib = {"id": champ.get("id"), "method": champ.get("method"),
+                 "n_samples": champ.get("n_samples"), "created_at": champ.get("created_at"),
+                 "metrics": champ.get("metrics", {}), "reliability": champ.get("reliability", [])}
+    return {"champion": calib, "model": model_out}
 
 
 @app.post("/brokerages/{brokerage_id}/kalshi/kill", response_class=JSONResponse)

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -282,6 +282,8 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
     odds_cache: dict = {}       # sport_key -> {"ts": wall, "events": [...], "quota": int|None}
     espn_cache: dict = {"ts": 0.0, "board": []}   # ESPN live scores+clock (timing only, ~30s)
     _calibrator = None            # champion isotonic calibrator (self-improving loop); None = identity
+    _model_champion = "physical"  # SP2 champion model; "physical" (default) = no override
+    _model_probs_fn = None        # winner-probs fn when champion is learned/ensemble
     raw_dumped = False           # one-time raw-market field dump (price diagnostics)
     placed_markets: set = set()  # market_tickers already held/ordered — don't re-order
     _soccer_series = config.soccer_series or discovery.DEFAULT_SOCCER_SERIES
@@ -373,6 +375,20 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                             f"{_m.get('cal_logloss', 0):.3f}).", "cyan")
                 except Exception:
                     _calibrator = None
+                # SP2: champion MODEL (physical / learned / ensemble). Degrade to
+                # physical (identity override) on any failure.
+                try:
+                    _mc = kdb.get_champion(conn, config.instance_id, "model")
+                    _model_champion = (_mc or {}).get("champion", "physical")
+                    if _mc and _model_champion != "physical":
+                        from kalshi.model_ensemble import champion_predict_fn
+                        _model_probs_fn = champion_predict_fn(_mc, nat_elo_table, elo_table)
+                        log(f"tick {tick}: champion MODEL = {_model_champion} "
+                            f"(beat physical on held-out).", "cyan")
+                    else:
+                        _model_probs_fn = None
+                except Exception:
+                    _model_champion, _model_probs_fn = "physical", None
             # 1b) Live national-team Elo (eloratings.net) for World Cup / international
             # markets — replaces the frozen static table when reachable. Degrade-safe:
             # {} keeps the static fallback (national_elo_from), so a feed outage is a no-op.
@@ -693,6 +709,8 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                 one_bet_per_fixture=getattr(config.caps, "one_bet_per_fixture", True),
                 devig_method=config.devig_method,
                 calibrator=_calibrator,
+                model_champion=_model_champion,
+                model_probs_fn=_model_probs_fn,
             )
             allocations, decisions = plan["allocations"], plan["decisions"]
             log(f"tick {tick}: {len(decisions)} candidate(s) evaluated → {len(allocations)} to place "

--- a/backend/kalshi/learned_model.py
+++ b/backend/kalshi/learned_model.py
@@ -45,21 +45,28 @@ def fit(X, y, *, l2: float = 2.0, iters: int = 1000, lr: float = 0.5) -> list:
         P = _softmax_rows(Xb @ W)
         grad = Xb.T @ (P - Y) / n + (l2 / n) * (W * reg_mask)
         W -= lr * grad
+    if not np.isfinite(W).all():
+        # Diverged (e.g. an extreme l2/lr). Never persist NaN/inf weights — fall back
+        # to a bias-only model (uniform after softmax) so predict() stays well-defined.
+        return np.zeros((d + 1, 3)).tolist()
     return W.tolist()
 
 
 def predict(weights, x) -> dict:
     """Predict {home,draw,away} for a single feature vector. Degrade-safe: any
     shape mismatch / bad weights -> uniform 1/3 each (never raises)."""
+    uniform = {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
     try:
         W = np.asarray(weights, dtype=float)
         xb = np.append(np.asarray(x, dtype=float), 1.0)
-        if xb.shape[0] != W.shape[0]:
-            return {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+        if xb.shape[0] != W.shape[0] or not np.isfinite(W).all() or not np.isfinite(xb).all():
+            return uniform
         z = xb @ W
         z = z - z.max()
         e = np.exp(z)
         p = e / e.sum()
+        if not np.isfinite(p).all():   # NaN never raises — guard explicitly
+            return uniform
         return {"home": float(p[0]), "draw": float(p[1]), "away": float(p[2])}
     except Exception:
-        return {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+        return uniform

--- a/backend/kalshi/learned_model.py
+++ b/backend/kalshi/learned_model.py
@@ -1,0 +1,65 @@
+"""Learned 1X2 model (pure numpy): L2-regularized multinomial logistic regression.
+
+SP2's data-driven counterpart to the physical Elo->Dixon-Coles model. It learns to
+map a small feature vector (the physical model's own probs + Elo diff + neutral-site
+flag) onto the actual outcome — i.e. it learns to CORRECT the physical model from
+settled results. Deliberately simple + strongly regularized: on ~dozens-to-hundreds
+of games a heavier model (gradient boosting) would overfit; logistic regression with
+L2 degrades gracefully toward the base rate instead.
+
+Deterministic (zero init, fixed iterations) so the same data always yields the same
+weights — required for the registry/champion reproducibility. No sklearn/scipy.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+CLASSES = ("home", "draw", "away")
+
+
+def _softmax_rows(z):
+    z = z - z.max(axis=1, keepdims=True)
+    e = np.exp(z)
+    return e / e.sum(axis=1, keepdims=True)
+
+
+def fit(X, y, *, l2: float = 2.0, iters: int = 1000, lr: float = 0.5) -> list:
+    """Fit weights for a 3-class multinomial logistic regression.
+
+    X: sequence of feature vectors (equal length). y: class indices in {0,1,2}
+    (home,draw,away). Returns the weight matrix (d+1 x 3, last row = bias) as a
+    plain nested list (JSON-serialisable for the registry). L2 penalizes weights
+    but not the bias. Empty/degenerate input -> a bias-only model at the base rate."""
+    X = np.asarray(list(X), dtype=float)
+    y = np.asarray(list(y), dtype=int)
+    if X.ndim != 2 or len(X) == 0:
+        return np.zeros((1, 3)).tolist()  # bias-only -> uniform after softmax
+    n, d = X.shape
+    Xb = np.hstack([X, np.ones((n, 1))])          # append bias column
+    W = np.zeros((d + 1, 3))
+    Y = np.zeros((n, 3))
+    Y[np.arange(n), np.clip(y, 0, 2)] = 1.0
+    reg_mask = np.ones((d + 1, 1))
+    reg_mask[-1, 0] = 0.0                          # don't regularize the bias
+    for _ in range(iters):
+        P = _softmax_rows(Xb @ W)
+        grad = Xb.T @ (P - Y) / n + (l2 / n) * (W * reg_mask)
+        W -= lr * grad
+    return W.tolist()
+
+
+def predict(weights, x) -> dict:
+    """Predict {home,draw,away} for a single feature vector. Degrade-safe: any
+    shape mismatch / bad weights -> uniform 1/3 each (never raises)."""
+    try:
+        W = np.asarray(weights, dtype=float)
+        xb = np.append(np.asarray(x, dtype=float), 1.0)
+        if xb.shape[0] != W.shape[0]:
+            return {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+        z = xb @ W
+        z = z - z.max()
+        e = np.exp(z)
+        p = e / e.sum()
+        return {"home": float(p[0]), "draw": float(p[1]), "away": float(p[2])}
+    except Exception:
+        return {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}

--- a/backend/kalshi/model_ensemble.py
+++ b/backend/kalshi/model_ensemble.py
@@ -1,0 +1,167 @@
+"""SP2 model ensemble: features, blend, and the champion-selection harness that
+compares the physical / learned / ensemble models on held-out settled games.
+
+The learned model stacks on the physical model — its features ARE the physical
+model's probs plus a little context (Elo gap, neutral-site) — so it can only learn
+to *correct* the physical view, and the ensemble hedges the two. Selection is
+held-out log-loss (same discipline as SP1: never trust in-sample fit), so the
+worker only promotes a model that actually beats the others on unseen games.
+"""
+from __future__ import annotations
+
+import math
+
+from kalshi import learned_model, training
+from kalshi.quant.elo import elo_to_expected_goals, HOME_FIELD_ADVANTAGE, NEUTRAL_HFA
+from kalshi.quant.dixon_coles import scoreline_matrix
+from kalshi.quant.derive_markets import one_x_two
+from kalshi.quant.national_elo import national_elo_from, is_national_team
+from kalshi.data.sources.clubelo import elo_for
+
+CLASSES = ("home", "draw", "away")
+FEATURE_NAMES = ("phys_home", "phys_draw", "phys_away", "elo_diff_tanh", "neutral")
+
+
+def build_feature_fn(nat_elo, elo):
+    """Return `feat(fx) -> (features:list, phys_probs:dict)`. The physical winner
+    probs are computed with the SAME context-aware HFA the live model uses, so the
+    learned model trains on the same signal it will see live."""
+    nat_elo = nat_elo or {}
+    elo = elo or {}
+
+    def _elo(name):
+        return national_elo_from(nat_elo, name) if is_national_team(name) else elo_for(elo, name)
+
+    def feat(fx):
+        home, away = (fx or {}).get("home", ""), (fx or {}).get("away", "")
+        he, ae = _elo(home), _elo(away)
+        neutral = 1.0 if (is_national_team(home) and is_national_team(away)) else 0.0
+        hfa = NEUTRAL_HFA if neutral else HOME_FIELD_ADVANTAGE
+        hxg, axg = elo_to_expected_goals(he, ae, hfa=hfa)
+        phys = one_x_two(scoreline_matrix(hxg, axg))
+        features = [phys.get("home", 1 / 3), phys.get("draw", 1 / 3), phys.get("away", 1 / 3),
+                    math.tanh((he - ae) / 400.0), neutral]
+        return features, phys
+
+    return feat
+
+
+def ensemble(phys: dict, learned: dict, w: float = 0.5) -> dict:
+    """Weighted blend of two {home,draw,away} dicts, renormalized. `w` = weight on
+    the LEARNED model (0 = pure physical, 1 = pure learned)."""
+    out = {s: (1.0 - w) * float(phys.get(s, 0.0)) + w * float(learned.get(s, 0.0)) for s in CLASSES}
+    tot = sum(out.values()) or 1.0
+    return {s: out[s] / tot for s in CLASSES}
+
+
+def _per_side_samples(fixtures, probs_fn):
+    s = []
+    for f in fixtures:
+        probs = probs_fn(f)
+        res = f.get("result")
+        for side in CLASSES:
+            s.append((probs.get(side, 1 / 3), 1.0 if side == res else 0.0))
+    return s
+
+
+def evaluate_models(fixtures, feat_fn, *, l2: float = 2.0, ensemble_w: float = 0.5,
+                    min_train: int = 30, margin: float = 0.02) -> dict:
+    """Split settled fixtures train/test (by kickoff), fit the learned model on the
+    train half, then score physical / learned / ensemble on the HELD-OUT half.
+    Returns a ranked report + the champion + the fitted learned weights.
+
+    Champion selection is MARGIN-GUARDED: physical is the safe default, and we only
+    switch to learned/ensemble when it beats physical's held-out log-loss by at least
+    `margin` (relative). On thin/noisy data (where the raw winner flips with the
+    regularization strength) this keeps us on physical rather than chasing a split-
+    specific fluke. Degrades to physical when there isn't enough data to fit."""
+    fixtures = [f for f in (fixtures or []) if (f or {}).get("result") in CLASSES]
+    fixtures.sort(key=lambda f: (str(f.get("kickoff_ts") or ""), str(f.get("fixture_id") or "")))
+    train, test = fixtures[::2], fixtures[1::2]
+
+    Xtr, ytr = [], []
+    for f in train:
+        feats, _ = feat_fn(f)
+        Xtr.append(feats)
+        ytr.append(CLASSES.index(f["result"]))
+    weights = learned_model.fit(Xtr, ytr, l2=l2) if len(Xtr) >= min_train else None
+
+    def phys_fn(f):
+        return feat_fn(f)[1]
+
+    def learned_fn(f):
+        if not weights:
+            return feat_fn(f)[1]
+        return learned_model.predict(weights, feat_fn(f)[0])
+
+    def ens_fn(f):
+        if not weights:
+            return feat_fn(f)[1]
+        feats, phys = feat_fn(f)
+        return ensemble(phys, learned_model.predict(weights, feats), ensemble_w)
+
+    results = {}
+    for name, fn in (("physical", phys_fn), ("learned", learned_fn), ("ensemble", ens_fn)):
+        m = training.evaluate(_per_side_samples(test, fn), None)   # raw (uncalibrated) held-out
+        results[name] = {"logloss": round(m["raw_logloss"], 4),
+                         "brier": round(m["raw_brier"], 4), "n": m["n_eval"]}
+    return _select(results, weights, ensemble_w, len(Xtr), len(test), l2, margin)
+
+
+def _select(results, weights, ensemble_w, n_train, n_test, l2, margin):
+    ranked = [k for k, _ in sorted(results.items(), key=lambda kv: kv[1]["logloss"])]
+    # Margin guard: physical is the default; switch only on a real held-out win.
+    champion = "physical"
+    if weights and results["physical"]["n"] > 0:
+        phys_ll = results["physical"]["logloss"]
+        best = ranked[0]
+        if best != "physical" and results[best]["logloss"] <= phys_ll * (1.0 - margin):
+            champion = best
+    return {"results": results, "ranked": ranked, "champion": champion,
+            "learned_weights": weights if champion != "physical" else None,
+            "ensemble_w": ensemble_w, "feature_names": list(FEATURE_NAMES),
+            "l2": l2, "margin": margin, "n_train": n_train, "n_test": n_test}
+
+
+def refit_model_once(conn, instance_id, fixtures, feat_fn, *, new_id, now_iso,
+                     l2: float = 2.0, ensemble_w: float = 0.5, min_train: int = 30,
+                     margin: float = 0.02, promote: bool = True) -> dict:
+    """Run the physical/learned/ensemble comparison, persist a `kind='model'`
+    registry version, and promote it (the margin guard inside `evaluate_models`
+    already keeps the champion = physical unless a real held-out win, so promoting
+    the latest assessment is safe)."""
+    from kalshi import db as _db
+    rep = evaluate_models(fixtures, feat_fn, l2=l2, ensemble_w=ensemble_w,
+                          min_train=min_train, margin=margin)
+    version = {
+        "id": new_id, "instance_id": instance_id, "kind": "model",
+        "created_at": now_iso, "is_champion": False,
+        "champion": rep["champion"], "learned_weights": rep["learned_weights"],
+        "ensemble_w": rep["ensemble_w"], "feature_names": rep["feature_names"],
+        "l2": rep.get("l2"), "metrics": rep["results"], "ranked": rep["ranked"],
+        "n_train": rep["n_train"], "n_test": rep["n_test"],
+    }
+    _db.save_model_version(conn, version)
+    if promote:
+        _db.set_champion(conn, new_id, instance_id, "model")
+    version["promoted"] = bool(promote)
+    return version
+
+
+def champion_predict_fn(champ_doc, nat_elo, elo):
+    """Return `fn(fx) -> winner_probs` for the current model champion. Defaults to
+    the physical model (safe) for a missing/physical champion; uses the learned or
+    ensemble prediction only when the champion is that and weights are present."""
+    feat_fn = build_feature_fn(nat_elo, elo)
+    champ = (champ_doc or {}).get("champion", "physical")
+    weights = (champ_doc or {}).get("learned_weights")
+    ew = float((champ_doc or {}).get("ensemble_w", 0.5))
+
+    def fn(fx):
+        feats, phys = feat_fn(fx)
+        if champ == "physical" or not weights:
+            return phys
+        learned = learned_model.predict(weights, feats)
+        return learned if champ == "learned" else ensemble(phys, learned, ew)
+
+    return fn

--- a/backend/kalshi/orchestrator.py
+++ b/backend/kalshi/orchestrator.py
@@ -33,6 +33,8 @@ def plan_and_allocate(
     one_bet_per_fixture: bool = True,
     devig_method: str = "power",
     calibrator: dict | None = None,
+    model_champion: str = "physical",
+    model_probs_fn=None,
 ) -> dict:
     """fixtures: each {fixture_id, expected_goals, sharp_probs, analyst:{adjustments,
     rationales}, kalshi_markets, liquidity, hours_to_kickoff, model_confidence}.
@@ -56,6 +58,23 @@ def plan_and_allocate(
         player_probs = fx.get("player_probs")
         fused = build_market_probs(eg, sharp, adjustments, player_probs=player_probs, w_sharp=w_sharp, llm_cap=llm_cap)
         model_only = build_market_probs(eg, {}, {}, player_probs=player_probs, w_sharp=w_sharp, llm_cap=llm_cap)
+        # SP2 MODEL CHAMPION: when a learned/ensemble model has beaten the physical one
+        # on held-out data, re-fuse the WINNER group off that model instead (same sharp
+        # weighting). Gated on model_champion != 'physical', so it is a strict no-op on
+        # the safe default — no live behaviour change until a real champion switch.
+        if model_champion and model_champion != "physical" and model_probs_fn and fused.get("winner"):
+            try:
+                mc = model_probs_fn(fx)
+            except Exception:
+                mc = None
+            if mc:
+                sw = (sharp or {}).get("winner")
+                if sw:
+                    fused["winner"] = renormalize_group(
+                        {s: w_sharp * float(sw.get(s, 0.0)) + (1.0 - w_sharp) * float(mc.get(s, 0.0))
+                         for s in ("home", "draw", "away")})
+                else:
+                    fused["winner"] = renormalize_group({s: float(mc.get(s, 0.0)) for s in ("home", "draw", "away")})
         # MARKET ANCHOR: with no sharp line, pull the (overconfident) model toward the
         # de-vigged Kalshi market so edge = a SHRUNK model-vs-market disagreement, not
         # the model's blind view. Only fires when there is no sharp anchor already.

--- a/backend/kalshi/orchestrator.py
+++ b/backend/kalshi/orchestrator.py
@@ -11,7 +11,7 @@ from kalshi.capital.opportunity import score as opportunity_score
 from kalshi.capital.planner import allocate
 from kalshi.decisions import decision_doc
 from kalshi.devig import market_probs_from_asks
-from kalshi.intelligence.fusion import renormalize_group
+from kalshi.intelligence.fusion import renormalize_group, fuse, clamp_adjustment
 from kalshi import training
 
 
@@ -67,14 +67,21 @@ def plan_and_allocate(
                 mc = model_probs_fn(fx)
             except Exception:
                 mc = None
+            # Route through the SAME fuse() build_market_probs uses (not a hand-rolled
+            # blend) so the champion model still gets the cheap-side overconfidence cap,
+            # the w_sharp clamp, and the analyst adjustment — dropping those is exactly
+            # the favorite-longshot failure mode the physical path guards against.
             if mc:
-                sw = (sharp or {}).get("winner")
-                if sw:
-                    fused["winner"] = renormalize_group(
-                        {s: w_sharp * float(sw.get(s, 0.0)) + (1.0 - w_sharp) * float(mc.get(s, 0.0))
-                         for s in ("home", "draw", "away")})
-                else:
-                    fused["winner"] = renormalize_group({s: float(mc.get(s, 0.0)) for s in ("home", "draw", "away")})
+                sw = (sharp or {}).get("winner") or {}
+                _adj = clamp_adjustment(float(adjustments.get("winner", 0.0) or 0.0), llm_cap)
+                base = {}
+                for side in ("home", "draw", "away"):
+                    sv = sw.get(side)
+                    mv = float(mc.get(side, sv if sv is not None else 0.0))
+                    base[side] = fuse(sharp=sv, model=mv, llm_adjustment=0.0,
+                                      w_sharp=w_sharp, llm_cap=llm_cap)
+                base["home"] = max(0.0, min(1.0, base["home"] + _adj))   # primary-side nudge
+                fused["winner"] = renormalize_group(base)
         # MARKET ANCHOR: with no sharp line, pull the (overconfident) model toward the
         # de-vigged Kalshi market so edge = a SHRUNK model-vs-market disagreement, not
         # the model's blind view. Only fires when there is no sharp anchor already.

--- a/backend/kalshi/runner.py
+++ b/backend/kalshi/runner.py
@@ -73,11 +73,13 @@ def _start_training_worker(instance_id, cfg) -> None:  # pragma: no cover - inte
         # seeded "__default__" bootstrap). start_date is intentionally recent — the model
         # prices with a single point-in-time Elo snapshot, so training only on the
         # current window keeps that a minor approximation, not a deep-history look-ahead.
+        from kalshi.model_ensemble import build_feature_fn
         refit = training_worker.build_refit_fn(
             provider_factory=provider_factory, model_fn=model_fn, leagues=leagues,
             start_date="2026-01-01",
             end_date_fn=lambda: _dt.datetime.utcnow().strftime("%Y-%m-%d"),
-            instance_id=instance_id, min_total=100)
+            instance_id=instance_id, min_total=100,
+            feat_fn=build_feature_fn({}, {}))   # SP2: also refit the model champion
         try:
             from notifications import notify as _notify
         except Exception:

--- a/backend/kalshi/training_worker.py
+++ b/backend/kalshi/training_worker.py
@@ -66,11 +66,13 @@ def _new_id(instance_id: str) -> str:
 
 
 def build_refit_fn(*, provider_factory, model_fn, leagues, start_date,
-                   end_date_fn, instance_id: str = "__default__", min_total: int = 100):
-    """Return a `refit(conn) -> dict|None` that fetches settled fixtures, gathers
-    per-side calibration samples, splits train/test by fixture (no leakage), and
-    calls `refit_once`. `end_date_fn()` returns today's date string so the window
-    rolls forward. Degrade-safe: returns None on any data failure."""
+                   end_date_fn, instance_id: str = "__default__", min_total: int = 100,
+                   feat_fn=None):
+    """Return a `refit(conn) -> dict|None` that fetches settled fixtures and refits
+    (1) the isotonic calibrator (SP1) and, when `feat_fn` is given, (2) the model
+    champion — physical/learned/ensemble comparison (SP2). Deterministic split by
+    fixture (no leakage). Degrade-safe: returns None on any data failure; a model
+    refit failure never blocks the calibrator."""
     def refit(conn):
         try:
             provider = provider_factory(conn)
@@ -87,9 +89,21 @@ def build_refit_fn(*, provider_factory, model_fn, leagues, start_date,
         except Exception:
             log.exception("training: fixture fetch/gather failed")
             return None
-        return refit_once(conn, instance_id, train, test,
-                          new_id=_new_id(instance_id), now_iso=_now_iso(),
-                          min_total=min_total)
+        cal_version = refit_once(conn, instance_id, train, test,
+                                 new_id=_new_id(instance_id), now_iso=_now_iso(),
+                                 min_total=min_total)
+        if feat_fn is not None:   # SP2: also refit + promote the model champion
+            try:
+                from kalshi import model_ensemble
+                mv = model_ensemble.refit_model_once(
+                    conn, instance_id, fixtures, feat_fn,
+                    new_id=f"model|{instance_id}|{_new_id(instance_id).split('|')[-1]}",
+                    now_iso=_now_iso())
+                cal_version = dict(cal_version or {})
+                cal_version["model_champion"] = mv.get("champion")
+            except Exception:
+                log.exception("training: model champion refit failed (calibrator unaffected)")
+        return cal_version
     return refit
 
 

--- a/backend/tests/test_kalshi_learned_model.py
+++ b/backend/tests/test_kalshi_learned_model.py
@@ -44,3 +44,18 @@ def test_fit_empty_is_bias_only():
     w = lm.fit([], [])
     p = lm.predict(w, [])   # bias-only -> uniform
     assert abs(p["home"] - 1 / 3) < 1e-9
+
+
+def test_predict_uniform_on_nonfinite_weights():
+    nan_w = [[float("nan"), 0.0, 0.0], [0.0, float("inf"), 0.0]]
+    assert lm.predict(nan_w, [0.5]) == {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+
+
+def test_fit_never_returns_nonfinite_even_if_diverged():
+    import numpy as np
+    X = [[0.9, 0.05, 0.05]] * 30 + [[0.05, 0.05, 0.9]] * 30
+    y = [0] * 30 + [2] * 30
+    w = lm.fit(X, y, l2=100000.0, lr=0.5, iters=200)   # deliberately unstable -> must not persist NaN
+    assert np.isfinite(np.asarray(w)).all()
+    p = lm.predict(w, [0.9, 0.05, 0.05])
+    assert abs(sum(p.values()) - 1.0) < 1e-9 and all(0 <= v <= 1 for v in p.values())

--- a/backend/tests/test_kalshi_learned_model.py
+++ b/backend/tests/test_kalshi_learned_model.py
@@ -1,0 +1,46 @@
+"""Learned 1X2 model: fit/predict, it learns signal, and degrades safely."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import learned_model as lm
+
+
+def test_predict_is_a_distribution():
+    w = lm.fit([[0.6, 0.2, 0.2], [0.2, 0.2, 0.6]], [0, 2], iters=50)
+    p = lm.predict(w, [0.6, 0.2, 0.2])
+    assert set(p) == {"home", "draw", "away"}
+    assert abs(sum(p.values()) - 1.0) < 1e-9
+    assert all(0.0 <= v <= 1.0 for v in p.values())
+
+
+def test_learns_a_separable_signal():
+    # Feature 0 high -> home wins; feature 2 high -> away wins. Learnable.
+    X = [[0.9, 0.05, 0.05]] * 30 + [[0.05, 0.05, 0.9]] * 30
+    y = [0] * 30 + [2] * 30
+    w = lm.fit(X, y, l2=0.5, iters=800)
+    assert lm.predict(w, [0.9, 0.05, 0.05])["home"] > 0.5
+    assert lm.predict(w, [0.05, 0.05, 0.9])["away"] > 0.5
+
+
+def test_strong_l2_is_less_confident_than_weak():
+    X = [[0.9, 0.05, 0.05]] * 30 + [[0.05, 0.05, 0.9]] * 30
+    y = [0] * 30 + [2] * 30
+    weak = lm.predict(lm.fit(X, y, l2=0.1, iters=800), [0.9, 0.05, 0.05])["home"]
+    strong = lm.predict(lm.fit(X, y, l2=20.0, iters=800), [0.9, 0.05, 0.05])["home"]
+    assert strong < weak   # heavy L2 damps the feature-driven confidence
+
+
+def test_deterministic():
+    X, y = [[0.6, 0.2, 0.2], [0.3, 0.3, 0.4]], [0, 2]
+    assert lm.fit(X, y, iters=100) == lm.fit(X, y, iters=100)
+
+
+def test_predict_degrades_on_bad_input():
+    assert lm.predict([[0, 0, 0]], [1, 2, 3, 4, 5]) == {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+    assert lm.predict("garbage", [0.5]) == {"home": 1 / 3, "draw": 1 / 3, "away": 1 / 3}
+
+
+def test_fit_empty_is_bias_only():
+    w = lm.fit([], [])
+    p = lm.predict(w, [])   # bias-only -> uniform
+    assert abs(p["home"] - 1 / 3) < 1e-9

--- a/backend/tests/test_kalshi_model_ensemble.py
+++ b/backend/tests/test_kalshi_model_ensemble.py
@@ -1,0 +1,49 @@
+"""Ensemble blend + margin-guarded champion selection."""
+import sys, types
+sys.modules.setdefault("socketio", types.ModuleType("socketio"))
+
+from kalshi import model_ensemble as me
+
+
+def test_ensemble_blends_and_renormalizes():
+    phys = {"home": 0.7, "draw": 0.2, "away": 0.1}
+    learned = {"home": 0.3, "draw": 0.3, "away": 0.4}
+    b = me.ensemble(phys, learned, w=0.5)
+    assert abs(sum(b.values()) - 1.0) < 1e-9
+    assert 0.3 < b["home"] < 0.7            # between the two
+    # w=0 -> pure physical; w=1 -> pure learned
+    assert me.ensemble(phys, learned, w=0.0)["home"] == 0.7
+    assert abs(me.ensemble(phys, learned, w=1.0)["away"] - 0.4) < 1e-9
+
+
+def _synthetic_fixtures(n=100):
+    # Outcomes matching the physical probs below (50h/25d/25a) so physical is already
+    # well-calibrated -> a base-rate learned model can't beat it by a margin.
+    fx = []
+    for i in range(n):
+        m = i % 4
+        res = "home" if m in (0, 1) else ("draw" if m == 2 else "away")
+        fx.append({"fixture_id": f"f{i:03d}", "kickoff_ts": i,
+                   "home": "TeamA", "away": "TeamC", "result": res})
+    return fx
+
+
+def _feat_fn(fx):
+    # identical features every game -> learned can only recover the base rate, which
+    # equals the (well-calibrated) physical probs -> no margin win.
+    return [0.5, 0.25, 0.25, 0.0, 1.0], {"home": 0.5, "draw": 0.25, "away": 0.25}
+
+
+def test_evaluate_models_shape_and_margin_default_physical():
+    out = me.evaluate_models(_synthetic_fixtures(), _feat_fn, min_train=20, margin=0.02)
+    assert set(out["results"]) == {"physical", "learned", "ensemble"}
+    assert out["champion"] in ("physical", "learned", "ensemble")
+    # with identical physical features every game, learned can't beat physical by a
+    # margin -> stays physical (the safe default)
+    assert out["champion"] == "physical"
+    assert out["learned_weights"] is None   # not stored when champion is physical
+
+
+def test_too_little_data_stays_physical():
+    out = me.evaluate_models(_synthetic_fixtures(10), _feat_fn, min_train=30)
+    assert out["champion"] == "physical" and out["learned_weights"] is None

--- a/backend/tests/test_kalshi_orchestrator.py
+++ b/backend/tests/test_kalshi_orchestrator.py
@@ -229,3 +229,20 @@ def test_model_champion_physical_is_identity():
     fa = {d.get("side"): d["fused_fair"] for d in a["decisions"]}
     fb = {d.get("side"): d["fused_fair"] for d in b["decisions"]}
     assert fa == fb
+
+
+def test_model_champion_respects_cheap_side_cap():
+    """The override routes through fuse(), so a champion model that's overconfident on
+    a CHEAP side (sharp < 20c) can't run far above the sharp prob (the failure mode
+    a hand-rolled blend would reintroduce)."""
+    # sharp says home is a 10c longshot; the model champion loves home at 40%.
+    fx = _fixture_3way("f1", 1.0, 1.0, {"home": 62, "draw": 26, "away": 12},
+                       sharp={"home": 0.10, "draw": 0.25, "away": 0.65})
+    common = dict(instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+                  fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0,
+                  expected_better_soon=False, market_shrink=0.0, w_sharp=0.7)
+    out = plan_and_allocate([fx], **common, model_champion="ensemble",
+                            model_probs_fn=lambda f: {"home": 0.40, "draw": 0.20, "away": 0.40})
+    home = next(d["fused_fair"] for d in out["decisions"] if d.get("side") == "home")
+    # cheap_side_cap(0.10)=0.0 -> home may not exceed ~sharp(0.10) by more than rounding
+    assert home <= 0.14   # capped near sharp, NOT ~0.19 (the uncapped hand-rolled value)

--- a/backend/tests/test_kalshi_orchestrator.py
+++ b/backend/tests/test_kalshi_orchestrator.py
@@ -194,3 +194,38 @@ def test_calibrator_none_is_identity():
     fa = {d.get("side"): d["fused_fair"] for d in a["decisions"]}
     fb = {d.get("side"): d["fused_fair"] for d in b["decisions"]}
     assert fa == fb
+
+
+def test_model_champion_overrides_winner_when_nonphysical():
+    """A learned/ensemble champion re-fuses the winner group; 'physical' is a no-op."""
+    asks = {"home": 55, "draw": 26, "away": 19}
+    common = dict(instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+                  fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0,
+                  expected_better_soon=False, market_shrink=0.0)
+    # a champion model that strongly favours AWAY (opposite of the physical home lean)
+    away_fn = lambda fx: {"home": 0.1, "draw": 0.2, "away": 0.7}
+
+    base = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common,
+                             model_champion="physical", model_probs_fn=away_fn)  # gated off
+    ens = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common,
+                            model_champion="ensemble", model_probs_fn=away_fn)   # active
+
+    def side_fair(out, side):
+        return next(d["fused_fair"] for d in out["decisions"] if d.get("side") == side)
+
+    # physical champion -> away_fn ignored; ensemble champion -> away prob rises
+    assert side_fair(ens, "away") > side_fair(base, "away")
+    assert abs(sum(side_fair(ens, s) for s in ("home", "draw", "away")) - 1.0) < 1e-6
+
+
+def test_model_champion_physical_is_identity():
+    asks = {"home": 55, "draw": 26, "away": 19}
+    common = dict(instance_id="i1", brokerage_id="b1", ts="t", tier="medium", caps=CAPS,
+                  fee_rate=0.07, edge_threshold=0.01, reserve_frac=0.0,
+                  expected_better_soon=False, market_shrink=0.0)
+    a = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common)
+    b = plan_and_allocate([_fixture_3way("f1", 2.4, 0.4, asks)], **common,
+                          model_champion="physical", model_probs_fn=lambda fx: {"home": 0.9})
+    fa = {d.get("side"): d["fused_fair"] for d in a["decisions"]}
+    fb = {d.get("side"): d["fused_fair"] for d in b["decisions"]}
+    assert fa == fb


### PR DESCRIPTION
Learned multinomial-LR model (pure numpy) + ensemble + held-out comparison harness with a margin guard. Training worker refits the model champion; engine applies it via a gated override (no-op on the physical default). On real WC data: ensemble<learned<physical but within the 2% margin -> champion stays physical (honest). Adversarial bug-sweep run + all findings fixed (override now keeps the fusion safety nets; learned-model NaN guards; endpoint shape). 406 kalshi tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)