### PR TITLE
fix(server): self-heal RethinkDB control changefeeds on connection loss

### DIFF
--- a/backend/rethink_changefeed.py
+++ b/backend/rethink_changefeed.py
@@ -1,0 +1,158 @@
+"""Self-healing RethinkDB changefeed runner for the server control plane.
+
+Background (2026-07-06 backend outage): RethinkDB dropped mid-run and every
+control-changefeed thread in ``server.py`` died permanently. The retry loops
+only reconnected when the error text contained ``"primary replica"`` or
+``"not available"`` and re-raised everything else — including
+``"Connection is closed"`` / ``ReqlDriverError`` — so a transient DB blip
+killed the (daemon) threads for good, leaving the backend up but deaf to all
+control-table changes until a full restart.
+
+A control-plane changefeed must instead reconnect whenever RethinkDB comes
+back. This module holds that reconnect-forever loop, kept dependency-light
+(only ``time`` + a lazily-imported ``rethinkdb.errors``) so it can be unit
+tested without importing the server monolith (docker/socketio/waitress).
+"""
+from __future__ import annotations
+
+import time as _time
+
+# Substrings that indicate a *transient* RethinkDB connection/availability loss
+# (reconnect and continue) rather than a genuine programming error. Matched
+# case-insensitively against ``str(exc)``.
+_TRANSIENT_HINTS = (
+    "primary replica",
+    "not available",
+    "connection is closed",
+    "connection closed",
+    "connection refused",
+    "connection reset",
+    "connection is broken",
+    "broken pipe",
+    "bad file descriptor",
+    "could not connect",
+    "lost contact",
+    "timed out",
+    "timeout",
+)
+
+
+def is_transient_rethinkdb_error(exc: BaseException) -> bool:
+    """True when ``exc`` looks like a transient RethinkDB connection or
+    availability loss that should be retried by reconnecting.
+
+    ``ReqlDriverError`` (driver/connection-level failures such as
+    "Connection is closed.") and OS/socket errors (``OSError`` — e.g. errno
+    111 "Connection refused", ``ConnectionResetError``) are always transient.
+    Anything else falls back to substring matching on the message so that
+    ReqlError availability failures ("primary replica ... not available") are
+    also covered without a hard dependency on the driver's class hierarchy.
+    """
+    try:
+        from rethinkdb import errors as _rerr
+        if isinstance(exc, _rerr.ReqlDriverError):
+            return True
+    except Exception:
+        # driver not importable / unexpected layout — fall through to strings
+        pass
+    if isinstance(exc, (OSError, ConnectionError)):
+        return True
+    msg = str(exc).lower()
+    return any(hint in msg for hint in _TRANSIENT_HINTS)
+
+
+def run_reconnecting_changefeed(
+    open_feed,
+    handle_change,
+    label,
+    *,
+    get_conn,
+    log=None,
+    pass_conn=True,
+    initial_delay=2.0,
+    max_delay=30.0,
+    sleep=_time.sleep,
+    should_continue=None,
+):
+    """Run a RethinkDB changefeed forever, reconnecting on any transient
+    connection loss with capped exponential backoff.
+
+    Parameters
+    ----------
+    open_feed : callable(conn) -> iterable
+        Opens the changefeed cursor, e.g.
+        ``lambda c: r.db(DB).table(T).changes().run(c)``.
+    handle_change : callable(change, conn) or callable(change)
+        Per-change handler. Called with the live connection when
+        ``pass_conn`` is True (the default). Handlers are expected to swallow
+        their own errors; anything that escapes is treated like a feed error
+        and triggers a reconnect (the feed is never allowed to die).
+    label : str
+        Human name for log lines (e.g. ``"NexusControl"``).
+    get_conn : callable() -> connection
+        Opens a *fresh* RethinkDB connection.
+    log : callable(msg, color, service=...) or None
+        Optional logger. No-op when None.
+    pass_conn : bool
+        Pass the live connection to ``handle_change`` (default True).
+    initial_delay, max_delay : float
+        Backoff bounds in seconds. Backoff resets once the feed delivers a
+        change (proof it is genuinely live), not merely on a TCP connect — so a
+        connectable-but-unhealthy DB (e.g. primary-replica unavailable) still
+        backs off toward max_delay instead of reconnecting at the floor.
+    sleep, should_continue : callables
+        Test seams. ``should_continue()`` gates the loop (default: forever);
+        ``sleep(delay)`` defaults to ``time.sleep``.
+
+    Under normal operation this never returns: ``changes()`` blocks yielding
+    changes, and a dropped connection is logged + retried rather than raised.
+    """
+    def _log(msg, color):
+        if log is None:
+            return
+        try:
+            log(msg, color, service="RethinkDB")
+        except Exception:
+            pass
+
+    _cont = should_continue or (lambda: True)
+    delay = initial_delay
+    while _cont():
+        c = None
+        try:
+            c = get_conn()
+            healthy = False
+            for change in open_feed(c):
+                if not healthy:
+                    # A delivered change proves the feed is actually live (not a
+                    # TCP connect that then fails, e.g. primary-replica
+                    # unavailable) -> only now is it safe to reset the backoff.
+                    healthy = True
+                    delay = initial_delay
+                if pass_conn:
+                    handle_change(change, c)
+                else:
+                    handle_change(change)
+            # An infinite changefeed shouldn't exhaust; if it does the
+            # connection is effectively gone -> reconnect.
+            _log(f"{label} changefeed ended unexpectedly; reconnecting...", "yellow")
+        except Exception as e:  # noqa: BLE001 — deliberate: keep the feed alive
+            if is_transient_rethinkdb_error(e):
+                _log(
+                    f"{label} changefeed connection lost ({e}); "
+                    f"reconnecting in {delay:.0f}s...",
+                    "yellow",
+                )
+            else:
+                _log(
+                    f"{label} changefeed error ({e}); reconnecting in {delay:.0f}s...",
+                    "red",
+                )
+        finally:
+            if c is not None:
+                try:
+                    c.close()
+                except Exception:
+                    pass
+        sleep(delay)
+        delay = min(delay * 1.5, max_delay)

