### PR TITLE
fix(instance): self-heal instance-container RethinkDB changefeeds

### DIFF
--- a/backend/broker.py
+++ b/backend/broker.py
@@ -2407,40 +2407,54 @@ def watch_strategies_changefeed():
         _log(f"Watching Instances[{instance_id}] and Strategies[{strategy_id}] for changes...", "white")
         # Watch instance for strategy_id changes
         def watch_instance():
-            conn_inst = get_conn()
-            try:
-                for change in r.db(DB_NAME).table('Instances').get(instance_id).changes().run(conn_inst):
-                    if change.get('old_val') and change.get('new_val'):
-                        old_sid = change['old_val'].get('strategy_id')
-                        new_sid = change['new_val'].get('strategy_id')
-                        if old_sid != new_sid:
-                            _log(f"Instance strategy_id changed ({old_sid} -> {new_sid}). Exiting broker to reload...", "yellow")
-                            shutdown_requested = True
-                            return
-            except Exception as e:
-                _log(f"Instance changefeed error: {e}", "red")
-            finally:
+            # Self-heal: a RethinkDB blip must not kill this watcher — dying
+            # would silently stop reacting to strategy_id changes, and returning
+            # on error used to spuriously unblock the join (triggering a reload).
+            # Reconnect with backoff on any error; only the detected change exits.
+            while True:
+                conn_inst = None
                 try:
-                    conn_inst.close()
-                except Exception:
-                    pass
+                    conn_inst = get_conn()
+                    for change in r.db(DB_NAME).table('Instances').get(instance_id).changes().run(conn_inst):
+                        if change.get('old_val') and change.get('new_val'):
+                            old_sid = change['old_val'].get('strategy_id')
+                            new_sid = change['new_val'].get('strategy_id')
+                            if old_sid != new_sid:
+                                _log(f"Instance strategy_id changed ({old_sid} -> {new_sid}). Exiting broker to reload...", "yellow")
+                                shutdown_requested = True
+                                return
+                except Exception as e:
+                    _log(f"Instance changefeed error ({e}); reconnecting...", "yellow")
+                finally:
+                    if conn_inst is not None:
+                        try:
+                            conn_inst.close()
+                        except Exception:
+                            pass
+                time.sleep(2)
         # Watch strategy for config changes (if strategy_id exists)
         def watch_strategy():
             if strategy_id is None:
                 return
-            conn_strat = get_conn()
-            try:
-                for change in r.db(DB_NAME).table('Strategies').get(strategy_id).changes().run(conn_strat):
-                    _log("Strategy config changed. Exiting broker to reload...", "yellow")
-                    shutdown_requested = True
-                    return
-            except Exception as e:
-                _log(f"Strategy changefeed error: {e}", "red")
-            finally:
+            # Self-heal: reconnect on a RethinkDB blip instead of dying (or
+            # spuriously triggering a reload); only a real config change exits.
+            while True:
+                conn_strat = None
                 try:
-                    conn_strat.close()
-                except Exception:
-                    pass
+                    conn_strat = get_conn()
+                    for change in r.db(DB_NAME).table('Strategies').get(strategy_id).changes().run(conn_strat):
+                        _log("Strategy config changed. Exiting broker to reload...", "yellow")
+                        shutdown_requested = True
+                        return
+                except Exception as e:
+                    _log(f"Strategy changefeed error ({e}); reconnecting...", "yellow")
+                finally:
+                    if conn_strat is not None:
+                        try:
+                            conn_strat.close()
+                        except Exception:
+                            pass
+                time.sleep(2)
         # Start both watchers in separate threads
         t1 = threading.Thread(target=watch_instance, daemon=True)
         t1.start()

--- a/backend/instance.py
+++ b/backend/instance.py
@@ -40,6 +40,8 @@ _crash_loop_latched = False
 # so the live-trading log stays viewable in logs-history and the operator gets a
 # notification. Operator Stop (runCommand=False) still exits cleanly. Gated to
 # equities — Kalshi keeps its own kalshi/runner.py crash handling.
+from rethink_changefeed import is_transient_rethinkdb_error
+
 CHANGEFEED_RETRY_MAX = int(os.environ.get("INSTANCE_CHANGEFEED_RETRY_MAX", "3"))
 _KEEPALIVE_ENABLED = True   # set from the Instances row 'kind' at startup
 _crash_lock = threading.Lock()
