### PR TITLE
fix(nexus): cap trade-overlay LLM output tokens (stop reasoning-spiral stalls)

### DIFF
--- a/backend/strategies/graph_nexus_analysis.py
+++ b/backend/strategies/graph_nexus_analysis.py
@@ -18651,6 +18651,26 @@ def _store_overlay_result_cache(
         pass
 
 
+def _overlay_max_output_tokens(config: dict) -> int:
+    """Wire ``max_tokens`` for the trade-overlay LLM call.
+
+    The overlay response is a tiny bounded JSON, but a reasoning model (e.g.
+    Nemotron) will otherwise spiral into tens of thousands of thinking tokens:
+    passing 0 makes the OpenRouter path inject a 32,768-token reasoning-safe
+    default, and a ``requests`` between-bytes read timeout can't stop a steadily
+    streaming generation — so one runaway symbol stalls the whole bar. Cap it to
+    a value that fits normal reasoning yet cuts runaways short (a truncated call
+    falls back to the base score for that symbol). Coerce 0/invalid to the
+    default so the overlay can never be uncapped again. Tunable via
+    ``overlay_llm_max_output_tokens`` (default 2500).
+    """
+    try:
+        n = int((config or {}).get("overlay_llm_max_output_tokens", 2500) or 2500)
+    except (TypeError, ValueError):
+        n = 2500
+    return n if n > 0 else 2500
+
+
 def _apply_trade_overlay(
     symbol: str,
     base_score_doc: dict,
@@ -18796,7 +18816,7 @@ def _apply_trade_overlay(
                 "call_site": "overlay",
             },
             system_prompt=system_prompt,
-            max_output_tokens=0,
+            max_output_tokens=_overlay_max_output_tokens(config),
             timeout_sec=_overlay_timeout,
             retries=1,
             output_retries=2,
@@ -18933,7 +18953,7 @@ def _apply_etf_trade_overlay(
                 "call_site": "overlay_etf",
             },
             system_prompt=system_prompt,
-            max_output_tokens=0,
+            max_output_tokens=_overlay_max_output_tokens(config),
             retries=2,
             output_retries=2,
             provider_config=provider_config,

--- a/backend/tests/test_overlay_token_cap.py
+++ b/backend/tests/test_overlay_token_cap.py
@@ -1,0 +1,46 @@
+"""Trade-overlay LLM output-token cap.
+
+Regression for the 2026-07-06 live stall: the overlay call passed
+``max_output_tokens=0``, which the OpenRouter path turns into a 32,768-token
+reasoning-safe default. Nemotron then spiralled to ~28k reasoning tokens on a
+single symbol (238s), and a `requests` between-bytes read timeout can't stop a
+steadily-streaming generation — so one symbol stalled the whole bar. The
+overlay response is a tiny bounded JSON, so it must send a sane, tunable cap.
+"""
+import sys
+import os
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from strategies.graph_nexus_analysis import _overlay_max_output_tokens  # noqa: E402
+
+
+def test_default_when_absent():
+    assert _overlay_max_output_tokens({}) == 2500
+
+
+def test_none_config_uses_default():
+    assert _overlay_max_output_tokens(None) == 2500
+
+
+def test_honours_explicit_positive():
+    assert _overlay_max_output_tokens({"overlay_llm_max_output_tokens": 1200}) == 1200
+
+
+def test_zero_coerces_to_default_never_uncapped():
+    # 0 was the bug (→ 32768 on the wire); it must never mean "uncapped" again.
+    assert _overlay_max_output_tokens({"overlay_llm_max_output_tokens": 0}) == 2500
+
+
+def test_negative_coerces_to_default():
+    assert _overlay_max_output_tokens({"overlay_llm_max_output_tokens": -5}) == 2500
+
+
+def test_invalid_coerces_to_default():
+    assert _overlay_max_output_tokens({"overlay_llm_max_output_tokens": "abc"}) == 2500
+
+
+def test_string_number_is_accepted():
+    assert _overlay_max_output_tokens({"overlay_llm_max_output_tokens": "1800"}) == 1800


### PR DESCRIPTION
## Problem (2026-07-06 live stall)
The `alpaca-main` live bar stalled for ~15 min in the trade-overlay LLM phase and delayed all buys. Root cause: the stock and ETF overlay calls pass `max_output_tokens=0`, which `_call_openrouter` turns into the 32,768-token reasoning-safe default (`_openrouter_effective_max_output_tokens`). Nemotron then spiralled to **28,575 reasoning tokens on a single symbol (238s)**, and the `requests` timeout is a **between-bytes read timeout**, not a total deadline — a steadily-streaming generation never trips it (and retries double it: `attempt_timeout = timeout*2`). Since the overlay phase gates buys, one runaway symbol froze the whole bar and burned credit.

## Fix
- **`_overlay_max_output_tokens(config)`** — a bounded, tunable cap read from `overlay_llm_max_output_tokens` (default **2500**), coercing `0`/invalid to the default so the overlay can never be uncapped again. Matches the existing `overlay_llm_timeout_sec`/`overlay_llm_reasoning_effort` pattern (config-read with a default; not in the base schema, settable per-doc).
- Wired into **both** `_apply_trade_overlay` and `_apply_etf_trade_overlay`, replacing `max_output_tokens=0`.

Effect: normal overlay calls (~100–180 tokens) are unaffected; a spiral is truncated at the cap (~20s) and the existing `output_retries` fall back to the base score for that symbol, instead of stalling the bar for minutes.

## Tests / verification
- 7 unit tests (`backend/tests/test_overlay_token_cap.py`): default, explicit, `0`/negative/invalid → default, `None` config, string-number.
- `py_compile` clean; `gitnexus detect_changes` = LOW risk, 0 affected processes.

## Notes
- The default (2500) is tunable on doc-179 without a redeploy via `overlay_llm_max_output_tokens`.
- Follow-up worth considering (not in this PR): give the LLM calls a true wall-clock deadline so a between-bytes read timeout can't let any single call run for minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)