--- a/backend/server.py
+++ b/backend/server.py
@@ -22,6 +22,7 @@ import logging
 from datetime import datetime
 from typing import Dict
 from rethinkdb import RethinkDB
+from rethink_changefeed import run_reconnecting_changefeed
 import socketio
 from waitress import serve
 from os import system
@@ -286,24 +287,39 @@ def _augment_volumes_with_claude(volumes):
     return out
 
 
+_instance_network_warned = False
+
+
 def _get_instance_network(client):
     """
     Return the Docker network name to attach instance containers to.
     Uses INSTANCE_DOCKER_NETWORK if set and that network exists; otherwise
-    detects from the current container (works on Dockploy/remote).
+    auto-detects from the current container (works on Dockploy/remote).
+
+    When INSTANCE_DOCKER_NETWORK points at a network that no longer exists
+    (compose/Dockploy project drift), auto-detect is authoritative and spawned
+    containers still land on the backend's own network. We surface the detected
+    name once (not per-launch) so the stale env var is visible and fixable.
     """
+    global _instance_network_warned
     env_network = os.environ.get('INSTANCE_DOCKER_NETWORK', '').strip()
     if env_network:
         try:
             client.networks.get(env_network)
             return env_network
         except Exception:
-            # Network from env doesn't exist (e.g. on Dockploy); fall back to auto-detect
-            intellistock_logger.log(
-                f"Network '{env_network}' not found; using current container's network.",
-                "yellow",
-                service="SERVER",
-            )
+            # Network from env doesn't exist (e.g. on Dockploy); fall back to auto-detect.
+            detected = _detect_container_network(client)
+            if not _instance_network_warned:
+                intellistock_logger.log(
+                    f"INSTANCE_DOCKER_NETWORK='{env_network}' does not exist; "
+                    f"auto-detected '{detected}' from this container instead. "
+                    f"Set INSTANCE_DOCKER_NETWORK='{detected}' (or unset it) to silence this.",
+                    "yellow",
+                    service="SERVER",
+                )
+                _instance_network_warned = True
+            return detected
     return _detect_container_network(client)
 
 
@@ -1066,38 +1082,17 @@ def run_nexus_control_change(change, c):
 
 
 def run_nexus_control_changefeed():
