### PR TITLE
Kalshi: separate paper vs real-money trading (mode-scoped data + engine restart on toggle)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4479,6 +4479,22 @@ def _kalshi_instance_row(conn, instance_id: str) -> dict:
     return row
 
 
+def _kalshi_show_paper(conn, instance_row: dict) -> bool:
+    """Whether this instance should surface PAPER (MOCK) data — i.e. it is NOT placing
+    real orders (mirrors the engine's `dry` state). A live account with the gate on is
+    the only real-money state that hides paper; paper_mode and demo both show it. Paper
+    rows are never deleted — this only decides which mode's data the read surfaces."""
+    from kalshi.mode import is_real_mode
+    cfg = instance_row.get("kalshi_config") or {}
+    env = "demo"
+    try:
+        bk = _r_auth.db("IntelliStock").table("BrokerageAccounts").get(instance_row.get("brokerage_id")).run(conn) or {}
+        env = bk.get("kalshi_environment") or "demo"
+    except Exception:
+        pass
+    return not is_real_mode(env, bool(cfg.get("live_enabled")), bool(cfg.get("paper_mode")))
+
+
 @app.get("/instances/{instance_id}/kalshi/detail", response_class=JSONResponse)
 def api_kalshi_instance_detail(instance_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
     """Kalshi instance summary: config, run state, linked brokerage env."""
@@ -4505,8 +4521,9 @@ def api_kalshi_instance_decisions(instance_id: str, request: Request, limit: int
     """The LLM-reasoned decision log for this instance (newest first), enriched
     with readable team names + crests (league-agnostic)."""
     from kalshi.decisions import summarize_decisions
+    from kalshi.mode import scope_decisions
     from kalshi.data.ticker_names import parse_market_ticker
-    _kalshi_instance_row(conn, instance_id)
+    row = _kalshi_instance_row(conn, instance_id)
     rows = []
     try:
         rows = list(
@@ -4515,6 +4532,12 @@ def api_kalshi_instance_decisions(instance_id: str, request: Request, limit: int
         )
     except Exception:
         rows = []
+    # Scope to the ACTIVE mode: a real-money instance never surfaces paper rows (and a
+    # paper/demo instance never surfaces real rows). Paper rows stay in the DB — they're
+    # just filtered out of this view, so the board, summary counts, and the paper block
+    # (all derived from `rows`) reflect only the current mode.
+    show_paper = _kalshi_show_paper(conn, row)
+    rows = scope_decisions(rows, show_paper)
     rows.sort(key=lambda d: d.get("ts", ""), reverse=True)
     n = max(1, min(int(limit or 100), 500))
     out = rows[:n]
@@ -4708,6 +4731,7 @@ def api_kalshi_instance_orders(instance_id: str, request: Request, limit: int = 
     (from the broker). Drives the pending/past-orders cards."""
     from kalshi.data.ticker_names import parse_market_ticker
     row = _kalshi_instance_row(conn, instance_id)
+    show_paper = _kalshi_show_paper(conn, row)
     n = max(1, min(int(limit or 50), 200))
 
     # Lookup: market_ticker -> readable info stamped on the decision rows (real team
@@ -4777,9 +4801,17 @@ def api_kalshi_instance_orders(instance_id: str, request: Request, limit: int = 
     # filled-orders HISTORY (also MOCK-tagged) so completed paper trades don't disappear.
     mock: dict = {}
     mock_history: list = []
+    # PAPER (MOCK) trades only surface in paper/demo mode — a real-money instance hides
+    # them (rows stay in the DB, just filtered out of this view).
+    _paper_placed = []
+    if show_paper:
+        try:
+            _paper_placed = list(_r_auth.db("IntelliStock").table("kalshi_decisions")
+                                 .filter({"instance_id": str(instance_id), "decision": "placed", "paper": True}).run(conn))
+        except Exception:
+            _paper_placed = []
     try:
-        for r in list(_r_auth.db("IntelliStock").table("kalshi_decisions")
-                      .filter({"instance_id": str(instance_id), "decision": "placed", "paper": True}).run(conn)):
+        for r in _paper_placed:
             mt = r.get("market_ticker")
             size = int(r.get("size") or 0)
             entry = r.get("entry_avg_cents")

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4521,13 +4521,19 @@ def api_kalshi_instance_detail(instance_id: str, conn=Depends(conn_dependency), 
         env = bk.get("kalshi_environment") or "demo"
     except Exception:
         pass
+    from kalshi.mode import is_real_mode
+    cfg = row.get("kalshi_config") or {}
     return {
         "id": row.get("id"),
         "name": row.get("name"),
         "running": bool(row.get("runCommand", False)),
         "brokerage_id": bid,
         "environment": env,
-        "config": row.get("kalshi_config") or {},
+        "config": cfg,
+        # Authoritative paper-vs-real discriminator (mirrors the engine's dry state and
+        # the API's data scoping) so web/mobile gate paper UI on the SAME signal the
+        # API filters data by — no client-side re-derivation to drift out of sync.
+        "show_paper": not is_real_mode(env, bool(cfg.get("live_enabled")), bool(cfg.get("paper_mode"))),
     }
 
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4333,6 +4333,7 @@ def api_kalshi_update_instance(instance_id: str, body: UpdateKalshiInstanceBody,
     row = _kalshi_instance_row(conn, instance_id)
     bid = row.get("brokerage_id")
     live = False
+    bk = {}
     try:
         bk = _r_auth.db("IntelliStock").table("BrokerageAccounts").get(bid).run(conn) or {}
         live = (bk.get("kalshi_environment") or "demo") == "live"
@@ -4346,10 +4347,24 @@ def api_kalshi_update_instance(instance_id: str, body: UpdateKalshiInstanceBody,
     paper = bool(raw.get("paper_mode")) if raw.get("paper_mode") is not None else bool(prev.get("paper_mode", live))
     live_enabled = live and not paper
     config = normalize_config({**raw, "paper_mode": paper}, live_enabled=live_enabled)
+    # SAFETY: turning real money OFF (live→paper) must not leave resting REAL orders that
+    # could still fill after the switch. Cancel them (best-effort) before persisting the
+    # flip; the engine restart (server.py, triggered by this config write) then re-boots
+    # in paper mode. Open real POSITIONS are left on the broker (never auto-sold).
+    from kalshi.mode import is_real_mode
+    _env = "live" if live else "demo"
+    canceled_orders = 0
+    if (is_real_mode(_env, bool(prev.get("live_enabled")), bool(prev.get("paper_mode")))
+            and not is_real_mode(_env, live_enabled, paper)):
+        try:
+            canceled_orders = int(_kalshi_client_from_row(bk).cancel_all_open_orders() or 0)
+        except Exception:
+            canceled_orders = 0
     _r_auth.db("IntelliStock").table("Instances").get(str(instance_id)).update(
         {"name": body.name.strip(), "kalshi_config": config}
     ).run(conn)
-    return {"ok": True, "id": instance_id, "name": body.name.strip(), "config": config}
+    return {"ok": True, "id": instance_id, "name": body.name.strip(), "config": config,
+            "canceled_orders": canceled_orders}
 
 
 # --- Kalshi backtests -----------------------------------------------------

--- a/backend/kalshi/db.py
+++ b/backend/kalshi/db.py
@@ -302,7 +302,8 @@ def update_close_refs(conn, instance_id, sharp_map, mid_map) -> int:
 
 
 def prune_finished(conn, instance_id, open_tickers, now_iso, *,
-                   delete_after_hours: float = 3.0, expire_after_hours: float = 12.0) -> dict:
+                   delete_after_hours: float = 3.0, expire_after_hours: float = 12.0,
+                   expire_paper: bool = True) -> dict:
     """Drop stale skipped/blocked decision rows + expire stuck-open paper trades for
     markets no longer in Kalshi's OPEN set (finished games), so the pregame board and
     open-trade list don't accumulate completed matches. Recently-seen rows are kept
@@ -320,7 +321,8 @@ def prune_finished(conn, instance_id, open_tickers, now_iso, *,
         return {"deleted": 0, "expired": 0}
     plan = prune_finished_decisions(rows, open_tickers, now_iso,
                                     delete_after_hours=delete_after_hours,
-                                    expire_after_hours=expire_after_hours)
+                                    expire_after_hours=expire_after_hours,
+                                    expire_paper=expire_paper)
     deleted = expired = 0
     for did in plan["delete"]:
         try:

--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -890,6 +890,11 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                         d["entry_edge"] = d.get("edge")   # edge AT placement (UI: "placed @ X%")
                         log(f"tick {tick}: PAPER would place {a['contracts']}x {d['market_ticker']} @ "
                             f"{a['price_cents']}c (edge {(d['edge'] or 0):.1%}).", "cyan")
+                # Stamp the mode on EVERY decision row (not just placed fills) so the
+                # API/UI can scope the pregame board + decision-summary counts by mode.
+                # (The placed-paper branch above already set True when dry; this makes
+                # skipped/blocked/real rows carry paper=False explicitly.)
+                d["paper"] = bool(dry)
                 try:
                     kdb._r.db(kdb.DB_NAME).table("kalshi_decisions").insert(d, conflict="replace").run(conn)
                 except Exception:
@@ -909,13 +914,17 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
             except Exception as e:
                 log(f"tick {tick}: settle_and_learn failed: {type(e).__name__}: {e}", "yellow")
             # 7c) Mark open PAPER positions to the live Kalshi price (live unrealized
-            # P&L for the UI) + append each side's edge to the rolling sparkline series.
+            # P&L for the UI). PAPER (dry) mode ONLY — a live/real engine must never
+            # touch paper positions; they stay frozen at their last mark until paper
+            # resumes. `_mark_map` is still built every tick because update_close_refs
+            # (CLV, below) needs it for real positions too.
             try:
                 _mark_map = {p["market_ticker"]: p["mid_cents"] for p in soccer if p.get("mid_cents")}
-                _m = kdb.mark_paper_positions(conn, config.instance_id, _mark_map)
-                if _m.get("marked"):
-                    log(f"tick {tick}: marked {_m['marked']} paper position(s) — "
-                        f"unrealized {_m['unrealized_pnl_cents'] / 100:+.2f}.", "white")
+                if dry:
+                    _m = kdb.mark_paper_positions(conn, config.instance_id, _mark_map)
+                    if _m.get("marked"):
+                        log(f"tick {tick}: marked {_m['marked']} paper position(s) — "
+                            f"unrealized {_m['unrealized_pnl_cents'] / 100:+.2f}.", "white")
             except Exception as e:
                 log(f"tick {tick}: mark_paper_positions failed: {type(e).__name__}: {e}", "yellow")
             try:
@@ -941,7 +950,9 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
             # discovery (no mass-delete on an outage).
             try:
                 _open_tk = {p["market_ticker"] for p in soccer if p.get("market_ticker")}
-                _pr = kdb.prune_finished(conn, config.instance_id, _open_tk, ts)
+                # expire_paper=dry: a live/real engine deletes stale skipped board rows
+                # but never expires (mutates) a frozen paper position.
+                _pr = kdb.prune_finished(conn, config.instance_id, _open_tk, ts, expire_paper=dry)
                 if _pr.get("deleted") or _pr.get("expired"):
                     log(f"tick {tick}: pruned {_pr['deleted']} finished decision row(s), "
                         f"expired {_pr['expired']} stale open trade(s).", "white")
@@ -984,9 +995,9 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                 log(f"tick {tick}: live monitor — {len(live_matches)} in-play match(es), "
                     f"{len(live_rows)} markets watched, {acted} order(s).", "magenta")
                 for r in live_rows:
-                    # paper-tag in-play would-be trades so the feedback loop grades them too
-                    if live_dry and r.get("decision") == "placed":
-                        r["paper"] = True
+                    # Stamp mode on every in-play row (generalises the placed-only tag) so
+                    # the feedback loop + API/UI scope in-play decisions by mode too.
+                    r["paper"] = bool(live_dry)
                     try:
                         kdb._r.db(kdb.DB_NAME).table("kalshi_decisions").insert(r, conflict="replace").run(conn)
                     except Exception:

--- a/backend/kalshi/mode.py
+++ b/backend/kalshi/mode.py
@@ -1,0 +1,29 @@
+"""Pure paper-vs-real mode discriminator + decision-row scoping. No DB, no imports
+of the heavy engine module — so the API can import this cheaply on hot read paths.
+
+`is_real_mode` MIRRORS `engine.should_execute` (the real-order gate). The gate itself
+is NOT modified; `test_kalshi_mode.test_is_real_mode_matches_should_execute_contract`
+enforces the two never diverge.
+"""
+from __future__ import annotations
+
+
+def is_real_mode(environment: str, live_enabled: bool, paper_mode: bool = False) -> bool:
+    """True iff this instance places REAL orders. Demo executes freely; live requires
+    the explicit gate; paper_mode is a HARD override (never real). The single
+    discriminator for paper-vs-real scoping across engine, API, and UI."""
+    if paper_mode:
+        return False
+    env = (environment or "").lower()
+    if env == "demo":
+        return True
+    if env in ("live", "prod"):
+        return bool(live_enabled)
+    return False
+
+
+def scope_decisions(rows: list[dict], show_paper: bool) -> list[dict]:
+    """Keep only rows for the active mode. show_paper=True -> paper rows (paper
+    truthy); False -> real rows (paper falsy / absent)."""
+    want = bool(show_paper)
+    return [r for r in rows if bool(r.get("paper")) == want]

--- a/backend/kalshi/mode.py
+++ b/backend/kalshi/mode.py
@@ -27,3 +27,19 @@ def scope_decisions(rows: list[dict], show_paper: bool) -> list[dict]:
     truthy); False -> real rows (paper falsy / absent)."""
     want = bool(show_paper)
     return [r for r in rows if bool(r.get("paper")) == want]
+
+
+def kalshi_mode_changed(old_val, new_val) -> bool:
+    """True iff a kalshi instance's paper/live mode flipped between two Instances
+    changefeed snapshots. The engine's EngineConfig (incl. paper_mode/live_enabled) is
+    frozen at container boot, so a toggle only takes effect after the container is
+    recycled — server.py uses this to decide when to restart a RUNNING instance. Returns
+    False for non-kalshi rows, missing snapshots, or non-mode edits (name/caps/etc.)."""
+    if not old_val or not new_val:
+        return False
+    if new_val.get("kind") != "kalshi":
+        return False
+    o = old_val.get("kalshi_config") or {}
+    n = new_val.get("kalshi_config") or {}
+    return (bool(o.get("paper_mode")) != bool(n.get("paper_mode"))
+            or bool(o.get("live_enabled")) != bool(n.get("live_enabled")))

--- a/backend/kalshi/reconcile.py
+++ b/backend/kalshi/reconcile.py
@@ -182,7 +182,8 @@ def _last_seen_age_hours(row, now_iso) -> float | None:
 
 def prune_finished_decisions(rows, open_tickers, now_iso, *,
                              delete_after_hours: float = 3.0,
-                             expire_after_hours: float = 12.0) -> dict:
+                             expire_after_hours: float = 12.0,
+                             expire_paper: bool = True) -> dict:
     """Decisions whose market is no longer in Kalshi's OPEN set and that haven't been
     seen open for a while are from FINISHED games. Returns {"delete":[ids],"expire":[ids]}:
       - skipped/blocked/queued, not seen open for >= delete_after_hours -> DELETE (clears
@@ -205,7 +206,7 @@ def prune_finished_decisions(rows, open_tickers, now_iso, *,
         if age is None:
             continue
         if r.get("decision") == "placed":
-            if r.get("outcome") is None and age >= expire_after_hours:
+            if expire_paper and r.get("outcome") is None and age >= expire_after_hours:
                 # Realize at the LAST mark: the unrealized P&L the engine stamped each
                 # tick becomes the realized P&L (best estimate when Kalshi never settled
                 # it), so the dashboard's realized total + filled-orders history keep it.

--- a/backend/server.py
+++ b/backend/server.py
@@ -1241,6 +1241,24 @@ def run_thread_service_change(change, c):
                     running_threads.remove(instance_id)
         elif not run_approval and instance_id in running_threads_objs:
             stop_instance_container(instance_id)
+        elif run_approval and instance_id in running_threads_objs:
+            # Already running: recycle the container ONLY when the kalshi paper/live mode
+            # flipped. The engine's EngineConfig is frozen at boot, so a paper toggle needs
+            # a fresh process to take effect. Other config edits (name/caps/tier) keep
+            # today's behaviour (apply on next manual restart) to keep the blast radius on
+            # a real-money engine minimal.
+            from kalshi.mode import kalshi_mode_changed
+            if kalshi_mode_changed(old_val, new_val):
+                intellistock_logger.log(
+                    f"Kalshi instance {instance_id}: paper/live mode changed — restarting engine.",
+                    "yellow", service="SERVER")
+                stop_instance_container(instance_id)
+                running_threads.append(instance_id)
+                thread_count += 1
+                if start_instance_container(instance_id) is None:
+                    thread_count -= 1
+                    if instance_id in running_threads:
+                        running_threads.remove(instance_id)
     except Exception as e:
         intellistock_logger.log(str(e), "red", service="SERVER")
     callback_done.set()

--- a/backend/tests/test_kalshi_mode.py
+++ b/backend/tests/test_kalshi_mode.py
@@ -1,0 +1,36 @@
+"""Pure paper-vs-real mode discriminator + decision-row scoping (kalshi.mode).
+
+is_real_mode MUST mirror engine.should_execute (the real-order gate) — the contract
+test enforces they never diverge.
+"""
+from kalshi.mode import is_real_mode, scope_decisions
+from kalshi.engine import should_execute
+
+
+def test_is_real_mode_truth_table():
+    assert is_real_mode("demo", False, False) is True        # demo executes freely
+    assert is_real_mode("live", True, False) is True          # live + gate on
+    assert is_real_mode("live", False, False) is False        # live, gate off
+    assert is_real_mode("live", True, True) is False          # paper_mode hard override
+    assert is_real_mode("", True, False) is False             # unknown env
+
+
+def test_is_real_mode_matches_should_execute_contract():
+    # mode.is_real_mode MUST never diverge from the real-order gate.
+    for env in ("demo", "live", "prod", "", "weird"):
+        for le in (True, False):
+            for pm in (True, False):
+                assert is_real_mode(env, le, pm) == should_execute(env, le, pm)
+
+
+def test_scope_decisions_paper_vs_real():
+    rows = [
+        {"id": "a", "paper": True, "decision": "placed"},
+        {"id": "b", "decision": "skipped"},              # no flag -> real side
+        {"id": "c", "paper": False, "decision": "placed"},
+        {"id": "d", "paper": True, "decision": "skipped"},
+    ]
+    paper = {r["id"] for r in scope_decisions(rows, show_paper=True)}
+    real = {r["id"] for r in scope_decisions(rows, show_paper=False)}
+    assert paper == {"a", "d"}
+    assert real == {"b", "c"}

--- a/backend/tests/test_kalshi_mode.py
+++ b/backend/tests/test_kalshi_mode.py
@@ -3,7 +3,7 @@
 is_real_mode MUST mirror engine.should_execute (the real-order gate) — the contract
 test enforces they never diverge.
 """
-from kalshi.mode import is_real_mode, scope_decisions
+from kalshi.mode import is_real_mode, scope_decisions, kalshi_mode_changed
 from kalshi.engine import should_execute
 
 
@@ -34,3 +34,29 @@ def test_scope_decisions_paper_vs_real():
     real = {r["id"] for r in scope_decisions(rows, show_paper=False)}
     assert paper == {"a", "d"}
     assert real == {"b", "c"}
+
+
+def _inst(kind="kalshi", paper=False, live_enabled=True, name="x"):
+    return {"id": "i1", "kind": kind, "name": name,
+            "kalshi_config": {"paper_mode": paper, "live_enabled": live_enabled}}
+
+
+def test_mode_changed_on_paper_flip():
+    assert kalshi_mode_changed(_inst(paper=False, live_enabled=True),
+                               _inst(paper=True, live_enabled=False)) is True
+
+
+def test_mode_unchanged_on_name_only_edit():
+    assert kalshi_mode_changed(_inst(paper=True, live_enabled=False, name="a"),
+                               _inst(paper=True, live_enabled=False, name="b")) is False
+
+
+def test_mode_changed_ignores_non_kalshi():
+    old = {"id": "i", "kind": "stock", "kalshi_config": {"paper_mode": False}}
+    new = {"id": "i", "kind": "stock", "kalshi_config": {"paper_mode": True}}
+    assert kalshi_mode_changed(old, new) is False
+
+
+def test_mode_changed_handles_missing_snapshots():
+    assert kalshi_mode_changed(None, _inst()) is False
+    assert kalshi_mode_changed(_inst(), None) is False

--- a/backend/tests/test_kalshi_reconcile.py
+++ b/backend/tests/test_kalshi_reconcile.py
@@ -76,6 +76,23 @@ def test_prune_never_acts_without_open_set():
     assert out == {"delete": [], "expire": []}
 
 
+def test_prune_expire_paper_false_keeps_paper_positions_open():
+    # In LIVE mode the engine passes expire_paper=False so a frozen paper position is
+    # never expired (mutated), but stale skipped board rows are still cleaned up.
+    now = "2026-06-30T06:00:00+00:00"
+    rows = [
+        {"id": "i|OLDSKIP", "decision": "skipped", "market_ticker": "DONE1", "outcome": None,
+         "ts": "2026-06-29T00:00:00+00:00"},
+        {"id": "i|OPENTRADE", "decision": "placed", "market_ticker": "DONE3", "outcome": None,
+         "ts": "2026-06-29T00:00:00+00:00", "unrealized_pnl_cents": -120},
+    ]
+    out = prune_finished_decisions(rows, {"OPEN"}, now,
+                                   delete_after_hours=3.0, expire_after_hours=12.0,
+                                   expire_paper=False)
+    assert out["expire"] == []                      # paper position left frozen
+    assert set(out["delete"]) == {"i|OLDSKIP"}      # stale skipped still cleaned
+
+
 # --- P3: roll the closing reference (sharp prob + Kalshi mid) onto open positions ---
 
 def test_close_ref_updates_open_placed_only():

--- a/docs/superpowers/plans/2026-07-06-kalshi-paper-real-separation.md
+++ b/docs/superpowers/plans/2026-07-06-kalshi-paper-real-separation.md
@@ -1,0 +1,230 @@
+# Kalshi Paper vs Real-Money Separation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline). Steps use checkbox (`- [ ]`) syntax. Spec: `docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md`.
+
+**Goal:** Keep paper and real-money Kalshi trading in two logically separate spaces — engine, API, and UI each see only the active mode's data; paper data hidden-but-preserved; engine restarts on a paper-mode toggle.
+
+**Architecture:** One discriminator — `is_real_mode()` (a pure mirror of `engine.should_execute`) — applied on every read. Paper data is filtered, never moved/deleted. Engine stops marking/expiring paper positions when real; the `server.py` changefeed restarts the container on a mode change; the API scopes decisions/orders/paper-P&L by mode; the web UI gates paper sections on the existing `liveReal`.
+
+**Tech Stack:** Python (FastAPI, RethinkDB, pytest), Docker (per-instance engine container), Vue 3 (frontend).
+
+## Global Constraints
+
+- **Do NOT modify `engine.should_execute` (`backend/kalshi/engine.py:38`)** — it is the real-order gate. Mirror it in `kalshi/mode.py` and enforce parity with a contract test.
+- Discriminator everywhere: `is_real_mode(environment, live_enabled, paper_mode)`; `show_paper = not is_real_mode(...)`. Demo instances are `dry`/paper-showing.
+- No schema migration, no backfill, nothing deleted. Paper rows already carry `paper=True` on placed fills.
+- Restart trigger scoped to a paper_mode/live_enabled change on a **running** instance only.
+- Run `gitnexus_impact` before editing each symbol; `gitnexus_detect_changes` before committing.
+- Tests run from `backend/`: `cd backend && python3 -m pytest tests/<file> -q`.
+
+---
+
+### Task 0: Confirm test harness
+
+- [ ] Run an existing Kalshi test to confirm the command/paths.
+  Run: `cd backend && python3 -m pytest tests/test_kalshi_decisions.py -q`
+  Expected: PASS (baseline).
+
+---
+
+### Task 1: `kalshi/mode.py` — pure mode discriminator + row scoping
+
+**Files:**
+- Create: `backend/kalshi/mode.py`
+- Test: `backend/tests/test_kalshi_mode.py`
+
+**Interfaces — Produces:**
+- `is_real_mode(environment: str, live_enabled: bool, paper_mode: bool = False) -> bool`
+- `scope_decisions(rows: list[dict], show_paper: bool) -> list[dict]`
+
+- [ ] **Step 1: Write failing tests** (`backend/tests/test_kalshi_mode.py`):
+
+```python
+from kalshi.mode import is_real_mode, scope_decisions
+from kalshi.engine import should_execute
+
+
+def test_is_real_mode_truth_table():
+    assert is_real_mode("demo", False, False) is True        # demo executes freely
+    assert is_real_mode("live", True, False) is True          # live + gate on
+    assert is_real_mode("live", False, False) is False        # live, gate off
+    assert is_real_mode("live", True, True) is False          # paper_mode hard override
+    assert is_real_mode("", True, False) is False             # unknown env
+
+
+def test_is_real_mode_matches_should_execute_contract():
+    # mode.is_real_mode MUST never diverge from the real-order gate.
+    for env in ("demo", "live", "prod", "", "weird"):
+        for le in (True, False):
+            for pm in (True, False):
+                assert is_real_mode(env, le, pm) == should_execute(env, le, pm)
+
+
+def test_scope_decisions_paper_vs_real():
+    rows = [
+        {"id": "a", "paper": True, "decision": "placed"},
+        {"id": "b", "decision": "skipped"},              # no flag -> real side
+        {"id": "c", "paper": False, "decision": "placed"},
+        {"id": "d", "paper": True, "decision": "skipped"},
+    ]
+    paper = {r["id"] for r in scope_decisions(rows, show_paper=True)}
+    real = {r["id"] for r in scope_decisions(rows, show_paper=False)}
+    assert paper == {"a", "d"}
+    assert real == {"b", "c"}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`ModuleNotFoundError: kalshi.mode`).
+  Run: `cd backend && python3 -m pytest tests/test_kalshi_mode.py -q`
+
+- [ ] **Step 3: Implement `backend/kalshi/mode.py`:**
+
+```python
+"""Pure paper-vs-real mode discriminator + decision-row scoping. No DB, no imports
+of the heavy engine module — so the API can import this cheaply on hot read paths.
+
+`is_real_mode` MIRRORS `engine.should_execute` (the real-order gate). The gate is
+NOT modified; `test_kalshi_mode.test_is_real_mode_matches_should_execute_contract`
+enforces they never diverge.
+"""
+from __future__ import annotations
+
+
+def is_real_mode(environment: str, live_enabled: bool, paper_mode: bool = False) -> bool:
+    """True iff this instance places REAL orders. Demo executes freely; live requires
+    the explicit gate; paper_mode is a HARD override (never real). The single
+    discriminator for paper-vs-real scoping across engine, API, and UI."""
+    if paper_mode:
+        return False
+    env = (environment or "").lower()
+    if env == "demo":
+        return True
+    if env in ("live", "prod"):
+        return bool(live_enabled)
+    return False
+
+
+def scope_decisions(rows: list[dict], show_paper: bool) -> list[dict]:
+    """Keep only rows for the active mode. show_paper=True -> paper rows (paper
+    truthy); False -> real rows (paper falsy / absent)."""
+    want = bool(show_paper)
+    return [r for r in rows if bool(r.get("paper")) == want]
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(kalshi): pure is_real_mode + scope_decisions mode discriminator`.
+
+---
+
+### Task 2: `prune_finished_decisions` — gate paper-position expiry
+
+**Files:**
+- Modify: `backend/kalshi/reconcile.py:183` (`prune_finished_decisions`)
+- Modify: `backend/kalshi/db.py:304` (`prune_finished` — thread the param)
+- Test: `backend/tests/test_kalshi_reconcile.py` (add a case)
+
+**Interfaces — Produces:** `prune_finished_decisions(rows, open_tickers, now_iso, *, delete_after_hours=3.0, expire_after_hours=12.0, expire_paper=True)`; `db.prune_finished(..., expire_paper=True)`.
+
+- [ ] **Step 1: Failing test** — assert `expire_paper=False` yields an empty `expire` plan but still deletes stale skipped rows. (Read the existing test file first for row-shape fixtures; mirror them. Write a case building a stuck-open placed paper row + a stale skipped row for a finished market, assert `plan["expire"] == []` when `expire_paper=False`, and the skipped row still in `plan["delete"]`.)
+- [ ] **Step 2: Run — expect FAIL** (unexpected `expire_paper` kwarg).
+- [ ] **Step 3: Implement:** add `expire_paper: bool = True` to `prune_finished_decisions`; when False, force `expire = []` (keep `delete` unchanged). In `db.prune_finished`, add `expire_paper: bool = True` param and pass it through to `prune_finished_decisions`.
+- [ ] **Step 4: Run — expect PASS** (`tests/test_kalshi_reconcile.py`).
+- [ ] **Step 5: Commit** `feat(kalshi): prune_finished can skip paper-position expiry (expire_paper flag)`.
+
+---
+
+### Task 3: Engine — stamp mode on every decision row + gate paper mutations
+
+**Files:** Modify `backend/kalshi/engine.py` (inside `run_instance` tick loop).
+
+- [ ] `gitnexus_impact({target: "run_instance", direction: "upstream"})` and `gitnexus_impact({target: "mark_paper_positions"})`; report blast radius.
+- [ ] **Stamp pregame rows:** in the `for d in decisions:` loop (`~:808`), before the row insert (`~:894`), set `d["paper"] = bool(dry)`. (Supersedes the placed-only `d["paper"] = True` at `:888`, which stays consistent.)
+- [ ] **Stamp in-play rows:** before the in-play insert (`~:991`), set `r["paper"] = bool(live_dry)` for every `r` (generalises the placed-only `:989`).
+- [ ] **Gate marking:** wrap the `mark_paper_positions` block (`:911-920`) in `if dry:` so the live engine never marks paper positions.
+- [ ] **Gate expiry:** change the `prune_finished(...)` call (`:944`) to pass `expire_paper=dry`.
+- [ ] **Verify:** `cd backend && python3 -m pytest tests/test_kalshi_engine.py -q` (existing engine tests still green).
+- [ ] **Commit** `feat(kalshi): engine stamps mode on all decision rows; live engine leaves paper positions frozen`.
+
+---
+
+### Task 4: API — scope decisions & orders by mode
+
+**Files:** Modify `backend/api/main.py` (`api_kalshi_instance_decisions:4503`, `api_kalshi_instance_orders:4705`; add helper `_kalshi_show_paper`).
+
+- [ ] `gitnexus_impact` on `api_kalshi_instance_decisions` and `api_kalshi_instance_orders`.
+- [ ] Add helper near the other kalshi helpers:
+
+```python
+def _kalshi_show_paper(conn, instance_row: dict) -> bool:
+    """Whether this instance should surface PAPER data (i.e. it is NOT placing real
+    orders). Mirrors the engine's dry state."""
+    from kalshi.mode import is_real_mode
+    cfg = instance_row.get("kalshi_config") or {}
+    env = "demo"
+    try:
+        bk = _r_auth.db("IntelliStock").table("BrokerageAccounts").get(instance_row.get("brokerage_id")).run(conn) or {}
+        env = bk.get("kalshi_environment") or "demo"
+    except Exception:
+        pass
+    return not is_real_mode(env, bool(cfg.get("live_enabled")), bool(cfg.get("paper_mode")))
+```
+
+- [ ] **Decisions endpoint:** capture `row = _kalshi_instance_row(...)` (currently the return is unused), compute `show_paper = _kalshi_show_paper(conn, row)`, then `from kalshi.mode import scope_decisions; rows = scope_decisions(rows, show_paper)` right after the fetch (`~:4515`) so `out`, `summary`, `count`, and the `paper` block all derive from the scoped set. Return the `paper` block only when `show_paper` (`else None`).
+- [ ] **Orders endpoint:** compute `show_paper = _kalshi_show_paper(conn, row)` (row already fetched `:4710`); build `mock` / `mock_history` only when `show_paper` (else leave `mock={}` / `mock_history=[]`). The `info_by_ticker`/`edge_by_ticker` lookups stay (mode-agnostic enrichment).
+- [ ] **Test (pure helper already covered in Task 1).** Add/adjust `tests/test_kalshi_api_payloads.py` only if a pure shaper changed (it didn't) — endpoint wiring verified E2E in Task 7.
+- [ ] **Verify:** `cd backend && python3 -m pytest tests/test_kalshi_api_payloads.py tests/test_kalshi_mode.py -q`.
+- [ ] **Commit** `feat(kalshi): decisions & orders endpoints return only the active mode's data`.
+
+---
+
+### Task 5: Restart engine on paper-mode toggle (+ cancel resting orders on live→paper)
+
+**Files:** Modify `backend/api/main.py:4328` (`api_kalshi_update_instance`); `backend/server.py:1215` (`run_thread_service_change`); add pure helper `kalshi_mode_changed`.
+
+- [ ] `gitnexus_impact` on `api_kalshi_update_instance` and `run_thread_service_change`.
+- [ ] **PATCH — cancel resting real orders on a live→paper switch.** After computing `paper`/`live_enabled` and BEFORE writing config, compute prev vs next real-mode from `kalshi.mode.is_real_mode` (env from the brokerage `bk`); if `was_real and not now_real`, best-effort `_kalshi_client_from_row(bk).cancel_all_open_orders()` (wrap in try/except; never block the save).
+- [ ] **server.py — restart on mode change.** Add pure helper (top of file or a small util) and unit test:
+
+```python
+def kalshi_mode_changed(old_val, new_val) -> bool:
+    """True iff a running kalshi instance's paper/live mode flipped between two
+    changefeed snapshots (so the container must be recycled to rebuild EngineConfig)."""
+    if not old_val or not new_val:
+        return False
+    if (new_val.get("kind") != "kalshi"):
+        return False
+    o = old_val.get("kalshi_config") or {}
+    n = new_val.get("kalshi_config") or {}
+    return (bool(o.get("paper_mode")) != bool(n.get("paper_mode"))
+            or bool(o.get("live_enabled")) != bool(n.get("live_enabled")))
+```
+
+  In `run_thread_service_change`, add a branch after the start/stop elif: when `run_approval and instance_id in running_threads_objs and kalshi_mode_changed(old_val, new_val)`, recycle the container — `stop_instance_container(instance_id)`, then re-`append`/`thread_count += 1` and `start_instance_container(instance_id)` (mirror the existing start branch's bookkeeping).
+- [ ] **Test:** `backend/tests/test_server_kalshi_restart.py` — `kalshi_mode_changed` true on paper flip, false on name-only change / non-kalshi / missing old_val.
+- [ ] **Verify:** `cd backend && python3 -m pytest tests/test_server_kalshi_restart.py -q`.
+- [ ] **Commit** `feat(kalshi): restart engine on paper-mode toggle; cancel resting orders on live→paper`.
+
+---
+
+### Task 6: Web UI — show only the active mode
+
+**Files:** Modify `frontend/src/views/KalshiInstanceDetailView.vue`, `frontend/src/components/kalshi/KalshiPortfolioChart.vue`.
+
+- [ ] Read both files. Gate on the existing `liveReal` (`KalshiInstanceDetailView.vue:98`):
+  - MOCK progress chart (`:345`), MOCK trades summary (`:355`), per-row MOCK badge (`:486`) + per-row paper P&L (`:502`), Mock positions / Mock filled (`:541-590`): render only when `!liveReal`.
+  - Pass `:is-real="liveReal"` (or `:paper-mode="!liveReal"`) into `<KalshiPortfolioChart>`; in the component replace `isPaper = paperSeries.length > 0` (`:55`) with the prop, so it shows the real value curve in real mode and the paper P&L curve otherwise.
+  - Add real-mode empty states where a paper card is hidden ("No real trades yet").
+- [ ] **Verify:** `cd frontend && npm run build` (typecheck/build clean); visual check in Task 7.
+- [ ] **Commit** `feat(kalshi-web): hide paper sections in real-money mode, show real equivalents`.
+
+---
+
+### Task 7: End-to-end verification
+
+- [ ] Backend: `cd backend && python3 -m pytest tests/test_kalshi_mode.py tests/test_kalshi_reconcile.py tests/test_kalshi_engine.py tests/test_kalshi_decisions.py tests/test_kalshi_api_payloads.py tests/test_server_kalshi_restart.py -q` — all green.
+- [ ] Drive the real detail page: in real mode, MOCK/paper sections gone, real sections present; toggle to paper → engine restarts and paper view restored; toggle back → restarts into real. Confirm a `live` engine log no longer prints `marked N paper position(s)`.
+- [ ] `gitnexus_detect_changes()` — confirm only expected symbols/flows changed.
+- [ ] Open PR.
+
+## Self-Review (against spec)
+
+- Spec §3 write-path stamp → Task 3. §4.1 engine gating → Tasks 2–3. §4.2 restart + cancel → Task 5. §4.3 API scoping → Tasks 1,4. §4.4 web UI → Task 6. §6 tests → Tasks 1,2,5,7. §4.5 mobile → explicitly deferred (server-side gating in Task 4 covers its decisions/orders data). No placeholders; `is_real_mode`/`scope_decisions`/`show_paper`/`expire_paper`/`kalshi_mode_changed` names consistent across tasks.

--- a/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
+++ b/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
@@ -154,6 +154,13 @@ free.
   the real portfolio-value curve in real mode.
 - Real-mode empty states: until real trades exist, real sections show a clean "no real
   trades yet" rather than paper data.
+- **Pregame Analysis in real mode shows the *live* engine's decisions** (the engine
+  analyzes every match each tick regardless of mode), with no MOCK/paper markers — it is
+  not blanked out. The paper pregame board is preserved and restored on switch-back. This
+  reads the user's "the pregame data should disappear (and be saved)" as *replace the
+  paper board with the live board, preserving the paper one* — the more useful behavior
+  for a running real instance. (Hiding the section entirely in real mode is a one-line
+  conditional if preferred.)
 
 ### 4.5 Mobile (`mobile/lib/features/kalshi/**`)
 

--- a/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
+++ b/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
@@ -179,6 +179,21 @@ series selection is client-side — noted as a fast-follow, not in this change's
 - **Non-goals:** physical table separation; a paper-history "archive" browser in real
   mode; restarting on non-mode config edits; the mobile chart series selection.
 
+### Residual risks (reviewed & accepted)
+
+- **live→paper cancel is best-effort + the restart is async.** The API cancels resting
+  real orders, then the config write triggers the `server.py` restart. Between the cancel
+  and the container teardown the old (still real) engine could, in principle, place one
+  more order (poll interval 30s ≫ ~5s teardown, so effectively never). This strictly
+  improves on the pre-change behavior (no cancel, no restart at all). Fully closing it
+  would require canceling inside the server-side restart after the old container stops —
+  deferred as not worth the cross-process complexity for this window.
+- **Hiding real rows in paper mode reduces observability of a *missed* restart.** If the
+  engine ever failed to restart after a flip (requires a changefeed `old_val` of `None`,
+  which does not occur for `.update()`s), a still-real engine's rows would be filtered
+  out of the paper view. The restart guard is correct for all real update events; noted
+  for completeness.
+
 ## 6. Testing strategy
 
 - **Pure/unit (no DB):** `should_execute`-driven `show_paper`; `summarize_decisions` over a

--- a/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
+++ b/docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md
@@ -1,0 +1,197 @@
+# Kalshi Paper vs Real-Money Separation — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (design), pre-implementation
+**Scope:** A Kalshi trading instance must keep **paper** and **real-money** trading in
+two logically separate spaces. Each mode's engine, API, and UI see only that mode's
+data; the other mode's data is hidden but fully preserved. Toggling the paper setting
+restarts the engine so the change takes effect.
+
+---
+
+## 1. Problem
+
+When a live-brokerage Kalshi instance has its **paper-mode** toggle turned OFF (→ real
+money), the instance still surfaces all its paper ("MOCK") data:
+
+- The detail page shows the **PAPER P&L · PROGRESS (MOCK)** card, the **MOCK · N trades**
+  summary, mock positions/history, and per-row MOCK badges in Pregame Analysis.
+- The running engine still **marks paper positions every tick** (`marked 4 paper
+  position(s)` appears in a `live` engine's logs).
+
+Requirements (from the user):
+
+1. Paper and real are **two separate spaces** — positions, decisions, P&L, pregame.
+2. The engine sees **only the active mode's data** (the live engine must not read/mark/
+   mutate paper positions or decisions; the paper engine must not touch real ones).
+3. Flipping the paper toggle **restarts the engine** (both directions).
+4. The **UI shows only the active mode**, inactive-mode data hidden but preserved, so
+   switching back to paper restores everything exactly as it was.
+
+## 2. Root cause
+
+Paper and real are **not** separate tables. Everything lives in one set of `kalshi_*`
+tables. A paper trade is a `kalshi_decisions` row with `paper: true`; a real trade is the
+same row without it. That flag is stamped correctly **at write time**
+(`engine.py:888` pregame fill, `engine.py:989` in-play), so existing paper data is already
+tagged and safe — nothing needs migrating or deleting.
+
+The bug is entirely on the **read side**: nothing filters by the instance's *current* mode.
+
+- **Engine:** `mark_paper_positions()` (`db.py:244`, called `engine.py:915`) and the
+  paper-expire path of `prune_finished()` (`db.py:331`) run **regardless of mode** — the
+  only paper operations not already gated on `dry`. (Paper dedup `engine.py:759`, paper
+  cash `engine.py:797`, paper-fill tagging `engine.py:888`, and the paper-P&L snapshot
+  `engine.py:1054` are all already `if dry:`.)
+- **API:** three endpoints return paper data whenever it exists, with no mode check —
+  decisions/paper-block (`main.py:4537`), orders/mock (`main.py:4782`), portfolio
+  paper series (`api_payloads.py:30` via `telemetry.paper_pnl_series`).
+- **UI:** `KalshiInstanceDetailView.vue` computes `liveReal` but only uses it for the
+  header badge (`:319`); every MOCK section renders on data-presence alone.
+
+## 3. Design principle
+
+**One discriminator, applied on every read.** An instance is in **REAL mode** iff
+`should_execute(environment, live_enabled, paper_mode)` is true (`engine.py:38`); otherwise
+it is in **PAPER/dry mode**. Note **demo** instances are also `dry` and legitimately show
+paper data — so the discriminator is `should_execute` / the engine's `dry`, **not** raw
+`paper_mode`. The frontend's existing `liveReal` computes the same predicate. We unify all
+three layers (engine, API, UI) on this single notion of "is this instance placing real
+orders right now."
+
+- Paper data is **never moved or deleted** — it is filtered out of the active view and the
+  engine's working set, and reappears intact when the mode flips back.
+- Approach **A (mode-scoped reads)** chosen over **B (physical table split)**: rows are
+  already correctly tagged, so scoping is a filter — no schema migration or data move on a
+  live real-money dataset.
+
+### Decision-row mode tagging (the one write-path change)
+
+The `paper` flag is currently stamped **only on placed fills**, so skipped/blocked rows
+(the Pregame board and Decision-Summary counts) carry no mode tag and can't be scoped.
+Fix: stamp `paper = bool(dry)` on **every** decision row at write time (pregame
+`engine.py:894`, in-play `engine.py:991`).
+
+- Backward-compatible: existing paper-P&L / marking filters require
+  `decision == "placed" AND paper == True`, so adding `paper == False` to skipped/real
+  rows changes nothing there.
+- The decision `id` is `f"{instance_id}|{market_ticker}|{ts}"` (`decisions.py:36`) — the
+  timestamp is in the id, so each tick writes a *new* row and going live can **never**
+  overwrite a paper position row.
+- **No backfill.** Pre-deploy skipped rows lack the flag; they are visually identical to
+  live skipped rows (skipped rows carry no MOCK marker), get superseded by fresh
+  same-market rows each tick, and are pruned when their match finishes — self-healing
+  within hours. We deliberately do not mutate historical rows on a real-money instance.
+  (If exact historical counts are wanted immediately, a bounded non-placed-only backfill
+  is a possible fast-follow — out of scope here.)
+
+## 4. Changes by layer
+
+### 4.1 Engine (`backend/kalshi/engine.py`, `backend/kalshi/db.py`)
+
+- **Stamp mode on every decision row:** set `d["paper"] = bool(dry)` before the pregame
+  write (`engine.py:894`) and `r["paper"] = bool(live_dry)` before the in-play write
+  (`engine.py:991`). (Supersedes the placed-only `paper=True` stamps, which stay
+  harmlessly consistent.)
+- **Gate `mark_paper_positions()` on `dry`** (`engine.py:911-920`): the live engine does
+  not mark paper positions (fixes the `marked N paper position(s)` bleed). Frozen paper
+  positions keep their last mark until the instance is paper again.
+- **Gate the paper-expire path of `prune_finished()` on `dry`:** add an `expire_paper:
+  bool = True` param to `db.prune_finished` (default preserves backtest/paper behavior)
+  and pass `expire_paper=dry` from `engine.py:944`, so the live engine never expires
+  (mutates) a frozen paper position. Stale-skipped-row *deletion* stays mode-agnostic
+  cleanup (it never touches placed/position rows).
+
+### 4.2 Restart on toggle (`backend/server.py`, `backend/api/main.py`)
+
+Because `EngineConfig` is frozen at boot and the config PATCH (`main.py:4328`) only writes
+the DB row, a `paper_mode` change requires a full process restart to take effect.
+
+- **Restart is driven by `server.py`'s existing instance changefeed** (`run_instance_change`,
+  `server.py:1216`), which already owns container lifecycle + the `running_threads_objs`
+  registry — so it can stop→(container gone)→start race-free (unlike a naive
+  API-side `runCommand` flip, which the changefeed can collapse). When a **running**
+  kalshi instance's config changes such that `old.paper_mode != new.paper_mode` (or
+  derived `live_enabled` differs), the changefeed cycles the container
+  (`stop_instance_container` → `start_instance_container`).
+- **Safety — cancel resting orders on a live→paper switch.** Plain stop does not cancel
+  resting orders (only the kill switch does), so a resting real order could fill *after*
+  the user turned real money OFF. On a real→paper transition of a running instance, the
+  PATCH handler cancels the instance's resting orders (reusing the scoped cancel primitive
+  in `live_kill_switch.py`) before writing the config. Open real *positions* are left on
+  the broker (frozen, unmanaged) — we never auto-sell; documented behavior.
+- Scope the restart trigger to a **mode (paper/live) change only** — other config edits
+  keep today's behavior (apply on next manual restart). This matches the user's ask and
+  minimizes blast radius on a real-money engine.
+
+### 4.3 API read scoping (`backend/api/main.py`, `backend/kalshi/*`)
+
+Compute `show_paper = not should_execute(env, live_enabled, paper_mode)` per instance.
+
+- **Decisions** (`main.py:4503`): filter rows to the active mode
+  (`bool(r.get("paper")) == show_paper`) before building `decisions`, `summary`
+  (`summarize_decisions`), and `count`. Return the `paper` block only when `show_paper`
+  (else `null`). Fixes the mixed PLACED/SKIPPED counts and hides paper positions from the
+  board in real mode.
+- **Orders** (`main.py:4705`): build `mock` / `mock_history` only when `show_paper`
+  (else empty). The handler already reads the instance row.
+- **Portfolio chart series:** `portfolio_payload` keeps returning both `series` (real
+  value) and `paper_series`; the *chart* selects which to show by mode (see 4.4). Where an
+  endpoint is per-instance (`/instances/{id}/kalshi/equity`), it may additionally drop
+  `paper_series` in real mode for defense-in-depth.
+
+These are server-side, so the **mobile** client inherits the decisions/orders gating for
+free.
+
+### 4.4 Web UI (`frontend/src/**`)
+
+- `KalshiInstanceDetailView.vue`: gate every paper section on `!liveReal` and real
+  sections on `liveReal` — MOCK progress card (`:345`), MOCK trades summary (`:355`),
+  Pregame per-row MOCK badge/paper-P&L (`:486`,`:502`), Mock positions / Mock filled
+  (`:541-590`). `liveReal` (`:98`) already exists; extend its use beyond the header badge.
+- `KalshiPortfolioChart.vue`: replace data-presence `isPaper` (`:55`) with a `paperMode`/
+  `isReal` prop passed down from the detail page; show the paper P&L curve in paper mode,
+  the real portfolio-value curve in real mode.
+- Real-mode empty states: until real trades exist, real sections show a clean "no real
+  trades yet" rather than paper data.
+
+### 4.5 Mobile (`mobile/lib/features/kalshi/**`)
+
+Inherits the server-side decisions/orders gating automatically. Only the portfolio-chart
+series selection is client-side — noted as a fast-follow, not in this change's core scope.
+
+## 5. Safety & non-goals
+
+- **No data is deleted or moved.** Paper positions/decisions/P&L persist and reappear
+  intact when paper mode is re-enabled.
+- **No backfill / schema migration** on the live dataset.
+- Restart is scoped to a mode change on a running instance; resting real orders are
+  canceled on live→paper; open real positions are left untouched (never auto-sold).
+- Per repo rules: run `gitnexus_impact` before editing each symbol and
+  `gitnexus_detect_changes` before committing.
+- **Non-goals:** physical table separation; a paper-history "archive" browser in real
+  mode; restarting on non-mode config edits; the mobile chart series selection.
+
+## 6. Testing strategy
+
+- **Pure/unit (no DB):** `should_execute`-driven `show_paper`; `summarize_decisions` over a
+  mode-filtered row set; `paper_pnl_from_rows` unaffected by `paper=False` skipped rows;
+  decision-row stamping `paper == bool(dry)` for placed/skipped in both modes;
+  `prune_finished` with `expire_paper=False` does not expire paper positions but still
+  deletes stale skipped rows.
+- **API:** decisions endpoint returns only active-mode rows + null paper block in real
+  mode; orders endpoint returns empty mock in real mode; both return paper data in
+  paper/demo mode.
+- **Restart:** changefeed cycles the container on a paper_mode change of a running
+  instance and not on unrelated updates; live→paper cancels resting orders first.
+- **End-to-end verification:** drive the real detail page in real mode (paper sections
+  gone) and paper mode (restored); confirm a `live` engine log no longer prints
+  `marked N paper position(s)`.
+
+## 7. Rollout
+
+1. Land engine + API + UI + server.py restart behind the existing flags (no new config).
+2. Deploy backend + frontend.
+3. Verify on the live `Soccer Live` instance: real mode hides MOCK data and stops marking
+   paper positions; toggling to paper restarts the engine and restores the paper view;
+   toggling back restarts into real.

--- a/frontend/src/components/kalshi/KalshiPortfolioChart.vue
+++ b/frontend/src/components/kalshi/KalshiPortfolioChart.vue
@@ -5,6 +5,9 @@ import { getToken } from '../../utils/auth.js'
 
 const props = defineProps({
   brokerageId: { type: String, required: true },
+  // When true the instance is placing REAL orders -> show the real portfolio value
+  // curve, never the paper P&L curve (even if leftover paper snapshots exist).
+  isReal: { type: Boolean, default: false },
 })
 
 const API_BASE = import.meta.env.DEV ? '/api' : (import.meta.env.VITE_API_URL || '/api')
@@ -52,7 +55,7 @@ watch(() => props.brokerageId, load)
 
 // Paper instances have a static demo broker balance, so when paper P&L history exists
 // we show the paper P&L PROGRESS curve instead of the (flat) portfolio value.
-const isPaper = computed(() => paperSeries.value.length > 0)
+const isPaper = computed(() => !props.isReal && paperSeries.value.length > 0)
 const activeSeries = computed(() => (isPaper.value ? paperSeries.value : series.value))
 
 // Slice the full server series to the selected range client-side. 'ALL' shows

--- a/frontend/src/views/KalshiInstanceDetailView.vue
+++ b/frontend/src/views/KalshiInstanceDetailView.vue
@@ -342,7 +342,7 @@ onUnmounted(() => {
 
         <!-- Equity + decision summary -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
-          <KalshiPortfolioChart :brokerage-id="detail.brokerage_id" />
+          <KalshiPortfolioChart :brokerage-id="detail.brokerage_id" :is-real="liveReal" />
           <div class="glass-card rounded-2xl p-4 sm:p-5">
             <div class="flex items-center gap-2 mb-4"><span class="material-symbols-outlined text-primary text-[18px]">insights</span><span class="text-[11px] sm:text-xs font-semibold text-slate-400 uppercase tracking-widest">Decision summary</span></div>
             <div class="grid grid-cols-2 gap-3">
@@ -352,7 +352,7 @@ onUnmounted(() => {
               <div class="rounded-xl border border-border-subtle bg-surface/40 p-3"><div class="text-lg font-bold text-red-400 tabular-nums">{{ summary.blocked }}</div><div class="text-[10px] uppercase tracking-wide text-slate-500 font-semibold mt-0.5">Blocked</div></div>
             </div>
             <!-- Paper (mock) hypothetical P&L — "what your profit would have been" -->
-            <div v-if="paper.trades" class="mt-3 flex items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
+            <div v-if="!liveReal && paper.trades" class="mt-3 flex items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
               <span class="text-[11px] uppercase tracking-wide text-amber-400/90 font-semibold flex items-center gap-1.5"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span>Paper P&amp;L · {{ paper.trades }} trade{{ paper.trades === 1 ? '' : 's' }}<span v-if="paper.graded" class="text-slate-500 normal-case">({{ paper.graded }} settled)</span></span>
               <span class="text-right shrink-0">
                 <span class="text-base font-bold tabular-nums" :class="(paper.realized_pnl_cents || 0) >= 0 ? 'text-emerald-400' : 'text-red-400'">realized {{ (paper.realized_pnl_cents >= 0 ? '+' : '') + '$' + ((paper.realized_pnl_cents || 0) / 100).toFixed(2) }}</span>
@@ -483,7 +483,7 @@ onUnmounted(() => {
                   <div class="flex flex-col items-end gap-1 shrink-0">
                     <span class="text-xs tabular-nums font-semibold" :class="(d.edge || 0) >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ d.edge == null ? '' : (d.edge >= 0 ? '+' : '') + pct(d.edge) }}</span>
                     <span class="flex items-center gap-1">
-                      <span v-if="d.paper" class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400" title="Paper / mock — no real order placed">MOCK</span>
+                      <span v-if="!liveReal && d.paper" class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400" title="Paper / mock — no real order placed">MOCK</span>
                       <span class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded" :class="decBadge(d.decision)">{{ d.decision }}</span>
                     </span>
                   </div>
@@ -499,7 +499,7 @@ onUnmounted(() => {
                     <div><span class="text-slate-600">Opp score</span> {{ d.opportunity_score == null ? '—' : d.opportunity_score.toFixed(2) }}</div>
                     <div v-if="d.outcome"><span class="text-slate-600">Outcome</span> {{ d.outcome }}</div>
                     <div v-if="d.clv != null"><span class="text-slate-600">CLV</span> {{ pct(d.clv) }}</div>
-                    <div v-if="d.paper && d.realized_pnl_cents != null"><span class="text-slate-600">Paper P&amp;L</span> <span :class="d.realized_pnl_cents >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ (d.realized_pnl_cents >= 0 ? '+' : '') + '$' + (d.realized_pnl_cents / 100).toFixed(2) }}</span></div>
+                    <div v-if="!liveReal && d.paper && d.realized_pnl_cents != null"><span class="text-slate-600">Paper P&amp;L</span> <span :class="d.realized_pnl_cents >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ (d.realized_pnl_cents >= 0 ? '+' : '') + '$' + (d.realized_pnl_cents / 100).toFixed(2) }}</span></div>
                   </div>
                   <p v-if="d.llm_rationale" class="text-slate-300 bg-surface/60 border border-border-subtle rounded-lg px-3 py-2">
                     <span class="material-symbols-outlined text-primary text-[14px] align-middle mr-1">psychology</span>{{ d.llm_rationale }}
@@ -539,8 +539,8 @@ onUnmounted(() => {
                 </div>
               </div>
               <!-- Mock (paper) positions — live unrealized P&L on the right -->
-              <div class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock positions · {{ orders.mock.length }}</span></div>
-              <p v-if="!orders.mock.length" class="text-xs text-slate-500 mb-2">No open mock positions.</p>
+              <div v-if="!liveReal" class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock positions · {{ orders.mock.length }}</span></div>
+              <p v-if="!liveReal && !orders.mock.length" class="text-xs text-slate-500 mb-2">No open mock positions.</p>
               <div v-for="(m, i) in orders.mock" :key="'m' + i" class="flex items-center gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 mb-2">
                 <img v-if="m.pick_logo" :src="m.pick_logo" referrerpolicy="no-referrer" class="w-8 h-8 rounded-full object-contain bg-white/5 ring-1 ring-border-subtle shrink-0" />
                 <div v-else class="w-8 h-8 rounded-full bg-surface ring-1 ring-border-subtle flex items-center justify-center text-[10px] font-bold text-slate-400 shrink-0">{{ initials((m.pick_label || '').replace(' to win','')) }}</div>
@@ -579,7 +579,7 @@ onUnmounted(() => {
               </template>
 
               <!-- Mock (paper) FILLED history — settled/expired paper trades with realized P&L -->
-              <template v-if="orders.mock_history.length">
+              <template v-if="!liveReal && orders.mock_history.length">
                 <div class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock filled · {{ orders.mock_history.length }}</span></div>
                 <div v-for="(m, i) in orders.mock_history" :key="'mh' + i" class="flex items-center gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 mb-2">
                   <img v-if="m.pick_logo" :src="m.pick_logo" referrerpolicy="no-referrer" class="w-8 h-8 rounded-full object-contain bg-white/5 ring-1 ring-border-subtle shrink-0" />

--- a/frontend/src/views/KalshiInstanceDetailView.vue
+++ b/frontend/src/views/KalshiInstanceDetailView.vue
@@ -98,6 +98,10 @@ const running = computed(() => !!detail.value?.running)
 // Real money ONLY when a live brokerage has live_enabled AND paper_mode off.
 const liveReal = computed(() => detail.value?.environment === 'live'
   && !!(detail.value?.config || {}).live_enabled && !(detail.value?.config || {}).paper_mode)
+// Whether to surface PAPER (MOCK) UI. Prefer the backend's authoritative flag (mirrors
+// the engine's dry state + how the API scopes data) so the client never disagrees with
+// the server; fall back to !liveReal for an older API that doesn't send it.
+const showPaper = computed(() => detail.value?.show_paper ?? !liveReal.value)
 
 // Edit / delete
 const showEdit = ref(false)
@@ -342,7 +346,7 @@ onUnmounted(() => {
 
         <!-- Equity + decision summary -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
-          <KalshiPortfolioChart :brokerage-id="detail.brokerage_id" :is-real="liveReal" />
+          <KalshiPortfolioChart :brokerage-id="detail.brokerage_id" :is-real="!showPaper" />
           <div class="glass-card rounded-2xl p-4 sm:p-5">
             <div class="flex items-center gap-2 mb-4"><span class="material-symbols-outlined text-primary text-[18px]">insights</span><span class="text-[11px] sm:text-xs font-semibold text-slate-400 uppercase tracking-widest">Decision summary</span></div>
             <div class="grid grid-cols-2 gap-3">
@@ -352,7 +356,7 @@ onUnmounted(() => {
               <div class="rounded-xl border border-border-subtle bg-surface/40 p-3"><div class="text-lg font-bold text-red-400 tabular-nums">{{ summary.blocked }}</div><div class="text-[10px] uppercase tracking-wide text-slate-500 font-semibold mt-0.5">Blocked</div></div>
             </div>
             <!-- Paper (mock) hypothetical P&L — "what your profit would have been" -->
-            <div v-if="!liveReal && paper.trades" class="mt-3 flex items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
+            <div v-if="showPaper && paper.trades" class="mt-3 flex items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
               <span class="text-[11px] uppercase tracking-wide text-amber-400/90 font-semibold flex items-center gap-1.5"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span>Paper P&amp;L · {{ paper.trades }} trade{{ paper.trades === 1 ? '' : 's' }}<span v-if="paper.graded" class="text-slate-500 normal-case">({{ paper.graded }} settled)</span></span>
               <span class="text-right shrink-0">
                 <span class="text-base font-bold tabular-nums" :class="(paper.realized_pnl_cents || 0) >= 0 ? 'text-emerald-400' : 'text-red-400'">realized {{ (paper.realized_pnl_cents >= 0 ? '+' : '') + '$' + ((paper.realized_pnl_cents || 0) / 100).toFixed(2) }}</span>
@@ -483,7 +487,7 @@ onUnmounted(() => {
                   <div class="flex flex-col items-end gap-1 shrink-0">
                     <span class="text-xs tabular-nums font-semibold" :class="(d.edge || 0) >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ d.edge == null ? '' : (d.edge >= 0 ? '+' : '') + pct(d.edge) }}</span>
                     <span class="flex items-center gap-1">
-                      <span v-if="!liveReal && d.paper" class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400" title="Paper / mock — no real order placed">MOCK</span>
+                      <span v-if="showPaper && d.paper" class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400" title="Paper / mock — no real order placed">MOCK</span>
                       <span class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded" :class="decBadge(d.decision)">{{ d.decision }}</span>
                     </span>
                   </div>
@@ -499,7 +503,7 @@ onUnmounted(() => {
                     <div><span class="text-slate-600">Opp score</span> {{ d.opportunity_score == null ? '—' : d.opportunity_score.toFixed(2) }}</div>
                     <div v-if="d.outcome"><span class="text-slate-600">Outcome</span> {{ d.outcome }}</div>
                     <div v-if="d.clv != null"><span class="text-slate-600">CLV</span> {{ pct(d.clv) }}</div>
-                    <div v-if="!liveReal && d.paper && d.realized_pnl_cents != null"><span class="text-slate-600">Paper P&amp;L</span> <span :class="d.realized_pnl_cents >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ (d.realized_pnl_cents >= 0 ? '+' : '') + '$' + (d.realized_pnl_cents / 100).toFixed(2) }}</span></div>
+                    <div v-if="showPaper && d.paper && d.realized_pnl_cents != null"><span class="text-slate-600">Paper P&amp;L</span> <span :class="d.realized_pnl_cents >= 0 ? 'text-emerald-400' : 'text-red-400'">{{ (d.realized_pnl_cents >= 0 ? '+' : '') + '$' + (d.realized_pnl_cents / 100).toFixed(2) }}</span></div>
                   </div>
                   <p v-if="d.llm_rationale" class="text-slate-300 bg-surface/60 border border-border-subtle rounded-lg px-3 py-2">
                     <span class="material-symbols-outlined text-primary text-[14px] align-middle mr-1">psychology</span>{{ d.llm_rationale }}
@@ -539,8 +543,8 @@ onUnmounted(() => {
                 </div>
               </div>
               <!-- Mock (paper) positions — live unrealized P&L on the right -->
-              <div v-if="!liveReal" class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock positions · {{ orders.mock.length }}</span></div>
-              <p v-if="!liveReal && !orders.mock.length" class="text-xs text-slate-500 mb-2">No open mock positions.</p>
+              <div v-if="showPaper" class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock positions · {{ orders.mock.length }}</span></div>
+              <p v-if="showPaper && !orders.mock.length" class="text-xs text-slate-500 mb-2">No open mock positions.</p>
               <div v-for="(m, i) in orders.mock" :key="'m' + i" class="flex items-center gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 mb-2">
                 <img v-if="m.pick_logo" :src="m.pick_logo" referrerpolicy="no-referrer" class="w-8 h-8 rounded-full object-contain bg-white/5 ring-1 ring-border-subtle shrink-0" />
                 <div v-else class="w-8 h-8 rounded-full bg-surface ring-1 ring-border-subtle flex items-center justify-center text-[10px] font-bold text-slate-400 shrink-0">{{ initials((m.pick_label || '').replace(' to win','')) }}</div>
@@ -579,7 +583,7 @@ onUnmounted(() => {
               </template>
 
               <!-- Mock (paper) FILLED history — settled/expired paper trades with realized P&L -->
-              <template v-if="!liveReal && orders.mock_history.length">
+              <template v-if="showPaper && orders.mock_history.length">
                 <div class="flex items-center gap-1.5 mt-4 mb-2"><span class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400">MOCK</span><span class="text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Mock filled · {{ orders.mock_history.length }}</span></div>
                 <div v-for="(m, i) in orders.mock_history" :key="'mh' + i" class="flex items-center gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 mb-2">
                   <img v-if="m.pick_logo" :src="m.pick_logo" referrerpolicy="no-referrer" class="w-8 h-8 rounded-full object-contain bg-white/5 ring-1 ring-border-subtle shrink-0" />


### PR DESCRIPTION
## What & why

A Kalshi instance kept showing (and its engine kept *marking*) **paper/MOCK** data even after the paper-mode toggle was turned **off** for real-money trading. Paper and real trading now live in two logically separate spaces: **engine, API, and UI each see only the active mode's data**, the inactive mode's data is **hidden but fully preserved**, and flipping the toggle **restarts the engine** so the change actually takes effect.

Spec: `docs/superpowers/specs/2026-07-06-kalshi-paper-real-separation-design.md` · Plan: `docs/superpowers/plans/2026-07-06-kalshi-paper-real-separation.md`

## Root cause

Paper and real aren't separate tables — a paper trade is a `kalshi_decisions` row with `paper: true`; a real trade is the same row without it. That flag was already stamped correctly at write time, so **existing paper data is safe** — nothing is migrated or deleted. The bug was entirely on the **read side**: nothing filtered by the instance's *current* mode (the engine kept calling `mark_paper_positions()` regardless of mode; three API endpoints returned paper data unconditionally; the UI's `liveReal` only drove the header badge).

## Design

One discriminator, applied everywhere: **`show_paper = not is_real_mode(env, live_enabled, paper_mode)`**, which is provably equal to the engine's `dry` — the *same* bit the engine stamps on each decision row. So an instance always reads back exactly the rows it wrote in its current mode. `is_real_mode` is a pure mirror of the real-order gate `engine.should_execute`; a contract test enforces they never diverge (the gate itself is untouched).

## Changes by layer

- **`kalshi/mode.py`** (new): `is_real_mode` / `scope_decisions` / `kalshi_mode_changed` — pure, no heavy imports.
- **Engine** (`engine.py`, `db.py`, `reconcile.py`): stamp `paper = bool(dry)` on *every* decision row (pregame + in-play), gate `mark_paper_positions` on `dry`, and pass `expire_paper=dry` to `prune_finished` — a live/real engine no longer marks or expires paper positions (fixes the `marked N paper position(s)` in a live log); they stay frozen until paper resumes. `_mark_map` is still built each tick for CLV.
- **API** (`main.py`): decisions + orders endpoints return only the active mode's data (`scope_decisions`); the detail endpoint exposes an authoritative `show_paper`. Mobile inherits this (same endpoints).
- **Restart** (`server.py`, `main.py`): the Instances changefeed recycles a running Kalshi container when the paper/live mode flips (its `EngineConfig` is frozen at boot). On live→paper, the PATCH cancels resting **real** orders first so none fill after real money is turned off; open real *positions* are left untouched (never auto-sold).
- **Web UI** (`KalshiInstanceDetailView.vue`, `KalshiPortfolioChart.vue`): every MOCK/paper surface is gated on the backend's `show_paper`; the portfolio chart plots the real value curve in real mode.

## Testing & verification

- **418 Kalshi backend tests pass**, incl. new `test_kalshi_mode.py` (7: truth table, the should_execute **contract** test, scoping, `kalshi_mode_changed`) and a `prune_finished` `expire_paper` case.
- **Behavioral check with the real functions** on a representative row set (4 open paper positions + settled + paper/real skipped): real-money view = **0 paper trades / 0 positions / $0**; paper view preserves **all 4 positions + P&L**; **source rows unchanged** (nothing deleted); toggles detected.
- Frontend `vite build` clean; `gitnexus_impact` on each edited symbol (all LOW) and `gitnexus_detect_changes` confirm the blast radius is exactly the Kalshi engine/API flows.
- **Adversarial review** of the diff found no critical/high correctness bugs; its one finding (a demo-only frontend/backend discriminator mismatch) is fixed here via the authoritative `show_paper`. Two by-design residual risks are documented in the spec.

## Deploy note

Requires a **backend + frontend redeploy**. After deploy, on the live `Soccer Live` instance: real mode should hide all MOCK data and stop marking paper positions; toggling to paper should restart the engine and restore the paper view; toggling back restarts into real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2FmLVbTNUi9VZfch6VXt