@@ -273,10 +275,15 @@ def terminate_thread_on_command(conn):
             if not _KEEPALIVE_ENABLED:
                 # Original behavior: RethinkDB likely shut down; exit so container stops.
                 os._exit(0)
-            attempts += 1
-            if attempts > CHANGEFEED_RETRY_MAX:
-                trip_crash(f"Instances changefeed lost after {attempts} attempts: {e}", e)
-                return
+            # A transient RethinkDB blip (connection drop / primary-replica
+            # reconfiguration during a restart) must NOT burn the crash budget —
+            # reconnect indefinitely with backoff. Only a non-transient failure
+            # counts toward CHANGEFEED_RETRY_MAX -> crash keep-alive.
+            if not is_transient_rethinkdb_error(e):
+                attempts += 1
+                if attempts > CHANGEFEED_RETRY_MAX:
+                    trip_crash(f"Instances changefeed lost after {attempts} attempts: {e}", e)
+                    return
             time.sleep(_changefeed_backoff(attempts))
             try:
                 conn = get_conn()
@@ -470,10 +477,14 @@ def run_instance_stocks_changefeed():
             if not _KEEPALIVE_ENABLED:
                 # Original behavior: RethinkDB likely shut down; exit so container stops.
                 os._exit(0)
-            attempts += 1
-            if attempts > CHANGEFEED_RETRY_MAX:
-                trip_crash(f"Instances (stocks) changefeed lost after {attempts} attempts: {e}", e)
-                return
+            # Transient RethinkDB blips reconnect indefinitely (see
+            # terminate_thread_on_command); only non-transient errors count
+            # toward the crash-keepalive budget.
+            if not is_transient_rethinkdb_error(e):
+                attempts += 1
+                if attempts > CHANGEFEED_RETRY_MAX:
+                    trip_crash(f"Instances (stocks) changefeed lost after {attempts} attempts: {e}", e)
+                    return
             time.sleep(_changefeed_backoff(attempts))
             try:
                 conn = get_conn()

--- a/backend/priceBroker.py
+++ b/backend/priceBroker.py
@@ -11,6 +11,7 @@ try:
     from os import system
     from rethinkdb import RethinkDB
     from intellistock_logger import intellistock_logger
+    from rethink_changefeed import run_reconnecting_changefeed
 except Exception as e:
     import traceback
     traceback.print_exc()
@@ -53,45 +54,57 @@ else:
 
 
 def run_config_pings_changefeed():
-    """Watch Config.Pings and copy priceBrokerPing -> priceBrokerResponse."""
-    c = get_conn()
+    """Watch Config.Pings and copy priceBrokerPing -> priceBrokerResponse.
+
+    Self-heals: reconnects on any transient RethinkDB connection loss instead
+    of dying on the first error."""
     intellistock_logger.log("Config Pings changefeed thread started; watching for pings.", "white", service="PriceBroker")