-    """Run changefeed on EngineControl; start/stop nexus container when nexus_graph_engine.running changes."""
-    max_attempts = 30
-    delay = 2
-    for attempt in range(1, max_attempts + 1):
-        c = None
-        try:
-            c = get_conn()
-            for change in r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c):
-                run_nexus_control_change(change, c)
-            break
-        except Exception as e:
-            err_str = str(e).lower()
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
-            if "primary replica" in err_str or "not available" in err_str:
-                if attempt < max_attempts:
-                    time.sleep(delay)
-                    delay = min(delay * 1.5, 30)
-                else:
-                    raise
-            else:
-                intellistock_logger.log("NexusControl changefeed error: %s" % e, "red", service="SERVER")
-                raise
-        finally:
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
+    """Run changefeed on EngineControl; start/stop nexus container when nexus_graph_engine.running changes.
+
+    Self-healing: reconnects on any transient RethinkDB connection loss instead
+    of letting the daemon thread die (2026-07-06 outage regression)."""
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c),
+        run_nexus_control_change,
+        "NexusControl",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 def run_discover_control_change(change, c):
@@ -1128,38 +1123,17 @@ def run_discover_control_change(change, c):
 
 
 def run_discover_control_changefeed():
-    """Run changefeed on EngineControl; start/stop discover container when discover_engine.running changes."""
-    max_attempts = 30
-    delay = 2
-    for attempt in range(1, max_attempts + 1):
-        c = None
-        try:
-            c = get_conn()
-            for change in r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c):
-                run_discover_control_change(change, c)
-            break
-        except Exception as e:
-            err_str = str(e).lower()
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
-            if "primary replica" in err_str or "not available" in err_str:
-                if attempt < max_attempts:
-                    time.sleep(delay)
-                    delay = min(delay * 1.5, 30)
-                else:
-                    raise
-            else:
-                intellistock_logger.log("DiscoverControl changefeed error: %s" % e, "red", service="SERVER")
-                raise
-        finally:
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
+    """Run changefeed on EngineControl; start/stop discover container when discover_engine.running changes.
+
+    Self-healing: reconnects on any transient RethinkDB connection loss instead
+    of letting the daemon thread die (2026-07-06 outage regression)."""
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c),
+        run_discover_control_change,
+        "DiscoverControl",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 def launch_digest_from_db():
@@ -1316,46 +1290,17 @@ def run_digest_control_change(change, c):
 
 
 def run_digest_control_changefeed():
-    """Run changefeed on EngineControl; start/stop digest container when daily_digest_engine.running changes."""
-    max_attempts = 30
-    delay = 2
-    for attempt in range(1, max_attempts + 1):
-        c = None
-        try:
-            c = get_conn()
-            for change in r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c):
-                run_digest_control_change(change, c)
-            break
-        except Exception as e:
-            err_str = str(e).lower()
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
-            if "primary replica" in err_str or "not available" in err_str:
-                if attempt < max_attempts:
-                    intellistock_logger.log(
-                        f"AgentControl changefeed failed (attempt {attempt}/{max_attempts}): {e}. Retrying in {delay}s...",
-                        "yellow", service="SERVER",
-                    )
-                    time.sleep(delay)
-                    delay = min(delay * 1.5, 30)
-                else:
-                    intellistock_logger.log(
-                        f"AgentControl changefeed failed after {max_attempts} attempts. Giving up.",
-                        "red", service="SERVER",
-                    )
-                    raise
-            else:
-                intellistock_logger.log(f"AgentControl changefeed error: {e}", "red", service="SERVER")
-                raise
-        finally:
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
+    """Run changefeed on EngineControl; start/stop digest container when daily_digest_engine.running changes.
+
+    Self-healing: reconnects on any transient RethinkDB connection loss instead
+    of letting the daemon thread die (2026-07-06 outage regression)."""
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c),
+        run_digest_control_change,
+        "DigestControl",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 def launch_instances_from_db():
@@ -1453,39 +1398,17 @@ def check_resume_timer():
 
 
 def run_agent_control_changefeed():
