### PR TITLE
fix(llm): hard timeout + max_retries=0 on the structured LLM path (stops random hangs)

### DIFF
--- a/backend/bedrock_client.py
+++ b/backend/bedrock_client.py
@@ -80,10 +80,18 @@ def _make_bearer_injector(api_key: str):
 
 
 def _client_config(timeout_sec: float = 30.0, max_attempts: int = 1) -> Config:
+    # Clamp to a positive float: botocore treats read_timeout=None/0 as an
+    # UNBOUNDED read, which would let a stalled Bedrock call hang forever.
+    try:
+        _t = float(timeout_sec)
+    except (TypeError, ValueError):
+        _t = 30.0
+    if not (_t > 0):
+        _t = 30.0
     return Config(
         signature_version=botocore.UNSIGNED,  # bearer token via header, not SigV4
-        read_timeout=float(timeout_sec),
-        connect_timeout=min(15.0, float(timeout_sec)),
+        read_timeout=_t,
+        connect_timeout=min(15.0, _t),
         retries={"max_attempts": max_attempts, "mode": "standard"},
     )
 

--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -962,6 +962,29 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
             default_structured_output_mode="prompted",
         )
 
+    def _bounded_openai_client(*, base_url=None, api_key=None, default_headers=None,
+                               azure_endpoint=None, api_version=None):
+        """OpenAI-SDK async client for the pydantic-ai structured path with a
+        HARD read/connect timeout AND max_retries=0. Without this the SDK
+        defaults to max_retries=2 at a ~10-min timeout, so a stalled upstream
+        (OpenRouter/Nemotron especially) hangs the caller for many minutes —
+        the root cause of random backtest freezes. LLM_REQUEST_TIMEOUT (default
+        180s) bounds the read; connect is capped at 15s."""
+        import httpx as _httpx
+        _read = float(os.environ.get("LLM_REQUEST_TIMEOUT", "180") or 180.0)
+        _to = _httpx.Timeout(_read, connect=min(15.0, _read))
+        if azure_endpoint is not None:
+            from openai import AsyncAzureOpenAI as _AzCli
+            return _AzCli(azure_endpoint=azure_endpoint, api_version=api_version,
+                          api_key=api_key, timeout=_to, max_retries=0)
+        from openai import AsyncOpenAI as _OaCli
+        _kw = dict(api_key=api_key, timeout=_to, max_retries=0)
+        if base_url:
+            _kw["base_url"] = base_url
+        if default_headers:
+            _kw["default_headers"] = default_headers
+        return _OaCli(**_kw)
+
     if p == "azure":
         azure_endpoint = str(resolved.get("azure_endpoint") or "").strip()
         api_version = str(resolved.get("api_version") or "").strip()
@@ -972,16 +995,14 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         profile = _prompted_json_profile() if _prefers_prompted_structured_output(p, model) else None
         return OpenAIChatModel(
             model,
-            provider=AzureProvider(
-                azure_endpoint=azure_endpoint,
-                api_version=api_version,
-                api_key=api_key,
-            ),
+            provider=AzureProvider(openai_client=_bounded_openai_client(
+                azure_endpoint=azure_endpoint, api_version=api_version, api_key=api_key)),
             profile=profile,
         )
     if p == "deepseek":
         lower_model = model.lower()
-        if "reasoner" in lower_model and DeepSeekProvider is not None and ModelProfile is not None:
+        _ds_client = _bounded_openai_client(base_url="https://api.deepseek.com/v1", api_key=api_key)
+        if "reasoner" in lower_model and ModelProfile is not None:
             # DeepSeek reasoner supports JSON output, but the local PydanticAI DeepSeek
             # profile still defaults structured mode to tools for this model. Override
             # it to prompted JSON-object mode, and keep chat as a later fallback only.
@@ -993,31 +1014,20 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
             )
             return OpenAIChatModel(
                 model,
-                provider=DeepSeekProvider(api_key=api_key),
+                provider=OpenAIProvider(openai_client=_ds_client),
                 profile=reasoner_profile,
             )
         return OpenAIChatModel(
             model,
-            provider=OpenAIProvider(
-                base_url="https://api.deepseek.com/v1",
-                api_key=api_key,
-            ),
+            provider=OpenAIProvider(openai_client=_ds_client),
         )
     if p == "openai":
         base_url = str(resolved.get("base_url") or "").strip()
         profile = _prompted_json_profile() if _prefers_prompted_structured_output(p, model) else None
-        if base_url:
-            return OpenAIChatModel(
-                model,
-                provider=OpenAIProvider(
-                    base_url=base_url,
-                    api_key=api_key,
-                ),
-                profile=profile,
-            )
         return OpenAIChatModel(
             model,
-            provider=OpenAIProvider(api_key=api_key),
+            provider=OpenAIProvider(openai_client=_bounded_openai_client(
+                base_url=(base_url or None), api_key=api_key)),
             profile=profile,
         )
     if p == "nvidia":
@@ -1025,10 +1035,8 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         profile = _prompted_json_profile()
         return OpenAIChatModel(
             model,
-            provider=OpenAIProvider(
-                base_url=base_url,
-                api_key=api_key,
-            ),
+            provider=OpenAIProvider(openai_client=_bounded_openai_client(
+                base_url=base_url, api_key=api_key)),
             profile=profile,
         )
     if p == "bedrock":
@@ -1042,7 +1050,9 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         ).strip()
         if not region:
             return None
-        client = bedrock_client.build_runtime_client(api_key, region)
+        client = bedrock_client.build_runtime_client(
+            api_key, region,
+            timeout_sec=float(os.environ.get("LLM_REQUEST_TIMEOUT", "180") or 180.0))
         # Extended-thinking (bedrock_reasoning) is intentionally NOT applied on
         # the structured path: Converse requires budget_tokens < maxTokens, but
         # structured calls use small max_output_tokens (often 256) where a
