### PR TITLE
fix(kalshi): gate paper P&L series server-side (real instances never show MOCK chart)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4081,7 +4081,9 @@ def api_kalshi_portfolio(brokerage_id: str, conn=Depends(conn_dependency), curre
     for s in snaps:
         if s.get("ts", "") <= cutoff:
             prev_value_cents = int(s.get("value_cents", 0))
-    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents, prev_value_cents=prev_value_cents)
+    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents,
+                             prev_value_cents=prev_value_cents,
+                             show_paper=_kalshi_brokerage_show_paper(conn, brokerage_id))
 
 
 @app.get("/brokerages/{brokerage_id}/kalshi/positions", response_class=JSONResponse)
@@ -4510,6 +4512,29 @@ def _kalshi_show_paper(conn, instance_row: dict) -> bool:
     return not is_real_mode(env, bool(cfg.get("live_enabled")), bool(cfg.get("paper_mode")))
 
 
+def _kalshi_brokerage_show_paper(conn, brokerage_id: str) -> bool:
+    """Whether a brokerage's portfolio chart should show PAPER P&L — False if ANY of its
+    kalshi instances is placing REAL orders, so a real-money account never surfaces
+    leftover paper snapshots (the MOCK P&L card). Mirrors per-instance _kalshi_show_paper."""
+    from kalshi.mode import is_real_mode
+    env = "demo"
+    try:
+        bk = _r_auth.db("IntelliStock").table("BrokerageAccounts").get(brokerage_id).run(conn) or {}
+        env = bk.get("kalshi_environment") or "demo"
+    except Exception:
+        pass
+    try:
+        insts = list(_r_auth.db("IntelliStock").table("Instances")
+                     .filter({"brokerage_id": str(brokerage_id), "kind": "kalshi"}).run(conn))
+    except Exception:
+        insts = []
+    for i in insts:
+        cfg = i.get("kalshi_config") or {}
+        if is_real_mode(env, bool(cfg.get("live_enabled")), bool(cfg.get("paper_mode"))):
+            return False
+    return True
+
+
 @app.get("/instances/{instance_id}/kalshi/detail", response_class=JSONResponse)
 def api_kalshi_instance_detail(instance_id: str, conn=Depends(conn_dependency), current_user: dict = Depends(get_current_user)):
     """Kalshi instance summary: config, run state, linked brokerage env."""
@@ -4877,7 +4902,8 @@ def api_kalshi_instance_equity(instance_id: str, conn=Depends(conn_dependency), 
     except Exception:
         pass
     snaps = sorted(_kalshi_rows(conn, "kalshi_portfolio_snapshots", bid), key=lambda s: s.get("ts", ""))
-    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents)
+    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents,
+                             show_paper=_kalshi_show_paper(conn, row))
 
 
 class TestKalshiBody(BaseModel):

--- a/backend/kalshi/api_payloads.py
+++ b/backend/kalshi/api_payloads.py
@@ -15,6 +15,7 @@ def portfolio_payload(
     value_cents: int,
     cash_cents: int,
     prev_value_cents: int | None = None,
+    show_paper: bool = True,
 ) -> dict:
     """Account value + equity curve. day_change is value - prev_value_cents (the
     ~24h-ago baseline the caller resolves from raw snapshots). When no baseline
@@ -26,8 +27,10 @@ def portfolio_payload(
         day_change = round(series[-1]["value"] - series[0]["value"], 2)
     else:
         day_change = 0.0
-    # Paper P&L progress-over-time (only present for paper instances that recorded it).
-    paper_series = paper_pnl_series(snapshot_rows)
+    # Paper P&L progress-over-time — only for paper/demo instances. Dropped when the
+    # instance is real-money (show_paper=False) so a real account never surfaces leftover
+    # paper snapshots on the portfolio chart (the MOCK card).
+    paper_series = paper_pnl_series(snapshot_rows) if show_paper else []
     return {
         "value": round(value_cents / 100.0, 2),
         "cash": round(cash_cents / 100.0, 2),

--- a/backend/tests/test_kalshi_api_payloads.py
+++ b/backend/tests/test_kalshi_api_payloads.py
@@ -25,6 +25,18 @@ def test_portfolio_payload_day_change_from_24h_baseline():
     assert p["day_change"] == round((482014 - 481000) / 100.0, 2)  # 10.14, not 820.14
 
 
+def test_portfolio_payload_hides_paper_series_when_show_paper_false():
+    # Leftover paper snapshots must NOT surface once the instance is real-money:
+    # show_paper=False drops paper_series/paper_pnl but keeps the real value curve.
+    snaps = [{"ts": "t1", "value_cents": 600, "paper_pnl_cents": 9963},
+             {"ts": "t2", "value_cents": 612, "paper_pnl_cents": 9963}]
+    paper = portfolio_payload(snaps, value_cents=612, cash_cents=0)              # default show_paper
+    assert len(paper["paper_series"]) == 2 and paper["paper_pnl"] == 99.63
+    real = portfolio_payload(snaps, value_cents=612, cash_cents=0, show_paper=False)
+    assert real["paper_series"] == [] and real["paper_pnl"] is None
+    assert len(real["series"]) == 2                                             # real value curve intact
+
+
 def test_edges_payload_sorted_limited():
     rows = [
         {"market_ticker": "A", "edge": 0.02},


### PR DESCRIPTION
Follow-up to #103. The portfolio-chart **PAPER P&L · PROGRESS MOCK** card still showed on the Kalshi tab and only cleared on the instance detail page after the new bundle propagated ("took some time").

**Root cause:** `/brokerages/{id}/kalshi/portfolio` returned `paper_series` unconditionally; #103 selected paper-vs-real *client-side* (via an `is-real` prop), which `KalshiView.vue` (the Kalshi tab) never passed and which made the detail page depend on frontend deploy timing.

**Fix (backend-only):** gate `paper_series`/`paper_pnl` at the source — `portfolio_payload(show_paper=...)` drops them when the instance is real-money; the per-brokerage portfolio and per-instance equity endpoints compute `show_paper` from the instance mode (`is_real_mode`). Every consumer (both web pages + mobile) now shows the real value curve immediately. The real value curve is always intact.

**Tests:** new `test_portfolio_payload_hides_paper_series_when_show_paper_false`; full Kalshi suite green (413).

Backend-only — needs a **backend redeploy** (no frontend deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2FmLVbTNUi9VZfch6VXt