-    """Run changefeed on EngineControl; start/stop agent container when ai_backtest_engine.running changes."""
-    max_attempts = 30
-    delay = 2
-    for attempt in range(1, max_attempts + 1):
-        c = None
-        try:
-            c = get_conn()
-            for change in r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c):
-                run_agent_control_change(change, c)
-            break
-        except Exception as e:
-            err_str = str(e).lower()
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
-            if "primary replica" in err_str or "not available" in err_str:
-                if attempt < max_attempts:
-                    intellistock_logger.log(
-                        "AgentControl changefeed waiting for primary (attempt %d/%d), retrying in %ds..."
-                        % (attempt, max_attempts, delay), "yellow", service="RethinkDB",
-                    )
-                    time.sleep(delay)
-                    continue
-            intellistock_logger.log("AgentControl changefeed error: %s" % e, "red", service="RethinkDB")
-            break
-        finally:
-            if c:
-                try:
-                    c.close()
-                except Exception:
-                    pass
+    """Run changefeed on EngineControl; start/stop agent container when ai_backtest_engine.running changes.
+
+    Self-healing: reconnects on any transient RethinkDB connection loss instead
+    of letting the daemon thread die (2026-07-06 outage regression)."""
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table(ENGINE_CONTROL_TABLE).changes().run(c),
+        run_agent_control_change,
+        "AgentControl",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 def run():
@@ -1594,47 +1517,28 @@ def run():
     intellistock_logger.log("\nService is currently \033[04m\033[01mOnline", "green", service="STATUS")
 
     def run_config_changefeed():
-        """Run changefeed on Config.Pings and call status_service_change."""
-        c = get_conn()
-        try:
-            for change in r.db(DB_NAME).table('Config').get('Pings').changes().run(c):
-                status_service_change(change, c)
-        except Exception as e:
-            intellistock_logger.log(f"Config changefeed error: {e}", "red", service="RethinkDB")
-        finally:
-            c.close()
+        """Run changefeed on Config.Pings and call status_service_change.
+
+        Self-healing: reconnects on any transient RethinkDB connection loss."""
+        run_reconnecting_changefeed(
+            lambda c: r.db(DB_NAME).table('Config').get('Pings').changes().run(c),
+            status_service_change,
+            "Config",
+            get_conn=get_conn,
+            log=intellistock_logger.log,
+        )
 
     def run_instances_changefeed():
-        """Run changefeed on Instances and call run_thread_service_change. Retries on primary replica not available."""
-        max_attempts = 30
-        delay = 2
-        for attempt in range(1, max_attempts + 1):
-            c = None
-            try:
-                c = get_conn()
-                for change in r.db(DB_NAME).table('Instances').changes().run(c):
-                    run_thread_service_change(change, c)
-                break
-            except Exception as e:
-                err_str = str(e).lower()
-                if c:
-                    try:
-                        c.close()
-                    except Exception:
-                        pass
-                if "primary replica" in err_str or "not available" in err_str:
-                    if attempt < max_attempts:
-                        intellistock_logger.log(f"Instances changefeed waiting for primary (attempt {attempt}/{max_attempts}), retrying in {delay}s...", "yellow", service="RethinkDB")
-                        time.sleep(delay)
-                        continue
-                intellistock_logger.log(f"Instances changefeed error: {e}", "red", service="RethinkDB")
-                break
-            finally:
-                if c:
-                    try:
-                        c.close()
-                    except Exception:
-                        pass
+        """Run changefeed on Instances and call run_thread_service_change.
+
+        Self-healing: reconnects on any transient RethinkDB connection loss."""
+        run_reconnecting_changefeed(
+            lambda c: r.db(DB_NAME).table('Instances').changes().run(c),
+            run_thread_service_change,
+            "Instances",
+            get_conn=get_conn,
+            log=intellistock_logger.log,
+        )
 
     config_feed_thread = threading.Thread(target=run_config_changefeed, daemon=True)
     config_feed_thread.start()