@@ -1068,10 +1078,8 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         effective_key = api_key or "ollama"
         return OpenAIChatModel(
             model,
-            provider=OpenAIProvider(
-                base_url=base,
-                api_key=effective_key,
-            ),
+            provider=OpenAIProvider(openai_client=_bounded_openai_client(
+                base_url=base, api_key=effective_key)),
         )
     if p == "openrouter":
         base_url = str(resolved.get("openrouter_base_url") or "https://openrouter.ai/api/v1").strip().rstrip("/")
@@ -1091,16 +1099,11 @@ def _build_pydantic_ai_model(provider: str, api_key: str, model: str, provider_c
         # model that can't honour a forced schema. Models that DO support
         # native schema still work fine under prompted mode.
         profile = _prompted_json_profile()
-        if default_headers:
-            try:
-                from openai import AsyncOpenAI as _AsyncOpenAI
-                _client = _AsyncOpenAI(base_url=base_url, api_key=api_key, default_headers=default_headers)
-                return OpenAIChatModel(model, provider=OpenAIProvider(openai_client=_client), profile=profile)
-            except Exception:
-                pass  # fall through to header-less provider on any client-construction issue
         return OpenAIChatModel(
             model,
-            provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+            provider=OpenAIProvider(openai_client=_bounded_openai_client(
+                base_url=base_url, api_key=api_key,
+                default_headers=(default_headers or None))),
             profile=profile,
         )
     return GoogleModel(

--- a/backend/tests/test_llm_utils_ollama_structured.py
+++ b/backend/tests/test_llm_utils_ollama_structured.py
@@ -38,11 +38,14 @@ def test_build_pydantic_ai_model_ollama_points_at_v1_endpoint():
     assert out is not None
     assert captured["model_name"] == "llama3.2"
     prov_kwargs = fake_prov.call_args.kwargs
-    assert prov_kwargs["base_url"].endswith("/v1")
-    assert prov_kwargs["base_url"].startswith("http://localhost:11434")
+    # base_url + api_key now live on the injected timeout-bounded openai_client.
+    _client = prov_kwargs["openai_client"]
+    _base = str(_client.base_url).rstrip("/")
+    assert _base.endswith("/v1")
+    assert _base.startswith("http://localhost:11434")
     # Empty api_key gets sentinel string for the OpenAI SDK (which insists
     # on a non-empty key) — local Ollama ignores it.
-    assert prov_kwargs["api_key"]
+    assert _client.api_key
 
 
 def test_build_pydantic_ai_model_ollama_does_not_double_append_v1():
@@ -58,8 +61,9 @@ def test_build_pydantic_ai_model_ollama_does_not_double_append_v1():
             provider_config={"ollama_base_url": "https://ollama.com/v1"},
         )
     prov_kwargs = fake_prov.call_args.kwargs
-    assert prov_kwargs["base_url"] == "https://ollama.com/v1"
-    assert prov_kwargs["api_key"] == "cloud-key"
+    _client = prov_kwargs["openai_client"]
+    assert str(_client.base_url).rstrip("/") == "https://ollama.com/v1"
+    assert _client.api_key == "cloud-key"
 
 
 def test_build_pydantic_ai_model_ollama_empty_api_key_allowed():


### PR DESCRIPTION
## Why

Backtests (and live) hang randomly and **don't respect any timeout** — the run freezes mid-lookback with a live heartbeat but zero completed LLM calls. Root cause: the **pydantic-ai "native structured" path** — the path OpenRouter/Nemotron take for structured decisions — built its OpenAI-SDK clients with **no client-level `timeout` and no `max_retries` override**. The SDK then defaults to `max_retries=2` at a ~10-minute timeout, so a single stalled upstream read blocks the caller for **up to ~3×10min**, and the outer transient-retry loop multiplies it again. That's the "random multi-minute hang."

(An audit of every LLM call site confirmed the plain `requests`-based `_call_*` paths — gemini/deepseek/openai/nvidia/openrouter/azure/bedrock — **already** pass `timeout=(connect, read)`. Only the structured/SDK path was unbounded.)

## What

New `_bounded_openai_client()` builds `AsyncOpenAI` / `AsyncAzureOpenAI` with **`timeout=httpx.Timeout(LLM_REQUEST_TIMEOUT [default 180s], connect=15)` AND `max_retries=0`**, injected via `OpenAIProvider(openai_client=)` / `AzureProvider(openai_client=)` for **every** structured provider:

- **openrouter** (incl. the referer/title headers path), openai, azure, nvidia, deepseek, ollama.
- **bedrock**: now passes `LLM_REQUEST_TIMEOUT` (was the 30s default) and `_client_config` clamps `None`/`0` → a safe floor (botocore treats those as an *unbounded* read).
- google is already bounded via `ModelSettings.timeout` (verified in pydantic-ai 1.0.18).

So a stalled provider now aborts at the configured read timeout with **no hidden retry multiplier**, instead of hanging the backtest.

## Verification
- Smoke: openrouter/nvidia/openai/azure clients build with `Timeout(read=…, connect=15) max_retries=0`.
- 45 LLM/provider tests pass; 2 ollama structured tests updated (base_url now lives on the injected client — behaviour identical).
- Full-suite bisect head-vs-base: **byte-identical failure set — zero new failures.**

`LLM_REQUEST_TIMEOUT` (env, default 180) is the single knob to tune the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNDNM55dzjhsY5URx4rYaJ
