### PR TITLE
fix(kalshi): portfolio value = total equity (positions + cash)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4080,8 +4080,9 @@ def api_kalshi_portfolio(brokerage_id: str, conn=Depends(conn_dependency), curre
     prev_value_cents = None
     for s in snaps:
         if s.get("ts", "") <= cutoff:
-            prev_value_cents = int(s.get("value_cents", 0))
-    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents,
+            prev_value_cents = int(s.get("value_cents", 0)) + int(s.get("cash_cents", 0))
+    # Headline PORTFOLIO VALUE = TOTAL equity (positions + cash), matching the curve.
+    return portfolio_payload(snaps, value_cents=value_cents + cash_cents, cash_cents=cash_cents,
                              prev_value_cents=prev_value_cents,
                              show_paper=_kalshi_brokerage_show_paper(conn, brokerage_id))
 
@@ -4902,7 +4903,8 @@ def api_kalshi_instance_equity(instance_id: str, conn=Depends(conn_dependency), 
     except Exception:
         pass
     snaps = sorted(_kalshi_rows(conn, "kalshi_portfolio_snapshots", bid), key=lambda s: s.get("ts", ""))
-    return portfolio_payload(snaps, value_cents=value_cents, cash_cents=cash_cents,
+    # Headline = TOTAL equity (positions + cash), matching the curve.
+    return portfolio_payload(snaps, value_cents=value_cents + cash_cents, cash_cents=cash_cents,
                              show_paper=_kalshi_show_paper(conn, row))
 
 

--- a/backend/kalshi/telemetry.py
+++ b/backend/kalshi/telemetry.py
@@ -28,7 +28,9 @@ def portfolio_series(snapshots: list[dict], max_points: int = 120) -> list[dict]
     chronological order. Downsamples to <= max_points (keeps first+last) and
     converts cents to dollars."""
     pts = [
-        {"ts": s["ts"], "value": round(s["value_cents"] / 100.0, 2)}
+        # TOTAL account equity = positions (value_cents) + cash_cents. cash defaults to 0
+        # for pre-cash snapshots so they degrade to positions-only rather than break.
+        {"ts": s["ts"], "value": round((s["value_cents"] + s.get("cash_cents", 0)) / 100.0, 2)}
         for s in snapshots
     ]
     n = len(pts)

--- a/backend/tests/test_kalshi_telemetry.py
+++ b/backend/tests/test_kalshi_telemetry.py
@@ -45,6 +45,15 @@ def test_portfolio_series_converts_cents_to_dollars():
     assert out == [{"ts": "t1", "value": 4820.14}, {"ts": "t2", "value": 4883.14}]
 
 
+def test_portfolio_series_is_total_equity_positions_plus_cash():
+    # The equity curve is TOTAL account value: positions (value_cents) + cash_cents,
+    # not positions alone. (value_cents-only snapshots still work: cash defaults to 0.)
+    snaps = [{"ts": "t1", "value_cents": 0, "cash_cents": 5355},
+             {"ts": "t2", "value_cents": 612, "cash_cents": 4743}]
+    out = portfolio_series(snaps)
+    assert out == [{"ts": "t1", "value": 53.55}, {"ts": "t2", "value": 53.55}]
+
+
 def test_portfolio_series_downsamples_but_keeps_endpoints():
     snaps = [{"ts": str(i), "value_cents": i * 100} for i in range(1000)]
     out = portfolio_series(snaps, max_points=50)


### PR DESCRIPTION
The Kalshi portfolio chart showed `portfolio_value_cents` — Kalshi's **positions-only** market value — so a mostly-cash account read ~$6 instead of its true ~$53 (positions + cash). This surfaced once #103/#104 made the real value visible.

**Fix (backend-only, display):** snapshots already store both `value_cents` (positions) and `cash_cents`, so sum them — `portfolio_series` plots positions+cash, and the portfolio + equity endpoints set the headline and 24h baseline to positions+cash. History is fixed retroactively (`cash_cents` defaults to 0 for pre-cash snapshots). Trading logic is untouched — the engine reads `cash_cents`, never `portfolio_value_cents`.

**Tests:** new `test_portfolio_series_is_total_equity_positions_plus_cash`; full Kalshi suite green (414).

Backend-only — **backend redeploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2FmLVbTNUi9VZfch6VXt