--- a/backend/tests/test_changefeed_selfheal.py
+++ b/backend/tests/test_changefeed_selfheal.py
@@ -1,0 +1,219 @@
+"""Self-healing RethinkDB changefeed runner (server.py control plane).
+
+Regression for the 2026-07-06 backend outage: RethinkDB dropped mid-run and
+every control changefeed thread died permanently because the retry loops only
+reconnected on "primary replica"/"not available" and re-raised everything else
+(incl. "Connection is closed"). A control-plane feed must reconnect on any
+transient connection loss instead of killing its daemon thread.
+
+The logic lives in the standalone `rethink_changefeed` module so it can be
+tested without importing the server monolith (docker/socketio/waitress).
+"""
+import sys
+import os
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from rethinkdb import errors as rerr  # noqa: E402
+
+from rethink_changefeed import (  # noqa: E402
+    is_transient_rethinkdb_error,
+    run_reconnecting_changefeed,
+)
+
+
+class FakeConn:
+    def __init__(self):
+        self.closed = False
+
+    def close(self, *a, **k):
+        self.closed = True
+
+
+# --------------------------------------------------------------------------
+# error classification
+# --------------------------------------------------------------------------
+
+def test_transient_true_for_connection_loss():
+    # the exact class/message from the outage traceback
+    assert is_transient_rethinkdb_error(rerr.ReqlDriverError("Connection is closed."))
+    assert is_transient_rethinkdb_error(OSError("[Errno 111] Connection refused"))
+    assert is_transient_rethinkdb_error(ConnectionResetError("reset by peer"))
+
+
+def test_transient_true_for_availability_and_connect_messages():
+    assert is_transient_rethinkdb_error(Exception("primary replica for shard not available"))
+    assert is_transient_rethinkdb_error(Exception("Could not connect to rethinkdb:28015"))
+
+
+def test_transient_false_for_programming_errors():
+    assert not is_transient_rethinkdb_error(ValueError("bad field name"))
+    assert not is_transient_rethinkdb_error(KeyError("id"))
+
+
+# --------------------------------------------------------------------------
+# reconnect loop
+# --------------------------------------------------------------------------
+
+def _bounded(n):
+    """A should_continue() that returns True n times then False."""
+    state = {"i": 0}
+
+    def _cont():
+        state["i"] += 1
+        return state["i"] <= n
+
+    return _cont
+
+
+def test_reconnects_after_dropped_connection_and_processes_next_change():
+    conns = []
+
+    def get_conn():
+        c = FakeConn()
+        conns.append(c)
+        return c
+
+    attempts = {"n": 0}
+
+    def open_feed(c):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            # connection dies the moment we open the feed
+            raise rerr.ReqlDriverError("Connection is closed.")
+        return iter([{"new_val": {"id": "x"}}])
+
+    seen = []
+    sleeps = []
+
+    run_reconnecting_changefeed(
+        open_feed,
+        lambda ch, c: seen.append(ch),
+        "Test",
+        get_conn=get_conn,
+        log=None,
+        sleep=lambda d: sleeps.append(d),
+        should_continue=_bounded(2),
+    )
+
+    assert attempts["n"] == 2, "should reconnect and retry after the drop"
+    assert seen == [{"new_val": {"id": "x"}}], "processed the change after reconnect"
+    assert all(c.closed for c in conns), "every connection closed on its way out"
+    assert sleeps and sleeps[0] == 2.0, "backed off before reconnecting"
+
+
+def test_drop_mid_stream_does_not_escape():
+    """A drop *while iterating* changes must be caught, not propagate out of the
+    thread body."""
+    def get_conn():
+        return FakeConn()
+
+    def open_feed(c):
+        def gen():
+            yield {"new_val": {"id": "a"}}
+            raise rerr.ReqlDriverError("Connection is closed.")
+        return gen()
+
+    seen = []
+    # one cycle is enough; must return normally (no exception raised)
+    run_reconnecting_changefeed(
+        open_feed,
+        lambda ch, c: seen.append(ch),
+        "Test",
+        get_conn=get_conn,
+        log=None,
+        sleep=lambda d: None,
+        should_continue=_bounded(1),
+    )
+    assert seen == [{"new_val": {"id": "a"}}]
+
+
+def test_non_transient_error_also_reconnects_not_dies():
+    """Even an unexpected (non-connection) error must keep the feed alive."""
+    attempts = {"n": 0}
+
+    def open_feed(c):
+        attempts["n"] += 1
+        raise ValueError("unexpected")
+
+    logs = []
+    run_reconnecting_changefeed(
+        open_feed,
+        lambda ch, c: None,
+        "Test",
+        get_conn=lambda: FakeConn(),
+        log=lambda msg, color, service=None: logs.append((color, msg)),
+        sleep=lambda d: None,
+        should_continue=_bounded(3),
+    )
+    assert attempts["n"] == 3, "kept retrying despite a non-transient error"
+    assert any(color == "red" for color, _ in logs), "non-transient errors logged red"
+
+
+def test_backoff_grows_and_is_capped_when_feed_never_delivers():
+    """Connect succeeds but the feed keeps failing (e.g. primary-replica
+    unavailable): backoff must actually GROW toward max_delay, not stay pinned
+    at the floor. This is the connectable-but-unhealthy case."""
+    sleeps = []
+
+    def open_feed(c):
+        raise rerr.ReqlDriverError("Connection is closed.")
+
+    run_reconnecting_changefeed(
+        open_feed,
+        lambda ch, c: None,
+        "Test",
+        get_conn=lambda: FakeConn(),  # TCP connect always OK
+        log=None,
+        sleep=lambda d: sleeps.append(d),
+        should_continue=_bounded(10),
+        initial_delay=10.0,
+        max_delay=15.0,
+    )
+    assert sleeps[0] == 10.0
+    assert 15.0 in sleeps, "backoff must grow past the floor when the feed never recovers"
+    assert max(sleeps) <= 15.0, "backoff must not exceed max_delay"
+
+
+def test_backoff_resets_only_after_a_delivered_change():
+    """Backoff must reset when the feed proves healthy (delivers a change), and
+    NOT merely because get_conn() succeeded."""
+    calls = {"n": 0}
+
+    def open_feed(c):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            return iter([{"id": "ok"}])  # healthy cycle: delivers a change
+        raise rerr.ReqlDriverError("Connection is closed.")
+
+    sleeps = []
+    run_reconnecting_changefeed(
+        open_feed,
+        lambda ch, c: None,
+        "Test",
+        get_conn=lambda: FakeConn(),
+        log=None,
+        sleep=lambda d: sleeps.append(d),
+        should_continue=_bounded(4),
+        initial_delay=2.0,
+        max_delay=30.0,
+    )
+    # fail(2)->3, fail(3)->4.5, healthy resets->2, fail(2)->3
+    assert sleeps == [2.0, 3.0, 2.0, 3.0]
+
+
+def test_pass_conn_false_calls_handler_without_connection():
+    seen = []
+    run_reconnecting_changefeed(
+        lambda c: iter([{"id": 1}]),
+        lambda ch: seen.append(ch),
+        "Test",
+        get_conn=lambda: FakeConn(),
+        log=None,
+        sleep=lambda d: None,
+        should_continue=_bounded(1),
+        pass_conn=False,
+    )
+    assert seen == [{"id": 1}]