-    try:
-        for change in r.db(DB_NAME).table('Config').get('Pings').changes().run(c):
-            new_val = change.get('new_val')
-            if new_val and 'priceBrokerPing' in new_val:
-                try:
-                    request = new_val['priceBrokerPing']
-                    r.db(DB_NAME).table('Config').get('Pings').update({
-                        'priceBrokerResponse': request
-                    }).run(c)
-                    intellistock_logger.log("Responded to priceBrokerPing.", "white", service="PriceBroker")
-                except Exception as e:
-                    intellistock_logger.log(str(e), "red", service="PriceBroker")
-    except Exception as e:
-        intellistock_logger.log(f"Config Pings changefeed error: {e}", "red", service="PriceBroker")
-    finally:
-        c.close()
+
+    def _handle(change, c):
+        new_val = change.get('new_val')
+        if new_val and 'priceBrokerPing' in new_val:
+            try:
+                request = new_val['priceBrokerPing']
+                r.db(DB_NAME).table('Config').get('Pings').update({
+                    'priceBrokerResponse': request
+                }).run(c)
+                intellistock_logger.log("Responded to priceBrokerPing.", "white", service="PriceBroker")
+            except Exception as e:
+                intellistock_logger.log(str(e), "red", service="PriceBroker")
+
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table('Config').get('Pings').changes().run(c),
+        _handle,
+        "Config Pings",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 def run_config_doc_changefeed():
-    """Watch Config.Config: exit when runPriceService is False or terminatePriceBroker is True."""
-    c = get_conn()
-    try:
-        for change in r.db(DB_NAME).table('Config').get('Config').changes().run(c):
-            new_val = change.get('new_val')
-            if new_val is None:
-                continue
-            if new_val.get('terminatePriceBroker') is True:
-                intellistock_logger.log("Terminate requested; exiting.", "yellow", service="PriceBroker")
-                os._exit(0)
-            if new_val.get('runPriceService') is False:
-                intellistock_logger.log("runPriceService=False; exiting.", "yellow", service="PriceBroker")
-                os._exit(0)
-    except Exception as e:
-        intellistock_logger.log(f"Config changefeed error: {e}", "red", service="PriceBroker")
-    finally:
-        c.close()
+    """Watch Config.Config: exit when runPriceService is False or terminatePriceBroker is True.
+
+    Self-heals: reconnects on any transient RethinkDB connection loss instead
+    of dying on the first error (only the terminate/stop signal exits)."""
+
+    def _handle(change, c):
+        new_val = change.get('new_val')
+        if new_val is None:
+            return
+        if new_val.get('terminatePriceBroker') is True:
+            intellistock_logger.log("Terminate requested; exiting.", "yellow", service="PriceBroker")
+            os._exit(0)
+        if new_val.get('runPriceService') is False:
+            intellistock_logger.log("runPriceService=False; exiting.", "yellow", service="PriceBroker")
+            os._exit(0)
+
+    run_reconnecting_changefeed(
+        lambda c: r.db(DB_NAME).table('Config').get('Config').changes().run(c),
+        _handle,
+        "Config",
+        get_conn=get_conn,
+        log=intellistock_logger.log,
+    )
 
 
 # Changefeed threads for terminate / runPriceService


### PR DESCRIPTION
## Problem
Companion to #108 (server self-heal). The **instance container's** control changefeeds hit the same RethinkDB-drop failure on 2026-07-06 (`[BROKER] Instance/Strategy changefeed error: Connection is closed`, `[RethinkDB] Instances (stocks) changefeed error`, `primary replica for shard ... not available`):

- **`broker.py` `watch_strategies_changefeed`** — both watchers (instance `strategy_id`, strategy config) just logged and `return`ed on any error, so a RethinkDB blip **silently killed** them (broker stops reacting to config changes); worse, the bare `return` unblocked the `join()` and could spuriously trigger a broker reload.
- **`instance.py`** — self-heals but only `CHANGEFEED_RETRY_MAX=3` (~12s of backoff) before crash-keepalive; a primary-replica reconfiguration during a RethinkDB restart can outlast that and needlessly trip a crash.
- **`priceBroker.py`** — Config Pings/Config feeds had the same die-on-first-error shape.

## Fix
- `broker.py`: both watchers now reconnect with backoff on any error; **only the detected config change exits** (also stops the spurious reload-on-blip).
- `instance.py`: `terminate_thread_on_command` + `run_instance_stocks_changefeed` — **transient** RethinkDB errors (`is_transient_rethinkdb_error`) reconnect indefinitely and don't burn the crash budget; only non-transient errors count toward `CHANGEFEED_RETRY_MAX` → crash keep-alive. Genuine keep-alive behavior preserved.
- `priceBroker.py`: both feeds routed through the shared `run_reconnecting_changefeed` helper.

## Verification
- Reuses the already-tested `rethink_changefeed` primitives (9 helper tests: reconnect-after-drop, drop-mid-stream, non-transient recovery, backoff grows+caps, resets after a delivered change).
- These three modules connect to RethinkDB **at import time**, so they aren't unit-importable — wiring verified by `py_compile` (all three clean) + review; reconnect logic by the helper tests.
- `gitnexus detect_changes`: LOW risk, 0 affected processes.

## Note — the recurring root cause is RethinkDB itself
This is the **third** RethinkDB drop today. The self-heal fixes make the app *survive* a drop, but they don't stop RethinkDB from dropping (`primary replica for shard not available` = the single node restarting/reconfiguring). The underlying RethinkDB instability (likely OOM / single-node with no failover) still needs infra attention or trading stays degraded during each drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)