### PR TITLE
fix(kalshi): wire score-gated in-play exits (completes c516742; un-breaks main)

### DIFF
--- a/backend/kalshi/engine.py
+++ b/backend/kalshi/engine.py
@@ -984,12 +984,30 @@ def run_instance(config: EngineConfig) -> None:  # pragma: no cover - integratio
                         return 0.0
 
                 live_dry = not should_execute(config.environment, config.live_enabled, config.paper_mode)
+                # Origin of each open position — 'pregame' (a pre-match conviction bet) vs
+                # 'inplay' (an in-play scalp). A pregame position is HELD TO SETTLEMENT by the
+                # monitor (never price-stopped); only a genuine late score-loss can exit it.
+                # From the placed decision rows: a placed row WITHOUT in_play=True is pregame.
+                position_origin: dict = {}
+                try:
+                    for _od in kdb._r.db(kdb.DB_NAME).table("kalshi_decisions").filter(
+                            {"instance_id": config.instance_id, "decision": "placed"}).pluck(
+                            "market_ticker", "in_play").run(conn):
+                        _otk = _od.get("market_ticker")
+                        if not _otk:
+                            continue
+                        if not _od.get("in_play"):
+                            position_origin[_otk] = "pregame"        # any pregame row -> pregame
+                        else:
+                            position_origin.setdefault(_otk, "inplay")
+                except Exception as e:
+                    log(f"tick {tick}: position_origin query failed: {type(e).__name__}: {e}", "yellow")
                 live_rows = live_monitor.run_live_step(
                     client=client, live_matches=live_matches, price_history=price_history,
                     adds_by_match=adds_by_match, positions_by_ticker=positions_by_ticker,
                     caps=_eff_inplay, dry_run=live_dry, instance_id=config.instance_id,
                     brokerage_id=config.brokerage_id, ts=ts, llm=_live_llm_tilt, log=log,
-                    already_placed=placed_markets,
+                    already_placed=placed_markets, position_origin=position_origin,
                 )
                 acted = sum(1 for r in live_rows if r.get("decision") == "placed")
                 log(f"tick {tick}: live monitor — {len(live_matches)} in-play match(es), "

--- a/backend/kalshi/instance_config.py
+++ b/backend/kalshi/instance_config.py
@@ -123,7 +123,11 @@ def normalize_config(raw: dict, *, live_enabled: bool) -> dict:
         "inplay_exposure_frac": float(raw.get("inplay_exposure_frac", td["inplay_exposure_frac"])),
         "max_adds_per_match": int(raw.get("max_adds_per_match", td["max_adds_per_match"])),
         "no_add_after_min": float(raw.get("no_add_after_min", 75.0)),
-        "stop_loss_frac": float(raw.get("stop_loss_frac", 0.35)),
+        "stop_loss_frac": float(raw.get("stop_loss_frac", 0.35)),   # DEAD (unread by decide); kept for back-compat
+        # In-play EXIT knobs — the ones that actually drive live exits (score-gated).
+        "catastrophe_stop_frac": float(raw.get("catastrophe_stop_frac", 0.6)),
+        "tp_overshoot_cents": float(raw.get("tp_overshoot_cents", 8.0)),
+        "late_exit_min": float(raw.get("late_exit_min", 70.0)),
         # Sharp-odds anchor (de-vig'd bookmaker odds -> fair value -> edge vs Kalshi).
         "odds_api_key": str(raw.get("odds_api_key") or "").strip(),
         # OddsPapi key (historical sharp line for backtests). Persisted so it's
@@ -204,6 +208,7 @@ def inplay_caps_from_config(config: dict) -> InPlayCaps:
         take_profit_mult=float(c.get("take_profit_mult", 1.6)),
         catastrophe_stop_frac=float(c.get("catastrophe_stop_frac", 0.6)),
         tp_overshoot_cents=float(c.get("tp_overshoot_cents", 8.0)),
+        late_exit_min=float(c.get("late_exit_min", 70.0)),
         maker_min_spread_cents=int(c.get("maker_min_spread_cents", 3)),
         maker_min_book_depth=int(c.get("maker_min_book_depth", 5)),
         maker_max_adverse_imbalance=float(c.get("maker_max_adverse_imbalance", -0.5)),

--- a/backend/kalshi/live/monitor.py
+++ b/backend/kalshi/live/monitor.py
@@ -20,10 +20,31 @@ def _noop(*_a, **_k):
     pass
 
 
+def _our_goal_margin(match, mk):
+    """Goals the side this YES market backs is currently ahead by (negative = behind); None
+    when the score is unknown or it isn't a match-winner market. This is the score signal
+    that gates in-play exits — a price move alone never triggers a sell (live_decision)."""
+    hs, as_ = match.get("home_score"), match.get("away_score")
+    if hs is None or as_ is None or (mk.get("market_type") or "").lower() != "winner":
+        return None
+    try:
+        hs, as_ = int(hs), int(as_)
+    except (TypeError, ValueError):
+        return None
+    side = (mk.get("side") or "").lower()
+    if side == "home":
+        return hs - as_
+    if side == "away":
+        return as_ - hs
+    if side == "draw":
+        return 0 if hs == as_ else -abs(hs - as_)
+    return None
+
+
 def run_live_step(*, client, live_matches, price_history, adds_by_match,
                   positions_by_ticker, caps, dry_run, instance_id, brokerage_id, ts,
                   llm=None, log=_noop, move_threshold_cents: float = 8.0,
-                  max_history: int = 10, already_placed=None) -> list[dict]:
+                  max_history: int = 10, already_placed=None, position_origin=None) -> list[dict]:
     """For each live match's markets: update the rolling mid history, detect a
     material move, (on a move) get a bounded LLM tilt, compute hybrid live fair,
     decide open/add/reduce/exit/hold, execute (unless dry_run), and emit a
@@ -85,6 +106,8 @@ def run_live_step(*, client, live_matches, price_history, adds_by_match,
                 caps=caps, phase=phase, elapsed_min=elapsed,
                 adds_so_far=int(adds_by_match.get(fixture_id, 0)),
                 allow_open=allow_open,
+                origin=(position_origin or {}).get(ticker, "inplay"),
+                our_goal_margin=_our_goal_margin(match, mk),
             )
 
             executed = "skipped"

--- a/backend/tests/test_kalshi_monitor.py
+++ b/backend/tests/test_kalshi_monitor.py
@@ -98,6 +98,7 @@ def test_exit_blocked_when_no_bid_to_sell_into():
     # a 0c sell that dumps the position.
     match = [{
         "fixture_id": "E1", "home": "A", "away": "B", "phase": LIVE, "elapsed_min": 70,
+        "home_score": 0, "away_score": 2,   # backed side (home) genuinely behind, late -> exit allowed
         "model_probs": {"M1": 0.2},
         "markets": [{"market_ticker": "M1", "side": "home", "market_type": "winner",
                      "yes_ask_cents": 30, "yes_bid_cents": 0, "mid_cents": 30}],
@@ -110,6 +111,35 @@ def test_exit_blocked_when_no_bid_to_sell_into():
     )
     assert fc.orders == []                       # no 0c dump
     assert rows[0]["live_action"] == "exit" and rows[0]["decision"] == "blocked"
+
+
+def test_pregame_position_held_through_price_collapse():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Pos:
+        market_ticker: str
+        contracts: int
+        avg_price_cents: float
+        current_price_cents: float
+
+    # THE SPAIN FIX end-to-end: a PREGAME 'home to win' bought 51c, price gapped to 19c
+    # (<=40% of entry), score level -> the monitor HOLDS (no dump), ride it to settlement.
+    match = [{
+        "fixture_id": "E1", "home": "A", "away": "B", "phase": LIVE, "elapsed_min": 55,
+        "home_score": 1, "away_score": 1, "model_probs": {"M1": 0.45},
+        "markets": [{"market_ticker": "M1", "side": "home", "market_type": "winner",
+                     "yes_ask_cents": 21, "yes_bid_cents": 19, "mid_cents": 20}],
+    }]
+    fc = FakeClient()
+    rows = run_live_step(
+        client=fc, live_matches=match, price_history={"M1": [51, 51]},
+        adds_by_match={}, positions_by_ticker={"M1": Pos("M1", 12, 51, 19)},
+        caps=CAPS, dry_run=False, instance_id="i", brokerage_id="b", ts="t", llm=None,
+        position_origin={"M1": "pregame"},
+    )
+    assert fc.orders == []                       # not sold
+    assert rows[0]["live_action"] == "hold"
 
 
 def test_llm_tilt_called_on_move():
@@ -125,3 +155,17 @@ def test_llm_tilt_called_on_move():
         instance_id="i", brokerage_id="b", ts="t", llm=spy_llm,
     )
     assert seen["called"] == ("E1", "M1", "up")
+
+
+def test_our_goal_margin_from_score_and_side():
+    from kalshi.live.monitor import _our_goal_margin
+    m = {"home_score": 2, "away_score": 1}
+    assert _our_goal_margin(m, {"market_type": "winner", "side": "home"}) == 1
+    assert _our_goal_margin(m, {"market_type": "winner", "side": "away"}) == -1
+    assert _our_goal_margin(m, {"market_type": "winner", "side": "draw"}) == -1   # not level -> "losing"
+    assert _our_goal_margin({"home_score": 1, "away_score": 1},
+                            {"market_type": "winner", "side": "draw"}) == 0
+    # Unknown score OR a non-winner market -> None => exits suppressed (position held).
+    assert _our_goal_margin({"home_score": None, "away_score": 1},
+                            {"market_type": "winner", "side": "home"}) is None
+    assert _our_goal_margin(m, {"market_type": "over_under", "side": "over"}) is None


### PR DESCRIPTION
**Completes the in-play exit fix.** The `decide()` score-gate landed on main in `c516742`, but its caller-side wiring was dropped during a concurrent rebase. **As a result main is currently broken**: `decide()` never receives the score/origin, so `our_goal_margin` is always `None` → **all in-play exits are disabled** (positions ride every genuine loss to zero), and `tests/test_kalshi_monitor.py::test_exit_blocked_when_no_bid_to_sell_into` is **red**. (An adversarial review flagged exactly this as a critical unbounded-loss regression.)

This PR supplies the missing wiring:
- **`monitor.run_live_step`**: `_our_goal_margin` (from the live score + market side) + a `position_origin` map, both passed into `decide()` — so exits are score-gated *in production*, not just in unit tests. Non-winner markets / unknown score → `None` → position held (safe default).
- **`engine`**: builds `position_origin` from placed decision rows (a placed row without `in_play` = a pregame conviction bet) and passes it to the monitor.
- **`instance_config`**: persists + exposes the REAL in-play exit knobs (`catastrophe_stop_frac`, `tp_overshoot_cents`, `late_exit_min`); `stop_loss_frac` documented as dead.
- **`live_monitoring` stays default-ON** (in-play kept; safety now comes from the score-gate, not from disabling it).

Behavior after this lands: an in-play position is exited **only when the scoreboard confirms the backed side is genuinely behind, late** — never on a price move alone. A pregame conviction bet (e.g. "Spain to win", bought 51¢, gapped to 19¢) is held through the noise and only exits on a genuine late loss. Directly prevents the Spain catastrophe-stop.

**Tests:** end-to-end `run_live_step` exit (behind-late) + pregame-hold + a `_our_goal_margin` unit test; full Kalshi suite **420 passed**, and the previously-red `test_exit_blocked` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2FmLVbTNUi9VZfch6VXt