### PR DESCRIPTION
## Problem (2026-07-06 backend outage)
RethinkDB dropped mid-run (`rethinkdb:28015` → `[Errno 111] Connection refused`). All six `intellistock-backend` control changefeed threads (nexus/discover/digest/agent/config/instances) died **permanently**: their retry loops only reconnected on `"primary replica"`/`"not available"` and re-raised everything else — including `"Connection is closed"` / `ReqlDriverError`. The process stayed up (main thread loops on `sleep`), so the container looked "up" but its control plane was deaf to all control-table changes until a full restart.

## Fix
- **New `backend/rethink_changefeed.py`** — `run_reconnecting_changefeed(...)`: a reconnect-forever loop with capped exponential backoff. `is_transient_rethinkdb_error` treats `ReqlDriverError`, `OSError`/socket errors, and connection-closed/refused/reset (plus availability messages) as transient → reconnect instead of dying. Backoff resets **only after the feed delivers a change** (proof it's live), so a connectable-but-unhealthy DB (primary-replica flap) still backs off toward `max_delay` instead of hammering the floor. Kept dependency-light so it's unit-testable without importing the server monolith.
- **`backend/server.py`** — all six changefeeds now delegate to the helper (also fixes a stale `"AgentControl"` mislabel the digest feed logged).
- **`_get_instance_network`** — throttle the `INSTANCE_DOCKER_NETWORK` not-found warning to once and name the auto-detected network. **Return value unchanged** (the fallback already attached spawned containers to the backend's own network).

## Tests / verification
- 9 new unit tests (`backend/tests/test_changefeed_selfheal.py`): error classification, reconnect-after-drop, drop-mid-stream, non-transient still recovers, backoff grows+caps, backoff resets only after a delivered change.
- `python3 -m py_compile server.py rethink_changefeed.py` clean; full `tests/` collection unchanged (same 2 pre-existing baseline collection errors, unrelated).
- `gitnexus detect_changes`: **LOW** risk, 0 affected processes.

## Operational follow-ups (not code)
- Get RethinkDB back up + restart the backend container (dead threads don't self-recover until this deploys).
- Fix the stale `INSTANCE_DOCKER_NETWORK` env var in Dokploy (set to the detected network or unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)