### PR TITLE
chore(infra): raise RethinkDB memory limit 3G -> 5G

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,7 +335,7 @@ services:
       resources:
         limits:
           cpus: "3"
-          memory: 3G
+          memory: 5G
         reservations:
           cpus: "2"
           memory: 512M


### PR DESCRIPTION
Single-node RethinkDB was thrashing swap under its **3G cgroup cap** (`docker-compose.yml` `deploy.resources.limits.memory`) on the 14 GiB Proxmox VM (server7-trading), which is what produced the recurring `primary replica for shard not available` / `Connection is closed` drops that killed changefeeds today. Its container logs show hundreds of `accessing a lot of swap memory` warnings since February.

Change: `memory: 3G` → **`5G`** so RethinkDB can keep its working set resident instead of paging.

**Requires a stack redeploy to take effect.**

Caveat (in the commit): the VM is at ~84% RAM (~2 GiB free) with CPU ~2% idle, so this only buys partial headroom — the durable fix is still more VM RAM (trade vCPUs for RAM in Proxmox) and/or pruning the big tables. Watch for VM-level memory pressure now that RethinkDB's ceiling is higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)